### PR TITLE
Fix writing of cargo-dist-json-schema.json

### DIFF
--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -202,6 +202,7 @@ fn emit() {
     let file = File::options()
         .create(true)
         .write(true)
+        .truncate(true)
         .open(schema)
         .unwrap();
     let mut file = BufWriter::new(file);


### PR DESCRIPTION
Currently, this is writing the schema file without first truncating. That means if this writes fewer bytes than currently exist in the file, whatever extra bytes were at the end of the file remain. Thiss is probably not a valid JSON file.

You can reproduce the problem by doing roughly:

```bash
cargo test
echo test >> cargo-dist-schema/cargo-dist-json-schema.json
cargo test
```

Expected: the file is overwritten with the new schema.

Actual: the file still contains the extra "test" at the end.