### PR TITLE
Append prerelease suffix to sugar'd release titles

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -98,6 +98,8 @@ Release notes are now temporarily simplified for reliability:
 
 * If you are publishing `1.2.0-prerelease` and we don't find that in your RELEASES/CHANGELOG file, we will now also look for bare `1.2.0` (stripping the prerelease/build portions), on the assumption that these are the WIP release notes for the version you're prereleasing. This lets you iterate on a version without having to churn headings every time you want to cut a prerelease (we recommend including a parenthetical indicating the version is not yet released).
 
+* If the above explained deferring happens, we will modify the release note's title to include the prerelease suffix. This ensures they are easily identifiable as prereleases on GitHub's releases page.
+
 * We will no longer attempt to include your release notes for Singular Announcements (see the previous section). They will only get auto-generated installers/downloads sections. This is obviously suboptimal, and will be fixed, we just need to do design work on the proper way to handle those cases. (Please tell me in [issue #139](https://github.com/axodotdev/cargo-dist/issues/139)!)
 
 

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -2318,7 +2318,12 @@ fn try_extract_changelog_normalized(
     );
 
     // insert prerelease suffix into the title
-    let title = format!("{}-{} {}", prefix_and_version.trim(), version.pre, freeform.trim());
+    let title = format!(
+        "{}-{} {}",
+        prefix_and_version.trim(),
+        version.pre,
+        freeform.trim()
+    );
 
     Some((title.trim().to_string(), release_notes.notes.to_string()))
 }


### PR DESCRIPTION
Fixes #142 by appending the prerelease suffix to sugar'd release titles.

An example: if you try to create a release for `1.0.0-pre1` and we detect a changelog entry of the form `## v1.0.0` the title of the release notes will end up as "v1.0.0-pre1".

Another example: you try `3.0.0-prerelease5`, we detect `## Version 3.0.0 (not yet released!)`, the title will end up "Version 3.0.0-prerelease5 (not yet released!)"

I am unsure whether we would want to strip the "(not yet released!)" part as well. When looking at the GitHub releases page they seem kinda confusing - a released version that says it is not released :exploding_head:

The problem is that it is not clear how we should detect such an indication. A simple solution would be to just strip everything after the first opening parenthesis. We could also try to remove only the parenthesis itself, leaving anything that comes after it intact, but this leaves us with the problem of deciding which parenthesizes to delete if there are multiple (or just yeet them all I guess).

On another note, it may actually be cleaner to use the 'Unreleased' header in the changelog together with #145 once that is implemented for achieving this painless and fast prereleasing.