### PR TITLE
Dist manifest cleanup

### DIFF
--- a/cargo-dist-schema/cargo-dist-json-schema.json
+++ b/cargo-dist-schema/cargo-dist-json-schema.json
@@ -37,6 +37,13 @@
         "null"
       ]
     },
+    "artifacts": {
+      "description": "The artifacts included in this Announcement, referenced by releases.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Artifact"
+      }
+    },
     "dist_version": {
       "description": "The version of cargo-dist that generated this",
       "type": [
@@ -287,7 +294,7 @@
           "description": "The artifacts for this release (zips, debuginfo, metadata...)",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Artifact"
+            "type": "string"
           }
         }
       }

--- a/cargo-dist-schema/cargo-dist-json-schema.json
+++ b/cargo-dist-schema/cargo-dist-json-schema.json
@@ -88,21 +88,6 @@
           }
         },
         {
-          "description": "Machine-readable metadata",
-          "type": "object",
-          "required": [
-            "kind"
-          ],
-          "properties": {
-            "kind": {
-              "type": "string",
-              "enum": [
-                "dist-metadata"
-              ]
-            }
-          }
-        },
-        {
           "description": "Installer",
           "type": "object",
           "required": [
@@ -304,20 +289,6 @@
           "items": {
             "$ref": "#/definitions/Artifact"
           }
-        },
-        "changelog_body": {
-          "description": "The body of the changelog for this release",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "changelog_title": {
-          "description": "The title of the changelog for this release",
-          "type": [
-            "string",
-            "null"
-          ]
         }
       }
     }

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -8,6 +8,8 @@
 //!
 //! The root type of the schema is [`DistManifest`][].
 
+use std::collections::BTreeMap;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +23,8 @@ pub type LocalPath = String;
 ///
 /// (Should we normalize this one?)
 pub type RelPath = String;
+/// The unique ID of an Artifact
+pub type ArtifactId = String;
 
 /// A report of the releases and artifacts that cargo-dist generated
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -52,6 +56,10 @@ pub struct DistManifest {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub releases: Vec<Release>,
+    /// The artifacts included in this Announcement, referenced by releases.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub artifacts: BTreeMap<ArtifactId, Artifact>,
 }
 
 /// A Release of an Application
@@ -65,7 +73,7 @@ pub struct Release {
     /// The artifacts for this release (zips, debuginfo, metadata...)
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub artifacts: Vec<Artifact>,
+    pub artifacts: Vec<ArtifactId>,
 }
 
 /// A distributable artifact that's part of a Release
@@ -180,7 +188,7 @@ pub struct ExecutableAsset {
 
 impl DistManifest {
     /// Create a new DistManifest
-    pub fn new(releases: Vec<Release>) -> Self {
+    pub fn new(releases: Vec<Release>, artifacts: BTreeMap<String, Artifact>) -> Self {
         Self {
             dist_version: None,
             announcement_tag: None,
@@ -189,6 +197,7 @@ impl DistManifest {
             announcement_changelog: None,
             announcement_github_body: None,
             releases,
+            artifacts,
         }
     }
 

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -66,14 +66,6 @@ pub struct Release {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<Artifact>,
-    /// The title of the changelog for this release
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub changelog_title: Option<String>,
-    /// The body of the changelog for this release
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub changelog_body: Option<String>,
 }
 
 /// A distributable artifact that's part of a Release
@@ -166,9 +158,6 @@ pub enum ArtifactKind {
     /// Standalone Symbols/Debuginfo for a build
     #[serde(rename = "symbols")]
     Symbols,
-    /// Machine-readable metadata
-    #[serde(rename = "dist-metadata")]
-    DistMetadata,
     /// Installer
     #[serde(rename = "installer")]
     Installer,

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -92,21 +92,6 @@ expression: json_schema
           }
         },
         {
-          "description": "Machine-readable metadata",
-          "type": "object",
-          "required": [
-            "kind"
-          ],
-          "properties": {
-            "kind": {
-              "type": "string",
-              "enum": [
-                "dist-metadata"
-              ]
-            }
-          }
-        },
-        {
           "description": "Installer",
           "type": "object",
           "required": [
@@ -308,20 +293,6 @@ expression: json_schema
           "items": {
             "$ref": "#/definitions/Artifact"
           }
-        },
-        "changelog_body": {
-          "description": "The body of the changelog for this release",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "changelog_title": {
-          "description": "The title of the changelog for this release",
-          "type": [
-            "string",
-            "null"
-          ]
         }
       }
     }

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -41,6 +41,13 @@ expression: json_schema
         "null"
       ]
     },
+    "artifacts": {
+      "description": "The artifacts included in this Announcement, referenced by releases.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Artifact"
+      }
+    },
     "dist_version": {
       "description": "The version of cargo-dist that generated this",
       "type": [
@@ -291,7 +298,7 @@ expression: json_schema
           "description": "The artifacts for this release (zips, debuginfo, metadata...)",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Artifact"
+            "type": "string"
           }
         }
       }

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -96,8 +96,6 @@ fn build_manifest(cfg: &Config, dist: &DistGraph) -> DistManifest {
         releases.push(Release {
             app_name: release.app_name.clone(),
             app_version: release.version.to_string(),
-            changelog_title: release.changelog_title.clone(),
-            changelog_body: release.changelog_body.clone(),
             artifacts,
         })
     }

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -5,7 +5,13 @@
 //!
 //!
 
-use std::{collections::HashMap, fs::File, io::BufReader, ops::Not, process::Command};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs::File,
+    io::BufReader,
+    ops::Not,
+    process::Command,
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_dist_schema::{Asset, AssetKind, DistManifest, ExecutableAsset, Release};
@@ -79,16 +85,21 @@ pub fn do_manifest(cfg: &Config) -> Result<DistManifest> {
 fn build_manifest(cfg: &Config, dist: &DistGraph) -> DistManifest {
     // Report the releases
     let mut releases = vec![];
+    let mut all_artifacts = BTreeMap::<String, cargo_dist_schema::Artifact>::new();
     for release in &dist.releases {
         // Gather up all the local and global artifacts
         let mut artifacts = vec![];
         for &artifact_idx in &release.global_artifacts {
-            artifacts.push(manifest_artifact(cfg, dist, artifact_idx));
+            let id = &dist.artifact(artifact_idx).id;
+            all_artifacts.insert(id.clone(), manifest_artifact(cfg, dist, artifact_idx));
+            artifacts.push(id.clone());
         }
         for &variant_idx in &release.variants {
             let variant = dist.variant(variant_idx);
             for &artifact_idx in &variant.local_artifacts {
-                artifacts.push(manifest_artifact(cfg, dist, artifact_idx));
+                let id = &dist.artifact(artifact_idx).id;
+                all_artifacts.insert(id.clone(), manifest_artifact(cfg, dist, artifact_idx));
+                artifacts.push(id.clone());
             }
         }
 
@@ -100,7 +111,7 @@ fn build_manifest(cfg: &Config, dist: &DistGraph) -> DistManifest {
         })
     }
 
-    let mut manifest = DistManifest::new(releases);
+    let mut manifest = DistManifest::new(releases, all_artifacts);
     manifest.dist_version = Some(env!("CARGO_PKG_VERSION").to_owned());
     manifest.announcement_tag = dist.announcement_tag.clone();
     manifest.announcement_is_prerelease = dist.announcement_is_prerelease;

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -154,7 +154,8 @@ fn print_human(out: &mut Term, manifest: &DistManifest) -> Result<(), std::io::E
                 .blue()
                 .apply_to(format!("  {} {}", release.app_name, release.app_version))
         )?;
-        for artifact in &release.artifacts {
+        for artifact_id in &release.artifacts {
+            let artifact = &manifest.artifacts[artifact_id];
             // Print out the name or path of the artifact (path is more useful by noisier)
             if let Some(path) = &artifact.path {
                 // Try to highlight the actual filename for easier scanning

--- a/cargo-dist/tests/snapshots/cli_tests__manifest.snap
+++ b/cargo-dist/tests/snapshots/cli_tests__manifest.snap
@@ -15,130 +15,137 @@ stdout:
       "app_name": "cargo-dist",
       "app_version": "1.0.0-FAKEVERSION",
       "artifacts": [
+        "cargo-dist-v1.0.0-FAKEVERSION-installer.sh",
+        "cargo-dist-v1.0.0-FAKEVERSION-installer.ps1",
+        "cargo-dist-v1.0.0-FAKEVERSION-x86_64-apple-darwin.tar.xz",
+        "cargo-dist-v1.0.0-FAKEVERSION-x86_64-pc-windows-msvc.zip",
+        "cargo-dist-v1.0.0-FAKEVERSION-x86_64-unknown-linux-gnu.tar.xz"
+      ]
+    }
+  ],
+  "artifacts": {
+    "cargo-dist-v1.0.0-FAKEVERSION-installer.ps1": {
+      "name": "cargo-dist-v1.0.0-FAKEVERSION-installer.ps1",
+      "kind": "installer",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "install_hint": "# WARNING: this installer is experimental\nirm https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-v1.0.0-FAKEVERSION-installer.ps1 | iex",
+      "description": "Install prebuilt binaries via powershell script"
+    },
+    "cargo-dist-v1.0.0-FAKEVERSION-installer.sh": {
+      "name": "cargo-dist-v1.0.0-FAKEVERSION-installer.sh",
+      "kind": "installer",
+      "target_triples": [
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-gnu"
+      ],
+      "install_hint": "# WARNING: this installer is experimental\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-v1.0.0-FAKEVERSION-installer.sh | sh",
+      "description": "Install prebuilt binaries via shell script"
+    },
+    "cargo-dist-v1.0.0-FAKEVERSION-x86_64-apple-darwin.tar.xz": {
+      "name": "cargo-dist-v1.0.0-FAKEVERSION-x86_64-apple-darwin.tar.xz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-apple-darwin"
+      ],
+      "assets": [
         {
-          "name": "cargo-dist-v1.0.0-FAKEVERSION-installer.sh",
-          "kind": "installer",
-          "target_triples": [
-            "x86_64-apple-darwin",
-            "x86_64-unknown-linux-gnu"
-          ],
-          "install_hint": "# WARNING: this installer is experimental\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-v1.0.0-FAKEVERSION-installer.sh | sh",
-          "description": "Install prebuilt binaries via shell script"
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
         },
         {
-          "name": "cargo-dist-v1.0.0-FAKEVERSION-installer.ps1",
-          "kind": "installer",
-          "target_triples": [
-            "x86_64-pc-windows-msvc"
-          ],
-          "install_hint": "# WARNING: this installer is experimental\nirm https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-v1.0.0-FAKEVERSION-installer.ps1 | iex",
-          "description": "Install prebuilt binaries via powershell script"
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
         },
         {
-          "name": "cargo-dist-v1.0.0-FAKEVERSION-x86_64-apple-darwin.tar.xz",
-          "kind": "executable-zip",
-          "target_triples": [
-            "x86_64-apple-darwin"
-          ],
-          "assets": [
-            {
-              "name": "LICENSE-APACHE",
-              "path": "LICENSE-APACHE",
-              "kind": "license"
-            },
-            {
-              "name": "LICENSE-MIT",
-              "path": "LICENSE-MIT",
-              "kind": "license"
-            },
-            {
-              "name": "README.md",
-              "path": "README.md",
-              "kind": "readme"
-            },
-            {
-              "name": "RELEASES.md",
-              "path": "RELEASES.md",
-              "kind": "changelog"
-            },
-            {
-              "name": "cargo-dist",
-              "path": "cargo-dist",
-              "kind": "executable"
-            }
-          ]
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
         },
         {
-          "name": "cargo-dist-v1.0.0-FAKEVERSION-x86_64-pc-windows-msvc.zip",
-          "kind": "executable-zip",
-          "target_triples": [
-            "x86_64-pc-windows-msvc"
-          ],
-          "assets": [
-            {
-              "name": "LICENSE-APACHE",
-              "path": "LICENSE-APACHE",
-              "kind": "license"
-            },
-            {
-              "name": "LICENSE-MIT",
-              "path": "LICENSE-MIT",
-              "kind": "license"
-            },
-            {
-              "name": "README.md",
-              "path": "README.md",
-              "kind": "readme"
-            },
-            {
-              "name": "RELEASES.md",
-              "path": "RELEASES.md",
-              "kind": "changelog"
-            },
-            {
-              "name": "cargo-dist",
-              "path": "cargo-dist.exe",
-              "kind": "executable"
-            }
-          ]
+          "name": "RELEASES.md",
+          "path": "RELEASES.md",
+          "kind": "changelog"
         },
         {
-          "name": "cargo-dist-v1.0.0-FAKEVERSION-x86_64-unknown-linux-gnu.tar.xz",
-          "kind": "executable-zip",
-          "target_triples": [
-            "x86_64-unknown-linux-gnu"
-          ],
-          "assets": [
-            {
-              "name": "LICENSE-APACHE",
-              "path": "LICENSE-APACHE",
-              "kind": "license"
-            },
-            {
-              "name": "LICENSE-MIT",
-              "path": "LICENSE-MIT",
-              "kind": "license"
-            },
-            {
-              "name": "README.md",
-              "path": "README.md",
-              "kind": "readme"
-            },
-            {
-              "name": "RELEASES.md",
-              "path": "RELEASES.md",
-              "kind": "changelog"
-            },
-            {
-              "name": "cargo-dist",
-              "path": "cargo-dist",
-              "kind": "executable"
-            }
-          ]
+          "name": "cargo-dist",
+          "path": "cargo-dist",
+          "kind": "executable"
+        }
+      ]
+    },
+    "cargo-dist-v1.0.0-FAKEVERSION-x86_64-pc-windows-msvc.zip": {
+      "name": "cargo-dist-v1.0.0-FAKEVERSION-x86_64-pc-windows-msvc.zip",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "name": "RELEASES.md",
+          "path": "RELEASES.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "cargo-dist",
+          "path": "cargo-dist.exe",
+          "kind": "executable"
+        }
+      ]
+    },
+    "cargo-dist-v1.0.0-FAKEVERSION-x86_64-unknown-linux-gnu.tar.xz": {
+      "name": "cargo-dist-v1.0.0-FAKEVERSION-x86_64-unknown-linux-gnu.tar.xz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-unknown-linux-gnu"
+      ],
+      "assets": [
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "name": "RELEASES.md",
+          "path": "RELEASES.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "cargo-dist",
+          "path": "cargo-dist",
+          "kind": "executable"
         }
       ]
     }
-  ]
+  }
 }
 
 stderr:


### PR DESCRIPTION
fixes #150 

Note that there's currently a weird denormalization where an artifact is referenced by id, but also has a "name" which is just the id again, but Optional. This is intentionally left in as future space for #72.