### PR TITLE
chore(book): show repository link

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -4,3 +4,7 @@ language = "en"
 multilingual = false
 src = "src"
 title = "cargo-dist"
+
+[output.html]
+git-repository-url = "https://github.com/axodotdev/cargo-dist"
+edit-url-template = "https://github.com/axodotdev/cargo-dist/edit/main/book/{path}"


### PR DESCRIPTION
Show 2 new icons:
- github repository
- button to edit the current page in GitHub 
<img width="247" alt="Introduction_-_cargo-dist" src="https://user-images.githubusercontent.com/11428655/221441315-947ada9d-7ebf-40d2-9272-aa6119271ba8.png">

## Separate suggestion

You might also want to add the [site-url](https://rust-lang.github.io/mdBook/format/configuration/renderers.html?highlight=site-url#html-renderer-options) option to improve the 404 links.

It should be something like this:
```
site-url = "/cargo-dist/book/"
```