### PR TITLE
Add `Swatinem/rust-cache@v2` to generated github CI

### DIFF
--- a/cargo-dist/src/ci.yml
+++ b/cargo-dist/src/ci.yml
@@ -53,6 +53,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: {{{{INSTALL_RUST}}}}
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2
       - name: Install cargo-dist
         run: {{{{INSTALL_DIST_SH}}}}
       - id: create-release


### PR DESCRIPTION
Since `cargo-dist` operates on binary crates, it seems to be reasonable to assume that dependency caching would be efficient — binary crates generally have quite a few dependencies which can be cached.

On the other hand caching is made less important/efficient by the fact that releases are generally a lot less frequent than, for example, per-commit/PR CI checks.

Thus I'm not entirely sure this has a lot of value, but I think it still should make releases a bit faster.

(P.S. sorry for not discussing in issues first, I didn't notice contributing instructing at first; anyway this change is small enough that I don't mind if my "work" is wasted here and this PR is not accepted)