### PR TITLE
Remove trailing spaces from templated files

### DIFF
--- a/cargo-dist/templates/ci.yml
+++ b/cargo-dist/templates/ci.yml
@@ -60,7 +60,7 @@ jobs:
           cargo dist manifest --tag=${{ github.ref_name }} --artifacts=all --no-local-paths --output-format=json > dist-manifest.json
           echo "dist manifest ran successfully"
           cat dist-manifest.json
-        
+
           # Create the Github Release™ based on what cargo-dist thinks it should be
           ANNOUNCEMENT_TITLE=$(cat dist-manifest.json | jq --raw-output ".announcement_title")
           IS_PRERELEASE=$(cat dist-manifest.json | jq --raw-output ".announcement_is_prerelease")

--- a/cargo-dist/templates/installer.sh
+++ b/cargo-dist/templates/installer.sh
@@ -113,7 +113,7 @@ install() {
         # unzip seems to need this chmod
         chmod +x "$_install_dir/$_bin_name"
     done
-    
+
     say "everything's installed!"
 }
 

--- a/cargo-dist/templates/npm/binary.js
+++ b/cargo-dist/templates/npm/binary.js
@@ -25,7 +25,7 @@ const getPlatform = () => {
   // for a platform, so translate the "os" library's concepts into rust ones
   let os_type = "";
   switch (raw_os_type) {
-    case "Windows_NT": 
+    case "Windows_NT":
       os_type = "pc-windows-msvc";
       break;
     case "Darwin":


### PR DESCRIPTION
Some of the files that `cargo dist` generates (namely, the GitHub release workflow and the installer scripts) contain lines with trailing spaces, which violates numerous coding standards.  This PR gets rid of the trailing whitespace in these files.

Note that there are many other files in this repository with lines with trailing spaces (I would recommend using [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks) via [pre-commit](https://github.com/pre-commit/pre-commit) to get rid of trailing whitespace and keep it out), but I have opted to leave them alone for the purposes of this PR.