### PR TITLE
fix(npm-installer): Update binary.js to respect suppressLog passed from run.js

### DIFF
--- a/cargo-dist/templates/npm/binary.js
+++ b/cargo-dist/templates/npm/binary.js
@@ -95,10 +95,9 @@ const getBinary = () => {
   return binary;
 };
 
-const install = () => {
+const install = (suppressLogs) => {
   const binary = getBinary();
   const proxy = configureProxy(binary.url);
-  const suppressLogs = false;
 
   return binary.install(proxy, suppressLogs);
 };

--- a/cargo-dist/templates/npm/install.js
+++ b/cargo-dist/templates/npm/install.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 const { install } = require("./binary");
-install();
+install(false);


### PR DESCRIPTION
Without this change, the argument passed from `run.js` is ignored:

https://github.com/axodotdev/cargo-dist/blob/4daf3da315032d73c2dcc263412d55c27cc1525d/cargo-dist/templates/npm/run.js#L4

FYI, `suppressLog` is a partially inverted in `binary-install` package: https://github.com/EverlastingBugstopper/binary-install/pull/23, but it is still better to pass `true` to avoid "... is already installed, skipping installation." message being printed on every CLI run.