### PR TITLE
usable interactive init/update?

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "clap",
  "clap-cargo",
  "console",
+ "dialoguer",
  "flate2",
  "guppy",
  "insta",
@@ -538,6 +539,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
 
 [[package]]
+name = "dialoguer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,7 +648,7 @@ checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "windows-sys 0.48.0",
 ]
 
@@ -850,6 +872,15 @@ dependencies = [
  "regex",
  "similar",
  "yaml-rust",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1332,6 +1363,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1659,19 @@ dependencies = [
  "cfg-expr",
  "guppy-workspace-hack",
  "target-lexicon",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1968,11 +2027,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2100,6 +2183,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[package]]
 name = "zip"

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -47,6 +47,7 @@ toml_edit = "0.15.0"
 parse-changelog = { version = "0.5.3", default-features = false }
 newline-converter = "0.2.2"
 axoproject = { version = "0.2.0", default-features = false, features = ["cargo-projects"] }
+dialoguer = "0.10.4"
 
 [dev-dependencies]
 insta = { version = "1.26.0", features = ["filters"] }

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -6,5 +6,45 @@
 //!
 //! If we ever change this decision, this will be a lot more important!
 
+use axoproject::errors::AxoprojectError;
+use miette::Diagnostic;
+use thiserror::Error;
+
 /// An alias for the common Result type of this crate
 pub type Result<T> = std::result::Result<T, miette::Report>;
+/// An alias for the NEW Result type for this crate (undergoing migration)
+pub type DistResult<T> = std::result::Result<T, DistError>;
+
+/// Errors cargo-dist can have
+#[derive(Debug, Error, Diagnostic)]
+pub enum DistError {
+    /// random i/o error
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// User declined to update cargo-dist, refuse to make progress
+    #[error(
+        "to update your cargo-dist config you must use the version your project is configured for"
+    )]
+    #[diagnostic(help(
+        "you're running {running_version} but the project is configured for {project_version}"
+    ))]
+    NoUpdateVersion {
+        /// Version the config had
+        project_version: semver::Version,
+        /// Version they're running
+        running_version: semver::Version,
+    },
+
+    /// User tried to enable Github CI support but had inconsistent urls for the repo
+    #[error("Github CI support requires your crates to agree on the URL of your repository")]
+    CantEnableGithubUrlInconsistent {
+        /// inner error that caught this
+        #[diagnostic_source]
+        inner: AxoprojectError,
+    },
+    /// User tried to enable Github CI support but no url for the repo
+    #[error("Github CI support requires you to specify the URL of your repository")]
+    #[diagnostic(help(r#"Set the repository = "https://github.com/..." key in your Cargo.toml"#))]
+    CantEnableGithubNoUrl,
+}

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -47,4 +47,7 @@ pub enum DistError {
     #[error("Github CI support requires you to specify the URL of your repository")]
     #[diagnostic(help(r#"Set the repository = "https://github.com/..." key in your Cargo.toml"#))]
     CantEnableGithubNoUrl,
+    /// User declined to force tar.gz with npm
+    #[error("Cannot enable npm support without forcing artifacts to be .tar.gz")]
+    MustEnableTarGz,
 }

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -932,8 +932,6 @@ fn init_dist_metadata(
         .unwrap_or_default()
         .contains(&InstallerStyle::Npm)
     {
-        const TAR_GZ: Option<ZipStyle> = Some(ZipStyle::Tar(CompressionImpl::Gzip));
-
         // If npm is being newly enabled here, prompt for a @scope
         let npm_is_new = !orig_meta
             .installers
@@ -969,14 +967,20 @@ fn init_dist_metadata(
         }
 
         // FIXME (#226): If they have an npm installer, force on tar.gz compression
-        let prompt = "the npm installer currently requires all artifacts be .tar.gz, is that ok?";
-        let force_targz = Confirm::with_theme(&theme)
-            .with_prompt(prompt)
-            .default(true)
-            .interact()?;
-        if force_targz {
-            meta.unix_archive = TAR_GZ;
-            meta.windows_archive = TAR_GZ;
+        const TAR_GZ: Option<ZipStyle> = Some(ZipStyle::Tar(CompressionImpl::Gzip));
+        if meta.unix_archive != TAR_GZ || meta.windows_archive != TAR_GZ {
+            let prompt =
+                "the npm installer currently requires all artifacts be .tar.gz, is that ok?";
+            let force_targz = Confirm::with_theme(&theme)
+                .with_prompt(prompt)
+                .default(true)
+                .interact()?;
+            if force_targz {
+                meta.unix_archive = TAR_GZ;
+                meta.windows_archive = TAR_GZ;
+            } else {
+                return Err(DistError::MustEnableTarGz)?;
+            }
         }
     }
 


### PR DESCRIPTION
This turns `cargo dist init` into an interactive setup/updater that walks you through setting things up (recommended settings can all be selected by mashing ENTER over and over). Including:

* prompting you to update your project to the version of cargo-dist you're running (refuses to proceed otherwise)
* prompting you to select what CI backend to use (only one option, github)
   * enabled by default if we see your project's repo contains "github"
   * errors out if you don't have a consistently set repository url in your workspace's Cargo.tomls
* prompting you to select what installers to enable
   * skips if no CI backend is enabled, as we use this to derive fetch URLs for artifacts
   * if npm is enabled:
     * if newly enabled, prompts you to provide an `@scope`
     * if tar.gz artifacts aren't enabled, prompts you to enable them
* adds comments to your Cargo.toml describing any keys that are set
* running `cargo dist generate-ci` afterwards

This also introduces some initial work for #222 to introduce a proper error type