### PR TITLE
recursively checkout submodules in ci template

### DIFF
--- a/cargo-dist/templates/ci.yml
+++ b/cargo-dist/templates/ci.yml
@@ -51,6 +51,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Install Rust
         run: {{{{INSTALL_RUST}}}}
       - name: Install cargo-dist
@@ -91,6 +93,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Install Rust
         run: {{{{INSTALL_RUST}}}}
       - name: Install cargo-dist
@@ -123,6 +127,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: mark release as non-draft
         run: |
           gh release edit ${{ github.ref_name }} --draft=false


### PR DESCRIPTION
This makes us behave properly for project with git submodules, at no cost to projects that don't need it(?)

fixes #242