### PR TITLE
Fallback to the  Unreleased section in changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+placeholder
+
 # Version 0.0.7 (2023-05-09)
 
 This is just a quick little release that makes the npm package tarballs we can generate


### PR DESCRIPTION
parse_changelog supports a special section title of 'Unreleased', which we can default to if we're publishing a prerelease and fail to find any entry for it.

Fixes #145