### PR TITLE
update GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,29 +24,22 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          profile: minimal
           components: rustfmt
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   # Check that clippy is appeased
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          profile: minimal
           components: clippy
-          override: true
       - uses: actions-rs/clippy-check@v1
         env:
           PWD: ${{ env.GITHUB_WORKSPACE }}
@@ -61,17 +54,12 @@ jobs:
      RUSTDOCFLAGS: -Dwarnings
    steps:
      - uses: actions/checkout@master
-     - uses: actions-rs/toolchain@v1
+     - uses: dtolnay/rust-toolchain@master
        with:
          toolchain: stable
-         profile: minimal
          components: rust-docs
-         override: true
      - uses: swatinem/rust-cache@v1
-     - uses: actions-rs/cargo@v1
-       with:
-         command: doc
-         args: --workspace --no-deps
+     - run: cargo doc --workspace --no-deps
 
   # Build and run tests/doctests/examples on all platforms
   # FIXME: look into `cargo-hack` which lets you more aggressively
@@ -86,37 +74,23 @@ jobs:
     steps:
       # Setup tools
       - uses: actions/checkout@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
       - uses: swatinem/rust-cache@v1
       # Run the tests/doctests (default features)
-      - uses: actions-rs/cargo@v1
+      - run: cargo test --workspace
         env:
           PWD: ${{ env.GITHUB_WORKSPACE }}
-        with:
-          command: test
-          args: --workspace
       # Run the tests/doctests (all features)
-      - uses: actions-rs/cargo@v1
+      - run: cargo test --workspace --all-features
         env:
           PWD: ${{ env.GITHUB_WORKSPACE }}
-        with:
-          command: test
-          args: --workspace --all-features
       # Test the examples (default features)
-      - uses: actions-rs/cargo@v1
+      - run: cargo test --workspace --examples --bins
         env:
           PWD: ${{ env.GITHUB_WORKSPACE }}
-        with:
-          command: test
-          args: --workspace --examples --bins
       # Test the examples (all features)
-      - uses: actions-rs/cargo@v1
+      - run: cargo test --workspace --all-features --examples --bins
         env:
           PWD: ${{ env.GITHUB_WORKSPACE }}
-        with:
-          command: test
-          args: --workspace --all-features --examples --bins

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -52,13 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Setup
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
 
       # OPTIONAL: build your mdbook
       # Note that "./book/" is the directory in our repo where the book.toml is


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v3
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)
* replace unmaintained `actions-rs/cargo` by direct invocation of `cargo`

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/axodotdev/cargo-dist/actions/runs/4949169752:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.