### PR TITLE
feat(toolchain): deprecate rust-toolchain-version in favor of rust-toolchain.toml

### DIFF
--- a/book/src/config.md
+++ b/book/src/config.md
@@ -67,9 +67,11 @@ If you delete the key, generate-ci will just use the version of cargo-dist that'
 
 ### rust-toolchain-version
 
-> since 0.0.3
+> since 0.0.3 (deprecated in 0.1.0)
 
 Example: `rust-toolchain-version = "1.67.1"` 
+
+> Deprecation reason: [rust-toolchain.toml](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) is a more standard/universal mechanism for pinning toolchain versions for reproducibility. Teams without dedicated release engineers will likely benefit from unpinning their toolchain and letting the underlying CI vendor silently update them to "some recent stable toolchain", as they will get updates/improvements and are unlikely to have regressions.
 
 **This can only be set globally**
 
@@ -77,7 +79,7 @@ This is added automatically by `cargo dist init`, recorded for the sake of repro
 
 The syntax must be a valid rustup toolchain like "1.60.0" or "stable" (should not specify the platform, we want to install this toolchain on all platforms).
 
-If you delete the key, generate-ci will just use "stable" which will drift over time as new stable releases occur.
+If you delete the key, generate-ci won't explicitly setup a toolchain, so whatever's on the machine will be used (with things like rust-toolchain.toml behaving as normal). Before being deprecated the default was to `rustup update stable`, but this is no longer the case.
 
 ### ci
 

--- a/cargo-dist-schema/cargo-dist-json-schema.json
+++ b/cargo-dist-schema/cargo-dist-json-schema.json
@@ -57,6 +57,17 @@
       "items": {
         "$ref": "#/definitions/Release"
       }
+    },
+    "system_info": {
+      "description": "Info about the toolchain used to build this announcement",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SystemInfo"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {
@@ -318,6 +329,19 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "SystemInfo": {
+      "description": "Info about the system/toolchain used to build this announcement.\n\nNote that this is info from the machine that generated this file, which *ideally* should be similar to the machines that built all the artifacts, but we can't guarantee that.\n\ndist-manifest.json is by default generated at the start of the build process, and typically on a linux machine because that's usually the fastest/cheapest part of CI infra.",
+      "type": "object",
+      "properties": {
+        "cargo_version_line": {
+          "description": "The version of Cargo used (first line of cargo -vV)\n\nNote that this is the version used on the machine that generated this file, which presumably should be the same version used on all the machines that built all the artifacts, but maybe not! It's more likely to be correct if rust-toolchain.toml is used with a specific pinned version.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -53,6 +53,10 @@ pub struct DistManifest {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub announcement_github_body: Option<String>,
+    /// Info about the toolchain used to build this announcement
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_info: Option<SystemInfo>,
     /// App releases we're distributing
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -61,6 +65,26 @@ pub struct DistManifest {
     #[serde(default)]
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub artifacts: BTreeMap<ArtifactId, Artifact>,
+}
+
+/// Info about the system/toolchain used to build this announcement.
+///
+/// Note that this is info from the machine that generated this file,
+/// which *ideally* should be similar to the machines that built all the artifacts, but
+/// we can't guarantee that.
+///
+/// dist-manifest.json is by default generated at the start of the build process,
+/// and typically on a linux machine because that's usually the fastest/cheapest
+/// part of CI infra.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SystemInfo {
+    /// The version of Cargo used (first line of cargo -vV)
+    ///
+    /// Note that this is the version used on the machine that generated this file,
+    /// which presumably should be the same version used on all the machines that
+    /// built all the artifacts, but maybe not! It's more likely to be correct
+    /// if rust-toolchain.toml is used with a specific pinned version.
+    pub cargo_version_line: Option<String>,
 }
 
 /// A Release of an Application
@@ -247,6 +271,7 @@ impl DistManifest {
             announcement_title: None,
             announcement_changelog: None,
             announcement_github_body: None,
+            system_info: None,
             releases,
             artifacts,
         }

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -61,6 +61,17 @@ expression: json_schema
       "items": {
         "$ref": "#/definitions/Release"
       }
+    },
+    "system_info": {
+      "description": "Info about the toolchain used to build this announcement",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SystemInfo"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {
@@ -322,6 +333,19 @@ expression: json_schema
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "SystemInfo": {
+      "description": "Info about the system/toolchain used to build this announcement.\n\nNote that this is info from the machine that generated this file, which *ideally* should be similar to the machines that built all the artifacts, but we can't guarantee that.\n\ndist-manifest.json is by default generated at the start of the build process, and typically on a linux machine because that's usually the fastest/cheapest part of CI infra.",
+      "type": "object",
+      "properties": {
+        "cargo_version_line": {
+          "description": "The version of Cargo used (first line of cargo -vV)\n\nNote that this is the version used on the machine that generated this file, which presumably should be the same version used on all the machines that built all the artifacts, but maybe not! It's more likely to be correct if rust-toolchain.toml is used with a specific pinned version.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -143,9 +143,8 @@ fn get_new_dist_metadata(
         DistMetadata {
             // If they init with this version we're gonna try to stick to it!
             cargo_dist_version: Some(std::env!("CARGO_PKG_VERSION").parse().unwrap()),
-            // latest stable release at this precise moment
-            // maybe there's something more clever we can do here, but, *shrug*
-            rust_toolchain_version: Some("1.67.1".to_owned()),
+            // deprecated, default to not emitting it
+            rust_toolchain_version: None,
             ci: vec![],
             installers: None,
             targets: cfg.targets.is_empty().not().then(|| cfg.targets.clone()),

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -125,6 +125,9 @@ fn build_manifest(cfg: &Config, dist: &DistGraph) -> DistManifest {
     manifest.announcement_title = dist.announcement_title.clone();
     manifest.announcement_changelog = dist.announcement_changelog.clone();
     manifest.announcement_github_body = dist.announcement_github_body.clone();
+    manifest.system_info = Some(cargo_dist_schema::SystemInfo {
+        cargo_version_line: dist.tools.cargo.version_line.clone(),
+    });
     manifest
 }
 
@@ -315,7 +318,7 @@ fn build_cargo_target(dist_graph: &DistGraph, target: &CargoBuildStep) -> Result
         target.target_triple, target.profile
     );
 
-    let mut command = Command::new(&dist_graph.cargo);
+    let mut command = Command::new(&dist_graph.tools.cargo.cmd);
     command
         .arg("build")
         .arg("--profile")

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -113,7 +113,7 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cargo_dist_version: Option<Version>,
 
-    /// The intended version of Rust/Cargo to build with (rustup toolchain syntax)
+    /// (deprecated) The intended version of Rust/Cargo to build with (rustup toolchain syntax)
     ///
     /// When generating full tasks graphs (such as CI scripts) we will pick this version.
     #[serde(rename = "rust-toolchain-version")]
@@ -918,6 +918,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         workspace_metadata.make_relative_to(&workspace.workspace_dir);
         let desired_cargo_dist_version = workspace_metadata.cargo_dist_version.clone();
         let desired_rust_toolchain = workspace_metadata.rust_toolchain_version.clone();
+        if desired_rust_toolchain.is_some() {
+            warn!("rust-toolchain-version is deprecated, use rust-toolchain.toml if you want pinned toolchains");
+        }
 
         let mut package_metadata = vec![];
         for package in &workspace.package_info {

--- a/cargo-dist/templates/ci.yml
+++ b/cargo-dist/templates/ci.yml
@@ -52,9 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
-      - name: Install Rust
-        run: {{{{INSTALL_RUST}}}}
+          submodules: recursive{{{{INSTALL_RUST}}}}
       - name: Install cargo-dist
         run: {{{{INSTALL_DIST_SH}}}}
       - id: create-release
@@ -94,9 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
-      - name: Install Rust
-        run: {{{{INSTALL_RUST}}}}
+          submodules: recursive{{{{INSTALL_RUST}}}}
       - name: Install cargo-dist
         run: ${{ matrix.install-dist }}
       - name: Run cargo-dist

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -90,6 +90,7 @@ fn test_manifest() {
         (r#""announcement_changelog": .*"#, r#""announcement_changelog": "CENSORED""#),
         (r#""announcement_github_body": .*"#, r#""announcement_github_body": "CENSORED""#),
         (r#""announcement_is_prerelease": .*"#, r#""announcement_is_prerelease": "CENSORED""#),
+        (r#""cargo_version_line": .*"#, r#""cargo_version_line": "CENSORED""#),
     ]}, {
         insta::assert_snapshot!(format_outputs(&output));
     });
@@ -121,6 +122,7 @@ fn test_lib_manifest() {
         (r#""announcement_changelog": .*"#, r#""announcement_changelog": "CENSORED""#),
         (r#""announcement_github_body": .*"#, r#""announcement_github_body": "CENSORED""#),
         (r#""announcement_is_prerelease": .*"#, r#""announcement_is_prerelease": "CENSORED""#),
+        (r#""cargo_version_line": .*"#, r#""cargo_version_line": "CENSORED""#),
     ]}, {
         insta::assert_snapshot!(format_outputs(&output));
     });
@@ -150,6 +152,7 @@ fn test_error_manifest() {
         (r#""announcement_changelog": .*"#, r#""announcement_changelog": "CENSORED""#),
         (r#""announcement_github_body": .*"#, r#""announcement_github_body": "CENSORED""#),
         (r#""announcement_is_prerelease": .*"#, r#""announcement_is_prerelease": "CENSORED""#),
+        (r#""cargo_version_line": .*"#, r#""cargo_version_line": "CENSORED""#),
     ]}, {
         insta::assert_snapshot!(format_outputs(&output));
     });

--- a/cargo-dist/tests/snapshots/cli_tests__error_manifest.snap
+++ b/cargo-dist/tests/snapshots/cli_tests__error_manifest.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/cli-tests.rs
-assertion_line: 154
 expression: format_outputs(&output)
 ---
 stdout:
@@ -8,6 +7,7 @@ stdout:
 
 stderr:
 analyzing workspace:
+ WARN rust-toolchain-version is deprecated, use rust-toolchain.toml if you want pinned toolchains
   cargo-dist (didn't match tag v1.0.0-FAKEVERSION)
     [bin] cargo-dist
   cargo-dist-schema (no binaries)

--- a/cargo-dist/tests/snapshots/cli_tests__lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/cli_tests__lib_manifest.snap
@@ -13,6 +13,7 @@ stdout:
 
 stderr:
 analyzing workspace:
+ WARN rust-toolchain-version is deprecated, use rust-toolchain.toml if you want pinned toolchains
   cargo-dist (didn't match tag cargo-dist-schema-v1.0.0-FAKEVERSION)
     [bin] cargo-dist
   cargo-dist-schema (no binaries)

--- a/cargo-dist/tests/snapshots/cli_tests__lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/cli_tests__lib_manifest.snap
@@ -9,6 +9,9 @@ stdout:
   "announcement_is_prerelease": "CENSORED"
   "announcement_title": "CENSORED"
   "announcement_github_body": "CENSORED"
+  "system_info": {
+    "cargo_version_line": "CENSORED"
+  }
 }
 
 stderr:

--- a/cargo-dist/tests/snapshots/cli_tests__manifest.snap
+++ b/cargo-dist/tests/snapshots/cli_tests__manifest.snap
@@ -10,6 +10,9 @@ stdout:
   "announcement_title": "CENSORED"
   "announcement_changelog": "CENSORED"
   "announcement_github_body": "CENSORED"
+  "system_info": {
+    "cargo_version_line": "CENSORED"
+  },
   "releases": [
     {
       "app_name": "cargo-dist",

--- a/cargo-dist/tests/snapshots/cli_tests__manifest.snap
+++ b/cargo-dist/tests/snapshots/cli_tests__manifest.snap
@@ -222,6 +222,7 @@ stdout:
 
 stderr:
 analyzing workspace:
+ WARN rust-toolchain-version is deprecated, use rust-toolchain.toml if you want pinned toolchains
   cargo-dist
     [bin] cargo-dist
   cargo-dist-schema (no binaries)


### PR DESCRIPTION
Deprecation reason: [rust-toolchain.toml](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) is a more standard/universal mechanism for pinning toolchain versions for reproducibility. Teams without dedicated release engineers will likely benefit from unpinning their toolchain and letting the underlying CI vendor silently update them to 'some recent stable toolchain', as they will get updates/improvements and are unlikely to have regressions.

If you delete the key, generate-ci won't explicitly setup a toolchain, so whatever's on the machine will be used (with things like rust-toolchain.toml behaving as normal). Before being deprecated the default was to 
ustup update stable, but this is no longer the case.

We will warn if the key is set, recommending rust-toolchain.toml

----

This also adds system_info.cargo_version_line to dist-manifest.json, giviing back some reproducibility info to folks using unpinned toolchains.

fixes #205 