### PR TITLE
feat(fault-isolate): prefer independent tasks and don't fail-fast

### DIFF
--- a/book/src/config.md
+++ b/book/src/config.md
@@ -238,6 +238,27 @@ For example, if you build for x64 macos and arm64 macos, by default we will gene
 
 The default is `false`. Before 0.1.0 it was always `true` and couldn't be changed, making releases annoyingly slow (and technically less fault-isolated). This config was added to allow you to restore the old behaviour, if you really want.
 
+### fail-fast
+
+> since 0.1.0
+
+Example `fail-fast = true`
+
+Whether failing tasks should make us give up on all other tasks. (defaults to false)
+
+When building a release you might discover that an obscure platform's build is broken. When this happens you have two options: give up on the release entirely (`fail-fast = true`), or keep trying to build all the other platforms anyway (`fail-fast = false`).
+
+cargo-dist was designed around the "keep trying" approach, as we create a draft Release
+and upload results to it over time, undrafting the release only if all tasks succeeded.
+The idea is that even if a platform fails to build, you can decide that's acceptable
+and manually undraft the release with some missing platforms.
+
+(Note that the dist-manifest.json is produced before anything else, and so it will assume
+that all tasks succeeded when listing out supported platforms/artifacts. This may make
+you sad if you do this kind of undrafting and also trust the dist-manifest to be correct.)
+
+Prior to 0.1.0 we didn't set the correct flags in our CI scripts to do this, but now we do.
+This flag was introduced to allow you to restore the old behaviour if you prefer.
 
 
 ## Subsetting CI Flags

--- a/book/src/config.md
+++ b/book/src/config.md
@@ -226,6 +226,20 @@ If that downside is big enough for you, this setting is a good idea.
 [workspace-hack]: https://docs.rs/cargo-hakari/latest/cargo_hakari/about/index.html
 
 
+### merge-tasks
+
+> since 0.1.0
+
+Example `merge-tasks = true`
+
+Whether we should try to merge otherwise-parallelizable tasks onto the same machine, sacrificing latency and fault-isolation for more the sake of minor effeciency gains.
+
+For example, if you build for x64 macos and arm64 macos, by default we will generate ci which builds those independently on separate logical machines. With this enabled we will build both of those platforms together on the same machine, making it take twice as long as any other build and making it impossible for only one of them to succeed.
+
+The default is `false`. Before 0.1.0 it was always `true` and couldn't be changed, making releases annoyingly slow (and technically less fault-isolated). This config was added to allow you to restore the old behaviour, if you really want.
+
+
+
 ## Subsetting CI Flags
 
 Several `metadata.dist` configs have globally available CLI equivalents. These can be used to select a subset of `metadata.dist` list for that run. If you don't pass any, it will be as-if you passed all the values in `metadata.dist`. You can pass these flags multiple times to provide a list. This includes:

--- a/cargo-dist/src/ci.rs
+++ b/cargo-dist/src/ci.rs
@@ -111,12 +111,15 @@ fn write_github_ci<W: std::io::Write>(f: &mut W, dist: &DistGraph) -> Result<(),
         push_github_artifacts_matrix_entry(&mut artifacts_matrix, runner, &dist_args, install_dist);
     }
 
+    let fail_fast = format!("{}", dist.fail_fast);
+
     // Finally write the final CI script to the Writer
     let ci_yml = include_str!("../templates/ci.yml");
     let ci_yml = ci_yml
         .replace("{{{{INSTALL_RUST}}}}", &install_rust)
         .replace("{{{{INSTALL_DIST_SH}}}}", &install_dist_sh)
-        .replace("{{{{ARTIFACTS_MATRIX}}}}", &artifacts_matrix);
+        .replace("{{{{ARTIFACTS_MATRIX}}}}", &artifacts_matrix)
+        .replace("{{{{FAIL_FAST}}}}", &fail_fast);
 
     f.write_all(dos2unix(&ci_yml).as_bytes())?;
 

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -157,6 +157,7 @@ fn get_new_dist_metadata(
             checksum: None,
             precise_builds: None,
             merge_tasks: None,
+            fail_fast: None,
         }
     };
 
@@ -521,6 +522,10 @@ fn update_toml_metadata(workspace_toml: &mut toml_edit::Document, meta: &DistMet
     const DESC_MERGE_TASKS: &str =
         "# Whether to run otherwise-parallelizable tasks on the same machine\n";
 
+    const KEY_FAIL_FAST: &str = "fail-fast";
+    const DESC_FAIL_FAST: &str =
+        "# Whether failing tasks should make us give up on all other tasks\n";
+
     let workspace = workspace_toml["workspace"].or_insert(toml_edit::table());
     if let Some(t) = workspace.as_table_mut() {
         t.set_implicit(true)
@@ -666,6 +671,14 @@ fn update_toml_metadata(workspace_toml: &mut toml_edit::Document, meta: &DistMet
             .key_decor_mut(KEY_MERGE_TASKS)
             .unwrap()
             .set_prefix(DESC_MERGE_TASKS);
+    }
+
+    if let Some(val) = meta.fail_fast {
+        table.insert(KEY_FAIL_FAST, value(val));
+        table
+            .key_decor_mut(KEY_FAIL_FAST)
+            .unwrap()
+            .set_prefix(DESC_FAIL_FAST);
     }
 
     table

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -156,6 +156,7 @@ fn get_new_dist_metadata(
             npm_scope: None,
             checksum: None,
             precise_builds: None,
+            merge_tasks: None,
         }
     };
 
@@ -516,6 +517,10 @@ fn update_toml_metadata(workspace_toml: &mut toml_edit::Document, meta: &DistMet
     const KEY_PRECISE_BUILDS: &str = "precise-builds";
     const DESC_PRECISE_BUILDS: &str = "# Build only the required packages, and individually\n";
 
+    const KEY_MERGE_TASKS: &str = "merge-tasks";
+    const DESC_MERGE_TASKS: &str =
+        "# Whether to run otherwise-parallelizable tasks on the same machine\n";
+
     let workspace = workspace_toml["workspace"].or_insert(toml_edit::table());
     if let Some(t) = workspace.as_table_mut() {
         t.set_implicit(true)
@@ -653,6 +658,14 @@ fn update_toml_metadata(workspace_toml: &mut toml_edit::Document, meta: &DistMet
             .key_decor_mut(KEY_PRECISE_BUILDS)
             .unwrap()
             .set_prefix(DESC_PRECISE_BUILDS);
+    }
+
+    if let Some(val) = meta.merge_tasks {
+        table.insert(KEY_MERGE_TASKS, value(val));
+        table
+            .key_decor_mut(KEY_MERGE_TASKS)
+            .unwrap()
+            .set_prefix(DESC_MERGE_TASKS);
     }
 
     table

--- a/cargo-dist/templates/ci.yml
+++ b/cargo-dist/templates/ci.yml
@@ -82,6 +82,7 @@ jobs:
     needs: create-release
     if: ${{ needs.create-release.outputs.has-releases == 'true' }}
     strategy:
+      fail-fast: {{{{FAIL_FAST}}}}
       matrix:
         # For these target platforms
         {{{{ARTIFACTS_MATRIX}}}}


### PR DESCRIPTION
[feat(fault-isolate): add merge-tasks config and default it to false](https://github.com/axodotdev/cargo-dist/commit/10f740b24f22094f49858ce98b4d9e76d6c9fbe8)

This config specifies whether we should try to merge otherwise-parallelizable tasks onto the same machine, sacrificing latency and fault-isolation for more the sake of minor effeciency gains.

For example, if you build for x64 macos and arm64 macos, by default we will generate ci which builds those independently on separate logical machines. With this enabled we will build both of those platforms together on the same machine, making it take twice as long as any other build and making it impossible for only one of them to succeed.

The default is false. Before 0.1.0 it was always true and couldn't be changed, making releases annoyingly slow (and technically less fault-isolated). This config was added to allow you to restore the old behaviour, if you really want.

----

[feat(fault-isolate): add fail-fast config and default it false](https://github.com/axodotdev/cargo-dist/commit/0291fd28f7db1334ea601ef92060486ef23be080)

When building a release you might discover that an obscure platform's build is broken. When this happens you have two options: give up on the release entirely (fail-fast = true), or keep trying to build all the other platforms anyway (fail-fast = false).

cargo-dist was designed around the 'keep trying' approach, as we create a draft Release
and upload results to it over time, undrafting the release only if all tasks succeeded.
The idea is that even if a platform fails to build, you can decide that's acceptable
and manually undraft the release with some missing platforms.

(Note that the dist-manifest.json is produced before anything else, and so it will assume
that all tasks succeeded when listing out supported platforms/artifacts. This may make
you sad if you do this kind of undrafting and also trust the dist-manifest to be correct.)

Prior to 0.1.0 we didn't set the correct flags in our CI scripts to do this, but now we do.
This flag was introduced to allow you to restore the old behaviour if you prefer.