### PR TITLE
feat(precise-builds): add a precise-builds config and default it false

### DIFF
--- a/book/src/config.md
+++ b/book/src/config.md
@@ -205,6 +205,27 @@ The hashes should match the result that sha256sum and sha512sum generate. The cu
 Future work is planned to [support more robust signed checksums][issue-sigstore].
 
 
+### precise-builds
+
+> since 0.1.0
+
+Example `precise-builds = true`
+
+Build only the required packages, and individually (default: false)
+
+By default when we need to build anything in your workspace, we build your entire workspace with --workspace. This setting tells cargo-dist to instead build each app individually.
+
+On balance, the Rust experts we've consulted with find building with --workspace to be a safer/better default, as it provides some of the benefits of a more manual [workspace-hack][], without the user needing to be aware that this is a thing.
+
+TL;DR: cargo prefers building one copy of each dependency in a build, so if two apps in your workspace depend on e.g. serde with different features, building with --workspace, will build serde once with the features unioned together. However if you build each package individually it will more precisely build two copies of serde with different feature sets.
+
+The downside of using --workspace is that if your workspace has lots of example/test crates, or if you release only parts of your workspace at a time, we build a lot of gunk that's not needed, and potentially bloat up your app with unnecessary features.
+
+If that downside is big enough for you, this setting is a good idea.
+
+[workspace-hack]: https://docs.rs/cargo-hakari/latest/cargo_hakari/about/index.html
+
+
 ## Subsetting CI Flags
 
 Several `metadata.dist` configs have globally available CLI equivalents. These can be used to select a subset of `metadata.dist` list for that run. If you don't pass any, it will be as-if you passed all the values in `metadata.dist`. You can pass these flags multiple times to provide a list. This includes:

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -155,6 +155,7 @@ fn get_new_dist_metadata(
             unix_archive: None,
             npm_scope: None,
             checksum: None,
+            precise_builds: None,
         }
     };
 
@@ -512,6 +513,9 @@ fn update_toml_metadata(workspace_toml: &mut toml_edit::Document, meta: &DistMet
     const KEY_CHECKSUM: &str = "checksum";
     const DESC_CHECKSUM: &str = "# Checksums to generate for each App\n";
 
+    const KEY_PRECISE_BUILDS: &str = "precise-builds";
+    const DESC_PRECISE_BUILDS: &str = "# Build only the required packages, and individually\n";
+
     let workspace = workspace_toml["workspace"].or_insert(toml_edit::table());
     if let Some(t) = workspace.as_table_mut() {
         t.set_implicit(true)
@@ -641,6 +645,14 @@ fn update_toml_metadata(workspace_toml: &mut toml_edit::Document, meta: &DistMet
             .key_decor_mut(KEY_CHECKSUM)
             .unwrap()
             .set_prefix(DESC_CHECKSUM);
+    }
+
+    if let Some(val) = meta.precise_builds {
+        table.insert(KEY_PRECISE_BUILDS, value(val));
+        table
+            .key_decor_mut(KEY_PRECISE_BUILDS)
+            .unwrap()
+            .set_prefix(DESC_PRECISE_BUILDS);
     }
 
     table

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -313,8 +313,8 @@ fn generate_checksum(
 
 /// Build a cargo target
 fn build_cargo_target(dist_graph: &DistGraph, target: &CargoBuildStep) -> Result<()> {
-    eprintln!(
-        "building cargo target ({}/{})",
+    eprint!(
+        "building cargo target ({}/{}",
         target.target_triple, target.profile
     );
 
@@ -347,9 +347,11 @@ fn build_cargo_target(dist_graph: &DistGraph, target: &CargoBuildStep) -> Result
     match &target.package {
         CargoTargetPackages::Workspace => {
             command.arg("--workspace");
+            eprintln!(" --workspace)");
         }
         CargoTargetPackages::Package(package) => {
-            command.arg("--package").arg(package.to_string());
+            command.arg("--package").arg(package);
+            eprintln!(" --package={})", package);
         }
     }
     info!("exec: {:?}", command);


### PR DESCRIPTION
Setting it to true tells us to Build only the required packages, and individually (default: false)

By default when we need to build anything in your workspace, we build your entire workspace with --workspace. This setting tells cargo-dist to instead build each app individually.

On balance, the Rust experts we've consulted with find building with --workspace to be a safer/better default, as it provides some of the benefits of a more manual [workspace-hack][], without the user needing to be aware that this is a thing.

TL;DR: cargo prefers building one copy of each dependency in a build, so if two apps in your workspace depend on e.g. serde with different features, building with --workspace, will build serde once with the features unioned together. However if you build each package individually it will more precisely build two copies of serde with different feature sets.

The downside of using --workspace is that if your workspace has lots of example/test crates, or if you release only parts of your workspace at a time, we build a lot of gunk that's not needed, and potentially bloat up your app with unnecessary features.

If that downside is big enough for you, this setting is a good idea.