### PR TITLE
feat(json-init): add a --with-json-config=path/to/config.json flag for passing json to init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
  "sha2",
  "tar",
  "thiserror",
- "toml_edit 0.15.0",
+ "toml_edit 0.19.14",
  "tracing",
  "xz2",
  "zip",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,21 +121,21 @@ dependencies = [
 
 [[package]]
 name = "axoasset"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3347278d8b9a15b998d45a0ff07919ca2b98795445aa550cd4222ddacd00e6"
+checksum = "26659fc6821b625ef4e2887e7236ad32247fe690c19ba2d7ec76db1421b5d098"
 dependencies = [
  "camino",
- "flate2",
  "image",
  "miette",
  "mime",
  "reqwest",
- "tar",
+ "serde",
+ "serde_json",
  "thiserror",
+ "toml",
+ "toml_edit 0.19.14",
  "url",
- "xz2",
- "zip",
 ]
 
 [[package]]
@@ -173,7 +173,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "toml_edit",
+ "toml_edit 0.15.0",
  "tracing",
 ]
 
@@ -298,7 +298,7 @@ dependencies = [
 name = "cargo-dist"
 version = "0.1.0-prerelease.4"
 dependencies = [
- "axoasset 0.2.0",
+ "axoasset 0.4.0",
  "axocli",
  "axoproject",
  "camino",
@@ -320,7 +320,7 @@ dependencies = [
  "sha2",
  "tar",
  "thiserror",
- "toml_edit",
+ "toml_edit 0.15.0",
  "tracing",
  "xz2",
  "zip",
@@ -489,22 +489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +628,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,7 +726,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -744,21 +734,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -785,6 +760,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,9 +789,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -859,7 +847,7 @@ dependencies = [
  "debug-ignore",
  "fixedbitset",
  "guppy-workspace-hack",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "nested",
  "once_cell",
@@ -891,7 +879,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -915,6 +903,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
@@ -996,16 +990,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
- "bytes",
+ "futures-util",
+ "http",
  "hyper",
- "native-tls",
+ "rustls",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1044,7 +1039,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -1302,24 +1307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nested"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,50 +1387,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "openssl"
-version = "0.10.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.23",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.90"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,7 +1404,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eab4bdddacb3dd2b7d704d58c2d4755ed63b74563d3d755691741e3b764ad9b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "memchr",
  "once_cell",
  "regex",
@@ -1512,7 +1455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -1671,26 +1614,43 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1727,19 +1687,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
-name = "schannel"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
-dependencies = [
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "schemars"
@@ -1772,26 +1754,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "security-framework"
-version = "2.9.1"
+name = "sct"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1936,6 +1905,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2166,12 +2141,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
 ]
 
@@ -2190,10 +2165,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
@@ -2202,9 +2192,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1541ba70885967e662f69d31ab3aeca7b1aaecfcd58679590b893e9239c3646"
 dependencies = [
  "combine",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
- "toml_datetime",
+ "toml_datetime 0.5.1",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+dependencies = [
+ "indexmap 2.0.0",
+ "toml_datetime 0.6.3",
+ "winnow",
 ]
 
 [[package]]
@@ -2302,7 +2303,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
  "regex",
 ]
 
@@ -2328,6 +2329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,12 +2356,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2451,6 +2452,25 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]
@@ -2612,6 +2632,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/book/src/config.md
+++ b/book/src/config.md
@@ -47,9 +47,9 @@ Note that the Cargo license-file flag only accepts one path, so it can't handle 
 
 
 
-## metadata.dist
+## workspace.metadata.dist
 
-Cargo allows other tools to include their own project-wide settings in [metadata tables][workspace-metadata]. The one cargo-dist uses is `[workspace.metadata.dist]`, which must appear in your root Cargo.toml (whether or not it's [virtual][workspace]). All settings specified here apply to all packages in your project. You can override them on a per-package basis with `[package.metadata.dist]`, which accepts all the same fields (except for those which must be specified once globally, see the docs for each individual option).
+Cargo allows other tools to include their own project-wide settings in [metadata tables][workspace-metadata]. The one cargo-dist uses is `[workspace.metadata.dist]`, which must appear in your root Cargo.toml (whether or not it's [virtual][workspace]). You can override them on a per-package basis with `[package.metadata.dist]`, which accepts all the same fields (except for those which must be specified once globally, see the docs for each individual option).
 
 ### cargo-dist-version
 
@@ -211,6 +211,8 @@ Future work is planned to [support more robust signed checksums][issue-sigstore]
 
 Example `precise-builds = true`
 
+**This can only be set globally**
+
 Build only the required packages, and individually (default: false)
 
 By default when we need to build anything in your workspace, we build your entire workspace with --workspace. This setting tells cargo-dist to instead build each app individually.
@@ -232,6 +234,8 @@ If that downside is big enough for you, this setting is a good idea.
 
 Example `merge-tasks = true`
 
+**This can only be set globally**
+
 Whether we should try to merge otherwise-parallelizable tasks onto the same machine, sacrificing latency and fault-isolation for more the sake of minor effeciency gains.
 
 For example, if you build for x64 macos and arm64 macos, by default we will generate ci which builds those independently on separate logical machines. With this enabled we will build both of those platforms together on the same machine, making it take twice as long as any other build and making it impossible for only one of them to succeed.
@@ -243,6 +247,8 @@ The default is `false`. Before 0.1.0 it was always `true` and couldn't be change
 > since 0.1.0
 
 Example `fail-fast = true`
+
+**This can only be set globally**
 
 Whether failing tasks should make us give up on all other tasks. (defaults to false)
 

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -43,7 +43,7 @@ xz2 = "0.1.7"
 guppy = "0.15.0"
 camino = "1.1.1"
 semver = "1.0.14"
-toml_edit = "0.15.0"
+toml_edit = "0.19.0"
 parse-changelog = { version = "0.5.3", default-features = false }
 newline-converter = "0.2.2"
 axoproject = { version = "0.3.0", default-features = false, features = ["cargo-projects"] }

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -48,7 +48,7 @@ parse-changelog = { version = "0.5.3", default-features = false }
 newline-converter = "0.2.2"
 axoproject = { version = "0.3.0", default-features = false, features = ["cargo-projects"] }
 dialoguer = "0.10.4"
-axoasset = "0.2.0"
+axoasset = { version = "0.4.0", features = ["json-serde", "toml-serde", "toml-edit"] }
 sha2 = "0.10.6"
 
 [dev-dependencies]

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -1,5 +1,6 @@
 //! All the clap stuff for parsing/documenting the cli
 
+use camino::Utf8PathBuf;
 use clap::{
     builder::{PossibleValuesParser, TypedValueParser},
     Args, Parser, Subcommand, ValueEnum,
@@ -214,6 +215,9 @@ pub struct InitArgs {
     /// Don't automatically invoke 'cargo dist generate-ci' at the end
     #[clap(long)]
     pub no_generate_ci: bool,
+    /// A path to a json file containing values to set in workspace.metadata.dist
+    #[clap(long)]
+    pub with_json_config: Option<Utf8PathBuf>,
 }
 
 #[derive(Args, Clone, Debug)]

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -3,6 +3,7 @@ use std::ops::Not;
 
 use axoproject::errors::AxoprojectError;
 use axoproject::WorkspaceInfo;
+use camino::Utf8PathBuf;
 use miette::{Context, IntoDiagnostic};
 use semver::Version;
 
@@ -19,6 +20,8 @@ pub struct InitArgs {
     pub yes: bool,
     /// Don't automatically generate ci
     pub no_generate_ci: bool,
+    /// A path to a json file containing values to set in workspace.metadata.dist
+    pub with_json_config: Option<Utf8PathBuf>,
 }
 
 /// Run 'cargo dist init'
@@ -130,6 +133,12 @@ fn get_new_dist_metadata(
 ) -> DistResult<DistMetadata> {
     use dialoguer::{Confirm, Input, MultiSelect};
     // Setup [workspace.metadata.dist]
+
+    if let Some(json_path) = &args.with_json_config {
+        let src = axoasset::SourceFile::load_local(json_path)?;
+        let meta: DistMetadata = src.deserialize_json()?;
+        return Ok(meta);
+    }
 
     let has_config = workspace_info
         .cargo_metadata_table

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -303,11 +303,7 @@ fn generate_checksum(
     for byte in hash {
         write!(&mut output, "{:02x}", byte).unwrap();
     }
-    axoasset::LocalAsset::write_new(
-        &output,
-        dest_path.file_name().unwrap(),
-        dest_path.parent().unwrap().as_str(),
-    )?;
+    axoasset::LocalAsset::write_new(&output, dest_path)?;
     Ok(())
 }
 

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -214,6 +214,7 @@ fn cmd_init(cli: &Cli, args: &InitArgs) -> Result<(), miette::Report> {
     let args = cargo_dist::InitArgs {
         yes: args.yes,
         no_generate_ci: args.no_generate_ci,
+        with_json_config: args.with_json_config.clone(),
     };
     do_init(&config, &args)
 }

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -852,6 +852,8 @@ pub struct Release {
     pub unix_archive: ZipStyle,
     /// Style of checksum to produce
     pub checksum: ChecksumStyle,
+    /// The @scope to include in NPM packages
+    pub npm_scope: Option<String>,
     /// Static assets that should be included in bundles like executable-zips
     pub static_assets: Vec<(StaticAssetKind, Utf8PathBuf)>,
 }
@@ -1183,6 +1185,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let app_repository_url = package_info.repository_url.clone();
         let app_homepage_url = package_info.homepage_url.clone();
         let app_keywords = package_info.keywords.clone();
+        let npm_scope = package_config.npm_scope.clone();
 
         let windows_archive = package_config.windows_archive.unwrap_or(ZipStyle::Zip);
         let unix_archive = package_config
@@ -1233,6 +1236,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             unix_archive,
             static_assets,
             checksum,
+            npm_scope,
         });
         idx
     }
@@ -1647,7 +1651,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         }
         let bin = release.bins[0].1.clone();
 
-        let npm_package_name = if let Some(scope) = &self.workspace_metadata.npm_scope {
+        let npm_package_name = if let Some(scope) = &release.npm_scope {
             format!("{scope}/{}", release.app_name)
         } else {
             release.app_name.clone()

--- a/cargo-dist/tests/snapshots/cli_tests__markdown-help.snap
+++ b/cargo-dist/tests/snapshots/cli_tests__markdown-help.snap
@@ -142,6 +142,9 @@ This is equivalent to just mashing ENTER over and over during the interactive pr
 #### `--no-generate-ci`
 Don't automatically invoke 'cargo dist generate-ci' at the end
 
+#### `--with-json-config <WITH_JSON_CONFIG>`
+A path to a json file containing values to set in workspace.metadata.dist
+
 #### `-h, --help`
 Print help (see a summary with '-h')
 


### PR DESCRIPTION
This exists for hosted services that want to edit the toml mechanically.
The format is basically the json equivalent of `[workspace.metadata.dist]`,
wrapped in a `workspace` field:

```json
{
    "workspace": {
        "cargo-dist-version": "0.1.0-prerelease.2",
        "ci": ["github"],
        "installers": ["shell", "powershell"],
        "targets": ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
    }
}
```

The given values will complete overwrite the `[workspace.metadata.dist]` section,
so if any fields are omitted they will be deleted from the Cargo.toml.

All the interactive logic that `init` supports will be ignored in this mode
(this is *NOT* equivalent to --yes, which runs the logic and just accepts every prompt).

generate-ci will be run afterwards as usual (disable with --no-generate-ci as usual).

fixes #278