### PR TITLE
feat: add Homebrew formula installer support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "clap",
  "clap-cargo",
  "console",
+ "cruet",
  "dialoguer",
  "flate2",
  "guppy",
@@ -552,6 +553,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cruet"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "113a9e83d8f614be76de8df1f25bf9d0ea6e85ea573710a3d3f3abe1438ae49c"
+dependencies = [
+ "once_cell",
+ "regex",
 ]
 
 [[package]]

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = "1.0.35"
 tracing = { version = "0.1.36", features = ["log"] }
 serde = { version = "1.0.144", features = ["derive"] }
 cargo_metadata = "0.15.0"
+cruet = "0.13.3"
 guppy = "0.15.0"
 camino = "1.1.1"
 semver = "1.0.14"

--- a/cargo-dist/src/backend/installer/homebrew.rs
+++ b/cargo-dist/src/backend/installer/homebrew.rs
@@ -1,0 +1,43 @@
+//! Code for generating installer.sh
+
+use axoasset::LocalAsset;
+use serde::Serialize;
+
+use super::InstallerInfo;
+use crate::{
+    backend::templates::{Templates, TEMPLATE_INSTALLER_RB},
+    errors::DistResult,
+    installer::ExecutableZipFragment,
+};
+
+/// Info about a Homebrew formula
+#[derive(Debug, Clone, Serialize)]
+pub struct HomebrewInstallerInfo {
+    /// The application's name
+    pub name: String,
+    /// Formula class name
+    pub formula_class: String,
+    /// The application's license, in SPDX format
+    pub license: Option<String>,
+    /// The URL to the application's homepage
+    pub homepage: Option<String>,
+    /// A brief description of the application
+    pub desc: Option<String>,
+    /// AMD64 artifact
+    pub x86_64: Option<ExecutableZipFragment>,
+    /// ARM64 artifact
+    pub arm64: Option<ExecutableZipFragment>,
+    /// List of binaries to install
+    pub binaries: Vec<String>,
+    /// Generic installer info
+    pub inner: InstallerInfo,
+}
+
+pub(crate) fn write_homebrew_formula(
+    templates: &Templates,
+    info: &HomebrewInstallerInfo,
+) -> DistResult<()> {
+    let script = templates.render_file_to_clean_string(TEMPLATE_INSTALLER_RB, info)?;
+    LocalAsset::write_new(&script, &info.inner.dest_path)?;
+    Ok(())
+}

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -10,8 +10,10 @@ use crate::{
     TargetTriple,
 };
 
+use self::homebrew::HomebrewInstallerInfo;
 use self::npm::NpmInstallerInfo;
 
+pub mod homebrew;
 pub mod npm;
 pub mod powershell;
 pub mod shell;
@@ -26,6 +28,8 @@ pub enum InstallerImpl {
     Powershell(InstallerInfo),
     /// npm installer package
     Npm(NpmInstallerInfo),
+    /// Homebrew formula
+    Homebrew(HomebrewInstallerInfo),
 }
 
 /// Generic info about an installer

--- a/cargo-dist/src/backend/templates.rs
+++ b/cargo-dist/src/backend/templates.rs
@@ -15,6 +15,8 @@ pub type TemplateId = &'static str;
 pub const TEMPLATE_INSTALLER_PS1: TemplateId = "installer/installer.ps1";
 /// Template key for installer.sh
 pub const TEMPLATE_INSTALLER_SH: TemplateId = "installer/installer.sh";
+/// Template key for Homebrew formula
+pub const TEMPLATE_INSTALLER_RB: TemplateId = "installer/homebrew.rb";
 /// Template key for the npm installer dir
 pub const TEMPLATE_INSTALLER_NPM: TemplateId = "installer/npm";
 /// Template key for the github ci.yml
@@ -304,6 +306,7 @@ mod test {
         let templates = Templates::new().unwrap();
 
         templates.get_template_file(TEMPLATE_INSTALLER_SH).unwrap();
+        templates.get_template_file(TEMPLATE_INSTALLER_RB).unwrap();
         templates.get_template_file(TEMPLATE_INSTALLER_PS1).unwrap();
         templates.get_template_dir(TEMPLATE_INSTALLER_NPM).unwrap();
 

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -129,7 +129,7 @@ pub enum Commands {
     /// that may not exist (since the build wasn't run).
     ///
     /// 'cargo dist plan' is an alias for this command that picks nicer defaults
-    /// by forcing a couple flags to have specific values. You probably want that.  
+    /// by forcing a couple flags to have specific values. You probably want that.
     #[clap(disable_version_flag = true)]
     Manifest(ManifestArgs),
     /// Print --help as markdown (for generating docs)
@@ -168,7 +168,7 @@ pub struct BuildArgs {
     ///
     /// Having this distinction lets us run cargo-dist independently on
     /// multiple machines without collisions between the outputs.
-    ///   
+    ///
     /// If let unspecified, we will pick a fuzzier "host" mode that builds "as much as possible"
     /// for the local system. This mode is appropriate for local testing/debugging/demoing.
     /// If no --target flags are passed on the CLI then "host" mode will try to intelligently
@@ -255,6 +255,8 @@ pub enum InstallerStyle {
     Powershell,
     /// Generates an npm project that fetches the right build to your node_modules
     Npm,
+    /// Generates a Homebrew formula
+    Homebrew,
 }
 
 impl InstallerStyle {
@@ -264,6 +266,7 @@ impl InstallerStyle {
             InstallerStyle::Shell => cargo_dist::config::InstallerStyle::Shell,
             InstallerStyle::Powershell => cargo_dist::config::InstallerStyle::Powershell,
             InstallerStyle::Npm => cargo_dist::config::InstallerStyle::Npm,
+            InstallerStyle::Homebrew => cargo_dist::config::InstallerStyle::Homebrew,
         }
     }
 }

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -381,6 +381,9 @@ pub enum InstallerStyle {
     /// Generate an npm project that fetches from [`crate::tasks::DistGraph::artifact_download_url`][]
     #[serde(rename = "npm")]
     Npm,
+    /// Generate a Homebrew formula that fetches from [`crate::tasks::DistGraph::artifact_download_url`][]
+    #[serde(rename = "homebrew")]
+    Homebrew,
 }
 
 impl std::fmt::Display for InstallerStyle {
@@ -389,6 +392,7 @@ impl std::fmt::Display for InstallerStyle {
             InstallerStyle::Shell => "shell",
             InstallerStyle::Powershell => "powershell",
             InstallerStyle::Npm => "npm",
+            InstallerStyle::Homebrew => "homebrew",
         };
         string.fmt(f)
     }

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -381,6 +381,7 @@ fn get_new_dist_metadata(
             InstallerStyle::Shell,
             InstallerStyle::Powershell,
             InstallerStyle::Npm,
+            InstallerStyle::Homebrew,
         ];
         let mut defaults = vec![];
         let mut keys = vec![];
@@ -403,6 +404,7 @@ fn get_new_dist_metadata(
                 InstallerStyle::Shell => "shell",
                 InstallerStyle::Powershell => "powershell",
                 InstallerStyle::Npm => "npm",
+                InstallerStyle::Homebrew => "homebrew",
             });
         }
 

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -17,7 +17,7 @@ use std::{
 
 use axoasset::LocalAsset;
 use backend::{
-    installer::{self, npm::NpmInstallerInfo, InstallerImpl},
+    installer::{self, homebrew::HomebrewInstallerInfo, npm::NpmInstallerInfo, InstallerImpl},
     templates::{TemplateEntry, TEMPLATE_INSTALLER_NPM},
 };
 use camino::{Utf8Path, Utf8PathBuf};
@@ -228,6 +228,7 @@ fn manifest_artifact(
         ArtifactKind::Installer(
             InstallerImpl::Powershell(info)
             | InstallerImpl::Shell(info)
+            | InstallerImpl::Homebrew(HomebrewInstallerInfo { inner: info, .. })
             | InstallerImpl::Npm(NpmInstallerInfo { inner: info, .. }),
         ) => {
             install_hint = Some(info.hint.clone());
@@ -579,6 +580,9 @@ fn generate_installer(dist: &DistGraph, style: &InstallerImpl) -> Result<()> {
             installer::powershell::write_install_ps_script(&dist.templates, info)?
         }
         InstallerImpl::Npm(info) => installer::npm::write_npm_project(&dist.templates, info)?,
+        InstallerImpl::Homebrew(info) => {
+            installer::homebrew::write_homebrew_formula(&dist.templates, info)?
+        }
     }
     Ok(())
 }

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -52,6 +52,7 @@ use std::process::Command;
 
 use axoproject::{PackageIdx, WorkspaceInfo};
 use camino::Utf8PathBuf;
+use cruet::to_class_case;
 use guppy::PackageId;
 use miette::{miette, Context, IntoDiagnostic};
 use semver::Version;
@@ -59,7 +60,10 @@ use tracing::{info, warn};
 
 use crate::{
     backend::{
-        installer::{npm::NpmInstallerInfo, ExecutableZipFragment, InstallerImpl, InstallerInfo},
+        installer::{
+            homebrew::HomebrewInstallerInfo, npm::NpmInstallerInfo, ExecutableZipFragment,
+            InstallerImpl, InstallerInfo,
+        },
         templates::Templates,
     },
     config::{
@@ -1003,6 +1007,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             InstallerStyle::Shell => self.add_shell_installer(to_release),
             InstallerStyle::Powershell => self.add_powershell_installer(to_release),
             InstallerStyle::Npm => self.add_npm_installer(to_release),
+            InstallerStyle::Homebrew => self.add_homebrew_installer(to_release),
         }
     }
 
@@ -1097,6 +1102,134 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 artifacts,
                 hint,
                 desc,
+            })),
+        };
+
+        self.add_global_artifact(to_release, installer_artifact);
+    }
+
+    fn add_homebrew_installer(&mut self, to_release: ReleaseIdx) {
+        if !self.global_artifacts_enabled() {
+            return;
+        }
+        let release = self.release(to_release);
+        let release_id = &release.id;
+        let Some(download_url) = &self.inner.artifact_download_url else {
+            warn!("skipping Homebrew formula: couldn't compute a URL to download artifacts from");
+            return;
+        };
+        // TODO ensure this is Homebrew-legal
+        let artifact_name = format!("{release_id}.rb");
+        let artifact_path = self.inner.dist_dir.join(&artifact_name);
+        let hint = format!("brew install {artifact_name}");
+        let desc = "Install prebuilt binaries via Homebrew".to_owned();
+
+        // If they have an x64 macos build but not an arm64 one, add a fallback entry
+        // to try to install x64 on arm64 and let rosetta2 deal with it.
+        //
+        // (This isn't strictly correct because rosetta2 isn't installed by default
+        // on macos, and the auto-installer only triggers for "real" apps, and not CLIs.
+        // Still, we think this is better than not trying at all.)
+        const X64_MACOS: &str = "x86_64-apple-darwin";
+        const ARM64_MACOS: &str = "aarch64-apple-darwin";
+        let mut has_x64_apple = false;
+        let mut has_arm_apple = false;
+        for &variant_idx in &release.variants {
+            let variant = self.variant(variant_idx);
+            let target = &variant.target;
+            if target == X64_MACOS {
+                has_x64_apple = true;
+            }
+            if target == ARM64_MACOS {
+                has_arm_apple = true;
+            }
+        }
+        let do_rosetta_fallback = has_x64_apple && !has_arm_apple;
+
+        let mut arm64 = None;
+        let mut x86_64 = None;
+
+        // Gather up the bundles the installer supports
+        let mut artifacts = vec![];
+        let mut target_triples = SortedSet::new();
+        for &variant_idx in &release.variants {
+            let variant = self.variant(variant_idx);
+            let target = &variant.target;
+            if target.contains("windows") || target.contains("linux-gnu") {
+                continue;
+            }
+            // Compute the artifact zip this variant *would* make *if* it were built
+            // FIXME: this is a kind of hacky workaround for the fact that we don't have a good
+            // way to add artifacts to the graph and then say "ok but don't build it".
+            let (artifact, binaries) =
+                self.make_executable_zip_for_variant(to_release, variant_idx);
+            target_triples.insert(target.clone());
+            let fragment = ExecutableZipFragment {
+                id: artifact.id,
+                target_triples: artifact.target_triples,
+                zip_style: artifact.archive.as_ref().unwrap().zip_style,
+                binaries: binaries
+                    .into_iter()
+                    .map(|(_, dest_path)| dest_path.file_name().unwrap().to_owned())
+                    .collect(),
+            };
+
+            if target == X64_MACOS {
+                x86_64 = Some(fragment.clone());
+            }
+            if target == ARM64_MACOS {
+                arm64 = Some(fragment.clone());
+            }
+
+            if do_rosetta_fallback && target == X64_MACOS {
+                // Copy the info but respecify it to be arm64 macos
+                let mut arm_fragment = fragment.clone();
+                arm_fragment.target_triples = vec![ARM64_MACOS.to_owned()];
+                artifacts.push(arm_fragment.clone());
+                arm64 = Some(arm_fragment);
+            }
+            artifacts.push(fragment);
+        }
+        if artifacts.is_empty() {
+            warn!("skipping Homebrew installer: not building any supported platforms (use --artifacts=global)");
+            return;
+        };
+
+        let release = self.release(to_release);
+        let app_name = release.app_name.clone();
+        let app_desc = release.app_desc.clone();
+        let app_license = release.app_license.clone();
+        let app_homepage_url = release.app_homepage_url.clone();
+
+        let formula_name = to_class_case(&app_name);
+
+        let installer_artifact = Artifact {
+            id: artifact_name,
+            target_triples: target_triples.into_iter().collect(),
+            archive: None,
+            file_path: artifact_path.clone(),
+            required_binaries: FastMap::new(),
+            checksum: None,
+            kind: ArtifactKind::Installer(InstallerImpl::Homebrew(HomebrewInstallerInfo {
+                arm64,
+                x86_64,
+                name: app_name,
+                formula_class: formula_name,
+                desc: app_desc,
+                license: app_license,
+                homepage: app_homepage_url,
+                // For now, assume all packages contain the same binaries
+                binaries: artifacts[0].binaries.clone(),
+                inner: InstallerInfo {
+                    dest_path: artifact_path,
+                    app_name: release.app_name.clone(),
+                    app_version: release.version.to_string(),
+                    install_path: release.install_path.clone().into_jinja(),
+                    base_url: download_url.clone(),
+                    artifacts,
+                    hint,
+                    desc,
+                },
             })),
         };
 
@@ -1552,6 +1685,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 writeln!(gh_body, "## Install {heading_suffix}\n").unwrap();
                 for (_installer, details) in global_installers {
                     let (InstallerImpl::Shell(info)
+                    | InstallerImpl::Homebrew(HomebrewInstallerInfo { inner: info, .. })
                     | InstallerImpl::Powershell(info)
                     | InstallerImpl::Npm(NpmInstallerInfo { inner: info, .. })) = details;
 

--- a/cargo-dist/templates/installer/homebrew.rb.j2
+++ b/cargo-dist/templates/installer/homebrew.rb.j2
@@ -1,0 +1,16 @@
+class {{ formula_class }} < Formula
+  {%- if desc %} desc "{{ desc }}" {% endif %}
+  {%- if homepage %} homepage "{{ homepage }}" {% endif %}
+  if Hardware::CPU.type == :arm
+    url "{{ inner.base_url }}/{{ arm64.id }}"
+    sha256 "{{ arm64.checksum }}"
+  else
+    url "{{ inner.base_url }}/{{ x86_64.id }}"
+    sha256 "{{ x86_64.checksum }}"
+  end
+  {% if license %} license "{{ license }}" {% endif %}
+
+  def install
+    bin.install {% for binary in binaries %}"{{ binary }}"{{ ", " if not loop.last else "" }} {% endfor %}
+  end
+end


### PR DESCRIPTION
This starts the work of adding a Homebrew installer. At this point, it generates a usable formula file that installs binaries and doc files, but not other optional features we might want. It also doesn't handle the work of uploading it to a tap yet.

Sample generated formula:

```ruby
class AkaikatanaRepack < Formula
  if Hardware::CPU.type == :arm
    url "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-aarch64-apple-darwin.tar.xz"
    sha256 ""
  else
    url "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz"
    sha256 ""
  end
   license "GPL-2.0-or-later" 

  def install
    bin.install "akextract",  "akmetadata",  "akrepack" 
  end
end
```

I tested it via `brew install`, and it works just fine; it installs all of the defined binaries, plus the README and license files.

refs #308 