### PR TITLE
feat(features): add the ability to specify features

### DIFF
--- a/book/src/config.md
+++ b/book/src/config.md
@@ -217,7 +217,7 @@ Build only the required packages, and individually.
 
 [See "inferring precise-builds" for the default behaviour.](#inferring-precise-builds)
 
-By default when we need to build anything in your workspace, we try to build your entire workspace with --workspace. This setting tells cargo-dist to instead build each app individually.
+By default when we need to build anything in your workspace, we try to build your entire workspace with `--workspace`. This setting tells cargo-dist to instead build each app individually.
 
 On balance, the Rust experts we've consulted with find building with --workspace to be a safer/better default, as it provides some of the benefits of a more manual [workspace-hack][], without the user needing to be aware that this is a thing.
 
@@ -234,7 +234,7 @@ If that downside is big enough for you, this setting is a good idea.
 
 Although cargo-dist prefers `--workspace` builds ([precise-builds](#precise-builds) = `false`) for the reasons stated above, it *will* attempt to check if that's possible, and use `--package` builds if necessary (`precise-builds = true`).
 
-If you explicitly set `precise-builds = false` and we determine --package builds are required, cargo-dist will produce an error. `precise-builds = true` will never produce an error.
+If you explicitly set `precise-builds = false` and we determine `--package` builds are required, cargo-dist will produce an error. `precise-builds = true` will never produce an error.
 
 Precise-builds are considered required when you use any of [features](#features), [all-features](#all-features), or [default-features](#default-features) *and* not all of the packages in your workspace have the same values set.
 
@@ -330,7 +330,7 @@ Future Improvements:
 
 Example: `features = ["serde-support", "fancy-output"]`
 
-Specifies feature-flags that should be passed to a package when building it. This lets you enable features that should on be on "in production" but for whatever reason shouldn't be on by default.
+Specifies feature-flags that should be passed to a package when building it. This lets you enable features that should be on "in production" but for whatever reason shouldn't be on by default.
 
 For instance for packages that are a library and a CLI binary, some developers prefer to make the library the default and the CLI opt-in. In such a case you would want to add `features = ["cli"]` to your `[package.metadata.dist]`.
 
@@ -357,7 +357,7 @@ If you use this you *probably* want to set it on `[package.metadata.dist]` and n
 
 Example: `all-features = true`
 
-Specifies that all features for a package should be enabled when building it (when set to true this tells us to pass --all-features to Cargo).
+Specifies that all features for a package should be enabled when building it (when set to true this tells us to pass `--all-features` to Cargo).
 
 Defaults false.
 

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -200,6 +200,18 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "install-path")]
     pub install_path: Option<InstallPathStrategy>,
+    /// TODO
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "features")]
+    pub features: Option<Vec<String>>,
+    /// TODO
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "no-default-features")]
+    pub no_default_features: Option<bool>,
+    /// TODO
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "all-features")]
+    pub all_features: Option<bool>,
 }
 
 impl DistMetadata {
@@ -223,6 +235,9 @@ impl DistMetadata {
             fail_fast: _,
             merge_tasks: _,
             install_path: _,
+            features: _,
+            no_default_features: _,
+            all_features: _,
         } = self;
         if let Some(include) = include {
             for include in include {
@@ -255,6 +270,9 @@ impl DistMetadata {
             merge_tasks,
             fail_fast,
             install_path,
+            features,
+            no_default_features,
+            all_features,
         } = self;
 
         // Check for global settings on local packages
@@ -304,6 +322,15 @@ impl DistMetadata {
         }
         if install_path.is_none() {
             *install_path = workspace_config.install_path.clone();
+        }
+        if features.is_none() {
+            *features = workspace_config.features.clone();
+        }
+        if no_default_features.is_none() {
+            *no_default_features = workspace_config.no_default_features;
+        }
+        if all_features.is_none() {
+            *all_features = workspace_config.all_features;
         }
 
         // This was historically implemented as extend, but I'm not convinced the

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -200,15 +200,21 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "install-path")]
     pub install_path: Option<InstallPathStrategy>,
-    /// TODO
+    /// A list of features to enable when building a package with cargo-dist
+    ///
+    /// (defaults to none)
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "features")]
     pub features: Option<Vec<String>>,
-    /// TODO
+    /// Whether to enable when building a package with cargo-dist
+    ///
+    /// (defaults to true)
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "no-default-features")]
-    pub no_default_features: Option<bool>,
-    /// TODO
+    #[serde(rename = "default-features")]
+    pub default_features: Option<bool>,
+    /// Whether to enable all features building a package with cargo-dist
+    ///
+    /// (defaults to false)
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "all-features")]
     pub all_features: Option<bool>,
@@ -236,7 +242,7 @@ impl DistMetadata {
             merge_tasks: _,
             install_path: _,
             features: _,
-            no_default_features: _,
+            default_features: _,
             all_features: _,
         } = self;
         if let Some(include) = include {
@@ -271,7 +277,7 @@ impl DistMetadata {
             fail_fast,
             install_path,
             features,
-            no_default_features,
+            default_features,
             all_features,
         } = self;
 
@@ -326,8 +332,8 @@ impl DistMetadata {
         if features.is_none() {
             *features = workspace_config.features.clone();
         }
-        if no_default_features.is_none() {
-            *no_default_features = workspace_config.no_default_features;
+        if default_features.is_none() {
+            *default_features = workspace_config.default_features;
         }
         if all_features.is_none() {
             *all_features = workspace_config.all_features;

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -111,6 +111,14 @@ pub enum DistError {
         /// The full value passed to install-path
         path: String,
     },
+
+    /// Use explicitly requested workspace builds, but had packages with custom feature settings
+    #[error("precise-builds = false was set, but some packages have custom build features, making it impossible")]
+    #[help("these packages customized either features, no-default-features, or all-features: {packages:?}")]
+    PreciseImpossible {
+        /// names of problem packages
+        packages: Vec<String>,
+    },
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -196,6 +196,9 @@ fn get_new_dist_metadata(
             merge_tasks: None,
             fail_fast: None,
             install_path: None,
+            features: None,
+            no_default_features: None,
+            all_features: None,
         }
     };
 
@@ -560,6 +563,9 @@ fn update_toml_metadata(
         merge_tasks,
         fail_fast,
         install_path,
+        features,
+        all_features,
+        no_default_features,
     } = &meta;
 
     apply_optional_value(
@@ -672,6 +678,27 @@ fn update_toml_metadata(
         "install-path",
         "# Path that installers should place binaries in\n",
         install_path.as_ref().map(|p| p.to_string()),
+    );
+
+    apply_string_list(
+        table,
+        "features",
+        "# Features to pass to cargo build\n",
+        features.as_ref(),
+    );
+
+    apply_optional_value(
+        table,
+        "no-default-features",
+        "# Whether to pass --no-default-features to cargo build\n",
+        *no_default_features,
+    );
+
+    apply_optional_value(
+        table,
+        "all-features",
+        "# Whether to pass --all-features to cargo build\n",
+        *all_features,
     );
 
     // Finalize the table

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -197,7 +197,7 @@ fn get_new_dist_metadata(
             fail_fast: None,
             install_path: None,
             features: None,
-            no_default_features: None,
+            default_features: None,
             all_features: None,
         }
     };
@@ -565,7 +565,7 @@ fn update_toml_metadata(
         install_path,
         features,
         all_features,
-        no_default_features,
+        default_features,
     } = &meta;
 
     apply_optional_value(
@@ -689,9 +689,9 @@ fn update_toml_metadata(
 
     apply_optional_value(
         table,
-        "no-default-features",
-        "# Whether to pass --no-default-features to cargo build\n",
-        *no_default_features,
+        "default-features",
+        "# Whether default-features should be enabled with cargo build\n",
+        *default_features,
     );
 
     apply_optional_value(

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -338,7 +338,7 @@ fn build_cargo_target(dist_graph: &DistGraph, target: &CargoBuildStep) -> Result
         .arg(&target.target_triple)
         .env("RUSTFLAGS", &target.rustflags)
         .stdout(std::process::Stdio::piped());
-    if target.features.no_default_features {
+    if !target.features.default_features {
         command.arg("--no-default-features");
     }
     match &target.features.features {

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -510,7 +510,7 @@ pub enum StaticAssetKind {
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CargoTargetFeatures {
     /// Whether to disable default features
-    pub no_default_features: bool,
+    pub default_features: bool,
     /// Features to enable
     pub features: CargoTargetFeatureList,
 }
@@ -610,7 +610,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             // Only the final value merged into a package_config matters
             install_path: _,
             features,
-            no_default_features,
+            default_features: no_default_features,
             all_features,
         } = &workspace_metadata;
 
@@ -635,7 +635,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             // Only do workspace builds if all the packages agree with the workspace feature settings
             if &package_config.features != features
                 || &package_config.all_features != all_features
-                || &package_config.no_default_features != no_default_features
+                || &package_config.default_features != no_default_features
             {
                 packages_with_mismatched_features.push(package.name.clone());
             }
@@ -805,7 +805,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             let id = format!("{binary_name}-v{version}-{target}");
 
             let features = CargoTargetFeatures {
-                no_default_features: package_metadata.no_default_features.unwrap_or(false),
+                default_features: package_metadata.default_features.unwrap_or(true),
                 features: if let Some(true) = package_metadata.all_features {
                     CargoTargetFeatureList::All
                 } else {


### PR DESCRIPTION
This adds the following configs to metadata.dist:

```toml
features = ["blah", "blargh"]
default-features = false
all-features = true
```

If applied to [workspace.metadata.dist] it will be applied to all packages

If applied to [package.metadata.dist] it will be applied to just that package (overriding the workspace value if it exists).

If not all packages end up with the same feature flags then precise-builds=true will be forced on.

fixes #274 