### PR TITLE
fix(ci): fix a typo in rustup update

### DIFF
--- a/cargo-dist/templates/ci/github_ci.yml.j2
+++ b/cargo-dist/templates/ci/github_ci.yml.j2
@@ -58,7 +58,7 @@ jobs:
           submodules: recursive
       {{%- if rust_version %}}
       - name: Install Rust
-        run: rustup update {{{ rust_version }}} --no-self-update && rustup default {{{ rust_version }}}"#
+        run: rustup update {{{ rust_version }}} --no-self-update && rustup default {{{ rust_version }}}
       {{%- endif %}}
       - name: Install cargo-dist
         run: {{{ install_dist_sh }}}
@@ -184,4 +184,3 @@ jobs:
       - name: mark release as non-draft
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
-

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1297,7 +1297,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install Rust
-        run: rustup update "1.67.1" --no-self-update && rustup default "1.67.1""#
+        run: rustup update "1.67.1" --no-self-update && rustup default "1.67.1"
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
       - id: create-release
@@ -1422,5 +1422,4 @@ jobs:
       - name: mark release as non-draft
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
-
 


### PR DESCRIPTION
This looks like a possible typo; it was introduced in #297. Fixes a parse error I ran into when `cargo init`ing from a fresh repo using this prerelease version.