### PR TITLE
fix: unreachable code in installer.sh template

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -93,7 +93,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -155,7 +154,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -329,7 +328,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -346,10 +345,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -90,7 +90,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -162,7 +161,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -312,7 +311,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -329,10 +328,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -90,7 +90,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -162,7 +161,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -312,7 +311,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -329,10 +328,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""
@@ -2289,5 +2288,4 @@ jobs:
       - name: mark release as non-draft
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
-
 

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist.rs
-assertion_line: 486
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -91,7 +90,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -163,7 +161,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -313,7 +311,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -330,10 +328,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist.rs
-assertion_line: 486
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -91,7 +90,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -163,7 +161,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -296,7 +294,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -313,10 +311,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist.rs
-assertion_line: 486
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -91,7 +90,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -163,7 +161,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -296,7 +294,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -313,10 +311,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist.rs
-assertion_line: 486
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -91,7 +90,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -163,7 +161,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -296,7 +294,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -313,10 +311,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist.rs
-assertion_line: 486
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -91,7 +90,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -163,7 +161,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -296,7 +294,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -313,10 +311,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist.rs
-assertion_line: 486
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -91,7 +90,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -163,7 +161,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -296,7 +294,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -313,10 +311,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist.rs
-assertion_line: 486
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -91,7 +90,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -163,7 +161,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -296,7 +294,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -313,10 +311,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist.rs
-assertion_line: 486
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -91,7 +90,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -163,7 +161,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -296,7 +294,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -313,10 +311,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist.rs
-assertion_line: 486
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -91,7 +90,6 @@ download_binary_and_run_installer() {
                 OPTIND=1
                 if [ "${arg%%--*}" = "" ]; then
                     err "unknown option $arg"
-                    continue
                 fi
                 while getopts :hvq sub_arg "$arg"; do
                     case "$sub_arg" in
@@ -163,7 +161,7 @@ download_binary_and_run_installer() {
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
-    
+
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
       say "this may be a standard network error, but it may also indicate"
@@ -296,7 +294,7 @@ add_install_dir_to_path() {
         local _pretty_line="source \"$_env_script_path_expr\""
 
         # Add the env script if it doesn't already exist
-        if [ ! -f "$_env_script_path" ]; then 
+        if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
             write_env_script "$_install_dir_expr" "$_env_script_path"
         else
@@ -313,10 +311,10 @@ add_install_dir_to_path() {
         # We search for both kinds of line here just to do the right thing in more cases.
         if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
            ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
-        then 
+        then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
-            if [ -f "$_env_script_path" ]; then 
+            if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_rcfile"
                 ensure echo "$_robust_line" >> "$_rcfile"
                 say ""


### PR DESCRIPTION
shellcheck rule SC2317:
https://www.shellcheck.net/wiki/SC2317

This was introduced in shellcheck 0.9.0 which explains why it wasn't seen in CI because it uses shellcheck 0.8.0 (because that's what's packaged in Ubuntu 22.04).

Fixes #344 (issue also has some more shellcheck details)

Incidentally this PR also includes some whitespace cleanup that my editor decided to perform. Let me know if that is undesired and I'll revert those!

Also, I'm not sure what `assertion_line` is or why it was removed in the updated insta snapshots?