### PR TITLE
feat: support slash as tag separator

### DIFF
--- a/book/src/cargo-release-guide.md
+++ b/book/src/cargo-release-guide.md
@@ -2,7 +2,7 @@
 
 <!-- toc -->
 
-> NOTE: It will be helpful to read [the section on cargo-dist Announcement Tags][announcements], because that is the interface boundary between cargo-release and cargo-dist. TL;DR: cargo-dist interprets a git tag of "v1.0.0" as "Announce/Release the whole workspace" (Unified Announcement) and "my-app-v1.0.0" as "Announce/Release that one package" (Singular Announcement).
+> NOTE: It will be helpful to read [the section on cargo-dist Announcement Tags][announcements], because that is the interface boundary between cargo-release and cargo-dist. TL;DR: cargo-dist interprets a git tag of "v1.0.0" as "Announce/Release the whole workspace" (Unified Announcement) and "my-app-v1.0.0" or "my-app/v1.0.0" as "Announce/Release that one package" (Singular Announcement).
 
 > NOTE: this guide assumes you're running [cargo-release v0.22.0][release-22] or greater, as that version made several significant changes to default behaviours (for the better!).
 
@@ -75,6 +75,7 @@ As we'll see below, these combined behaviours have the following interactions wi
 
 * ✅ one package workspace: tags it like "v1.0.0"
 * ✅ virtual workspace, independent versions: tags each package like "my-app-v1.0.0"
+* ✅ virtual workspace, independent versions: tags each package like "my-app/v1.0.0" (needs additional configuration in cargo-release, see below)
 * ❌ virtual workspace, unified versions: we want a single tag like "v1.0.0"
 * ❌ non-virtual workspace: it will mix the tag formats, which *might* be ok in one situation
 
@@ -125,6 +126,18 @@ If the package is a library the Github Release won't have any builds/artifacts u
 
 Note that we currently don't support finding/emitting Release Notes for Singular Releases (simply haven't had time to design and implement it yet).
 
+### Using slash in tag prefix with cargo-release
+
+For cargo-release to work with tag prefixes that use a slash, you must configure it to use a different prefix for tags in `Cargo.toml`.
+
+For a virtual workspace, put the following in your root Cargo.toml:
+
+```toml
+[workspace.metadata.release]
+tag-prefix = "{{crate_name}}/"
+```
+
+Please refer to [the cargo-release reference][cargo-release-ref-config] for further information on how you can configure cargo-release.
 
 
 
@@ -345,6 +358,7 @@ cargo release
 [cargo-release]: https://github.com/crate-ci/cargo-release
 [simple-guide]: ./simple-guide.md
 [cargo-release-ref]: https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md
+[cargo-release-ref-config]: https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md#configuration
 [workspace-guide]: ./workspace-guide.md
 [default-members]: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-default-members-field
 [virtual workspace]: https://doc.rust-lang.org/cargo/reference/workspaces.html#virtual-workspace

--- a/book/src/concepts.md
+++ b/book/src/concepts.md
@@ -8,7 +8,7 @@ An invocation of cargo-dist has 4 major inputs:
 
 * The structure of your project's [Cargo Workspace][workspace] (via [cargo-metadata][])
 * The config in your Cargo.toml `[workspace.metadata.dist]` (and `[package.metadata.dist]`)
-* The "announcement tag" (e.g. `--tag=v1.0.0`) 
+* The "announcement tag" (e.g. `--tag=v1.0.0`)
 * The "artifact mode" (e.g. `--artifacts=all`)
 
 The first two define the full "Universe" of your project -- the platforms/binaries/[installers][] that cargo-dist wants to build. The second two tell cargo-dist what subset of the Universe to actually bother with.
@@ -66,7 +66,7 @@ The parts we're really interested in here are "installers", "targets", and `[pro
 
 First the easy part: `profile.dist` is the profile cargo-dist will build everything with. We define a separate profile from `release` so that it can be tuned more aggressively for builds that are longer or more resource-intensive without making it tedious to develop locally.
 
-The other 3 fields are defining the various Artifacts that should be produced for each App in the workspace (because this is `[workspace.metadata]` and not `[package.metadata]`). 
+The other 3 fields are defining the various Artifacts that should be produced for each App in the workspace (because this is `[workspace.metadata]` and not `[package.metadata]`).
 
 For each entry in `targets` you will get a build of your App for [that platform][rust-platform] in the form of an [executable-zip][].
 
@@ -79,7 +79,7 @@ For each entry in `installers` you get that kind of [installer][installers] for 
 
 # Announcements (Selecting Apps)
 
-cargo-dist's self-generated CI is triggered by pushing git tags with specific formats like "v1.0.0" or "my-app-v1.0.0". Each tag will trigger its own independent run of that CI workflow. That tag defines the subset of the workspace (what packages) we want to produce a single unified Announcement for (i.e. a single Github Release). Every invocation of cargo-dist in that CI run will be passed that git tag with the `--tag` flag to ensure consensus on what to Announce (and therefore build and upload).
+cargo-dist's self-generated CI is triggered by pushing git tags with specific formats like "v1.0.0", "my-app-v1.0.0" or "my-app/v1.0.0". Each tag will trigger its own independent run of that CI workflow. That tag defines the subset of the workspace (what packages) we want to produce a single unified Announcement for (i.e. a single Github Release). Every invocation of cargo-dist in that CI run will be passed that git tag with the `--tag` flag to ensure consensus on what to Announce (and therefore build and upload).
 
 1 Git Tag = 1 cargo-dist Announcement = 1 Github Release
 
@@ -98,7 +98,7 @@ Here we have the same workspace we saw in the ["defining your apps" section][def
 The error goes on to recommend the two formats for the Announcement Tag:
 
 * Unified Announcement: `v{VERSION}` selects all packages with the given version (v1.0.0, v0.1.0-prerelease, etc.)
-* Singular Announcement: `{PACKAGE-NAME}-v{VERSION}` selects only the given package (error if the version doesn't match the Cargo.toml)
+* Singular Announcement: `{PACKAGE-NAME}-v{VERSION}` or `{PACKAGE-NAME}/v{VERSION}` selects only the given package (error if the version doesn't match the Cargo.toml)
 
 These two modes support the following workflows:
 
@@ -218,7 +218,7 @@ Ok so here's what goes through cargo-dist's brains when you run it:
 1. Read in the workspace/config/cli-flags
 2. Determine the Announcement Tag (select the Apps) ("v1.0.0")
 3. Determine what Targets we're building for
-3. Call the specific Version of each App a "Release" ("my-app-v1.0.0")
+3. Call the specific Version of each App a "Release" ("my-app-v1.0.0" or "my-app/v1.0.0")
 4. For each Release-Target pair, create a "ReleaseVariant" ("my-app-v1.0.0-x86_64-apple-darwin")
 5. Add executable-zip Artifacts to each Release (broadcasted to each Variant, filtered by Artifact Mode)
 6. Add all the enabled Installers to each Release (local ones broadcasted to each Variant, filtered by Artifact Mode)

--- a/book/src/concepts.md
+++ b/book/src/concepts.md
@@ -97,8 +97,8 @@ Here we have the same workspace we saw in the ["defining your apps" section][def
 
 The error goes on to recommend the two formats for the Announcement Tag:
 
-* Unified Announcement: `v{VERSION}` selects all packages with the given version (v1.0.0, v0.1.0-prerelease, etc.)
-* Singular Announcement: `{PACKAGE-NAME}-v{VERSION}` or `{PACKAGE-NAME}/v{VERSION}` selects only the given package (error if the version doesn't match the Cargo.toml)
+* Unified Announcement: VERSION selects all packages with the given version (v1.0.0, 0.1.0-prerelease.1, releases/1.2.3, ...)
+* Singular Announcement: PACKAGE-VERSION or PACKAGE/VERSION selects only the given package (my-app-v1.0.0, my-app/1.0.0, release/my-app/v1.2.3-alpha, ...)
 
 These two modes support the following workflows:
 
@@ -218,7 +218,7 @@ Ok so here's what goes through cargo-dist's brains when you run it:
 1. Read in the workspace/config/cli-flags
 2. Determine the Announcement Tag (select the Apps) ("v1.0.0")
 3. Determine what Targets we're building for
-3. Call the specific Version of each App a "Release" ("my-app-v1.0.0" or "my-app/v1.0.0")
+3. Call the specific Version of each App a "Release" ("my-app-v1.0.0")
 4. For each Release-Target pair, create a "ReleaseVariant" ("my-app-v1.0.0-x86_64-apple-darwin")
 5. Add executable-zip Artifacts to each Release (broadcasted to each Variant, filtered by Artifact Mode)
 6. Add all the enabled Installers to each Release (local ones broadcasted to each Variant, filtered by Artifact Mode)

--- a/book/src/install.md
+++ b/book/src/install.md
@@ -5,10 +5,19 @@
 Surprise! The tool for prebuilt shippable binaries has way too many ways to install it!
 Whichever way you choose to install it, it should be invocable as `cargo dist ...`. If you insist on invoking the binary directly as `cargo-dist` you must still add the extra `dist` arg and invoke it as `cargo-dist dist ...` (a quirk of the way cargo invokes subcommands).
 
-## Install Prebuilt Binaries With cargo-binstall
+
+## Use The Installer Scripts
+
+macOS and Linux (not NixOS, Alpine, or Asahi):
 
 ```sh
-cargo binstall cargo-dist
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/latest/download/cargo-dist-installer.sh | sh
+```
+
+Windows PowerShell:
+
+```sh
+irm https://github.com/axodotdev/cargo-dist/releases/latest/download/cargo-dist-installer.ps1 | iex
 ```
 
 ## Build From Source With Cargo
@@ -19,6 +28,12 @@ cargo install cargo-dist --locked --profile=dist
 
 (`--profile=dist` is the profile we build our shippable binaries with, it's optional.)
 
+
+## Install Prebuilt Binaries With cargo-binstall
+
+```sh
+cargo binstall cargo-dist
+```
 
 ## Installation on Arch Linux
 
@@ -31,19 +46,3 @@ pacman -S cargo-dist
 ## Download Prebuilt Binaries From Github Releases
 
 [See The Latest Release](https://github.com/axodotdev/cargo-dist/releases/latest)!
-
-## Use The Installer Scripts
-
-**NOTE: these installer scripts are currently under-developed and will place binaries in `$HOME/.cargo/bin/` without properly informing Cargo of the change, resulting in `cargo uninstall cargo-dist` and some other things not working. They are however suitable for quickly bootstrapping cargo-dist in temporary environments (like CI) without any other binaries being installed.**
-
-Linux and macOS:
-
-```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/latest/download/cargo-dist-installer.sh | sh
-```
-
-Windows PowerShell:
-
-```sh
-irm https://github.com/axodotdev/cargo-dist/releases/latest/download/cargo-dist-installer.ps1 | iex
-```

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -23,7 +23,7 @@ Being able to build a zip on your own machine is nice and all, but in practice y
 
 Just run `cargo dist init` and it will **generate its own CI scripts** which:
 
-* Waits for you to push a git tag for a new version (v1.0.0, my-app-v1.0.0, ...)
+* Waits for you to push a git tag for a new version (v1.0.0, my-app-v1.0.0, my-app/v1.0.0, ...)
 * Selects what apps in your workspace to announce new releases for based on that tag
 * Creates a draft Github Release to announce the apps in and host the downloads
 * Adds the relevant release notes from your RELEASES or CHANGELOG file

--- a/book/src/way-too-quickstart.md
+++ b/book/src/way-too-quickstart.md
@@ -85,7 +85,7 @@ git tag v0.1.0
 git push --tags
 ```
 
-The important parts are that you update the crates you want to release/announce to the desired version and push a git tag with that version. (prefixed with `v`!)
+The important parts are that you update the crates you want to release/announce to the desired version and push a git tag with that version.
 
 At this point you're done! The generated CI script should pick up the ball and create a Github Release with all your builds over the next few minutes!
 

--- a/book/src/workspace-guide.md
+++ b/book/src/workspace-guide.md
@@ -50,8 +50,14 @@ When you push a Git Tag to your repository, cargo-dist's CI will try to create a
 
 cargo-dist supports two forms of Announcement which you can select with the format of your Git Tag:
 
-* Unified Announcement: `v{VERSION}` selects all packages with the given version (v1.0.0, v0.1.0-prerelease, ...)
-* Singular Announcement: `{PACKAGE-NAME}-v{VERSION}` or `{PACKAGE-NAME}/v{VERSION}` selects only the given package (my-app-v1.0.0, my-app/v1.0.0, my-app-v1.0.0-prerelease, my-app/v1.0.0-prerelease, ...)
+* Unified Announcement: VERSION selects all packages with the given version (v1.0.0, 0.1.0-prerelease.1, releases/1.2.3, ...)
+* Singular Announcement: PACKAGE-VERSION or PACKAGE/VERSION selects only the given package (my-app-v1.0.0, my-app/1.0.0, release/my-app/v1.2.3-alpha, ...)
+
+> People love their different tag formats, so we do our best to parse lots
+> of different kinds! Prefixing the version with `v` is optional. Anything
+> that comes before a `/` is ignored unless it's exactly a package name
+> (so `really/cool/5.0.0/releases/v1.0.0` is just read as "1.0.0"). Note
+> that something like "1.0" is not a valid [Cargo SemVer Version][cargo semver].
 
 These two modes support the following workflows:
 
@@ -91,3 +97,4 @@ See [the dedicated guide to using cargo-release with cargo-dist][cargo-release-g
 [dist-config]: ./config.md#dist
 [cargo-release-guide]: ./cargo-release-guide.md
 [installers]: ./installers.md
+[cargo semver]: https://docs.rs/semver/latest/semver/struct.Version.html#errors

--- a/book/src/workspace-guide.md
+++ b/book/src/workspace-guide.md
@@ -51,7 +51,7 @@ When you push a Git Tag to your repository, cargo-dist's CI will try to create a
 cargo-dist supports two forms of Announcement which you can select with the format of your Git Tag:
 
 * Unified Announcement: `v{VERSION}` selects all packages with the given version (v1.0.0, v0.1.0-prerelease, ...)
-* Singular Announcement: `{PACKAGE-NAME}-v{VERSION}` selects only the given package (my-app-v1.0.0, my-app-v1.0.0-prerelease, ...)
+* Singular Announcement: `{PACKAGE-NAME}-v{VERSION}` or `{PACKAGE-NAME}/v{VERSION}` selects only the given package (my-app-v1.0.0, my-app/v1.0.0, my-app-v1.0.0-prerelease, my-app/v1.0.0-prerelease, ...)
 
 These two modes support the following workflows:
 

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -81,8 +81,9 @@ pub struct Cli {
     /// certain URLs. For instance the git tag associated with a Github Release is part of the
     /// URL to fetch artifacts from that release, which needs to be known by some installers!
     ///
-    /// The currently accepted formats are "v{VERSION}" and "{PACKAGE_NAME}-v{VERSION}"
-    /// ("v1.0.0", "v0.1.0-prerelease1", "my-app-v1.0.0", etc).
+    /// The currently accepted formats are "v{VERSION}", "{PACKAGE_NAME}-v{VERSION}",
+    /// and "{PACKAGE_NAME}/v{VERSION}" ("v1.0.0", "v0.1.0-prerelease1", "my-app-v1.0.0",
+    /// "my-app/v1.0.0, etc).
     ///
     /// If you use the prefixed version then we will only Announce/Release that package's apps
     /// (and return an error if that is not in fact the package's current version). This is

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -81,15 +81,17 @@ pub struct Cli {
     /// certain URLs. For instance the git tag associated with a Github Release is part of the
     /// URL to fetch artifacts from that release, which needs to be known by some installers!
     ///
-    /// The currently accepted formats are "v{VERSION}", "{PACKAGE_NAME}-v{VERSION}",
-    /// and "{PACKAGE_NAME}/v{VERSION}" ("v1.0.0", "v0.1.0-prerelease1", "my-app-v1.0.0",
-    /// "my-app/v1.0.0, etc).
+    /// Unified Announcement: VERSION selects all packages with the given version
+    /// (v1.0.0, 0.1.0-prerelease.1, releases/1.2.3, ...)
     ///
-    /// If you use the prefixed version then we will only Announce/Release that package's apps
+    /// Singular Announcement: PACKAGE-VERSION or PACKAGE/VERSION selects only the given package
+    /// (my-app-v1.0.0, my-app/1.0.0, release/my-app/v1.2.3-alpha, ...)
+    ///
+    /// If you use the singular version then we will only Announce/Release that package's apps
     /// (and return an error if that is not in fact the package's current version). This is
     /// appropriate for workspaces that have more than one app.
     ///
-    /// If you use the unprefixed version then we will assume you're Announcing/Releasing all
+    /// If you use the unified version then we will assume you're Announcing/Releasing all
     /// packages in the workspace that have that version. This is appropriate for workspaces
     /// that only have one app, or for monorepos that version all their apps in lockstep.
     ///

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -138,6 +138,27 @@ pub enum DistError {
         #[help]
         help: String,
     },
+    /// parse_tag concluded that versions didn't line up
+    #[error("The provided announcement tag ({tag}) claims we're releasing {package_name} {tag_version}, but that package is version {real_version}")]
+    ContradictoryTagVersion {
+        /// The full tag
+        tag: String,
+        /// The package name
+        package_name: String,
+        /// The version the tag claimed
+        tag_version: semver::Version,
+        /// The version the package actually has
+        real_version: axoproject::Version,
+    },
+    /// parse_tag couldn't parse the version component at all
+    #[error("Couldn't parse the version from the provided announcement tag ({tag})")]
+    TagVersionParse {
+        /// the full tag
+        tag: String,
+        /// parse error
+        #[source]
+        details: semver::Error,
+    },
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -119,6 +119,25 @@ pub enum DistError {
         /// names of problem packages
         packages: Vec<String>,
     },
+
+    /// parse_tag couldn't make sense of the --tag provided
+    #[error("The provided announcement tag ({tag}) didn't match any Package or Version")]
+    NoTagMatch {
+        /// The --tag
+        tag: String,
+    },
+
+    /// parse_tag concluded there was nothing to release
+    #[error("This workspace doesn't have anything for cargo-dist to Release!")]
+    NothingToRelease,
+
+    /// parse_tag concluded there are too many unrelated things for a single tag
+    #[error("There are too many unrelated apps in your workspace to coherently Announce!")]
+    TooManyUnrelatedApps {
+        /// full help printout (very dynamic)
+        #[help]
+        help: String,
+    },
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-#![allow(clippy::single_match)]
+#![allow(clippy::single_match, clippy::result_large_err)]
 
 //! # cargo-dist
 //!

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1928,14 +1928,15 @@ pub fn gather_work(cfg: &Config) -> Result<DistGraph> {
         for (pkg_id, package) in workspace.packages() {
             let package_version = package.version.as_ref().unwrap().cargo();
             let package_tag = format!("{}-v{}", package.name, package_version);
-            if &package_tag == tag {
+            let package_tag_slash = format!("{}/v{}", package.name, package_version);
+            if &package_tag == tag || &package_tag_slash == tag {
                 info!(
                     "announcement tag matched {}@{}",
                     package.name, package_version
                 );
                 assert!(
                     announcing_package.is_none(),
-                    "how on earth do you have two packages that match {package_tag}!?"
+                    "how on earth do you have two packages that match {package_tag} or {package_tag_slash}!?"
                 );
                 announcing_prerelease = !package_version.pre.is_empty();
                 announcing_package = Some(pkg_id);

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -1,0 +1,228 @@
+//! Mock testing utils, mostly you want the `workspace_*` functions,
+//! but other functions/consts will help you assert the results
+
+use crate::{CargoInfo, Tools};
+use axoproject::{AutoIncludes, PackageIdx, PackageInfo, WorkspaceInfo};
+use serde_json::json;
+
+pub const REPO_URL: &str = "https://github.com/axodotdev/axolotlsay";
+
+pub const BIN_AXO_NAME: &str = "axolotlsay";
+pub const BIN_AXO_VER: &str = "1.0.0";
+pub const BIN_AXO_VER_ALPHA: &str = "1.0.0-prerelease.1";
+pub const BIN_AXO_IDX: PackageIdx = PackageIdx(0);
+
+pub const LIB_SOME_NAME: &str = "some-lib";
+pub const LIB_SOME_VER: &str = BIN_AXO_VER;
+
+pub const BIN_HELPER_NAME: &str = "helper-bin";
+pub const BIN_HELPER_NAME2: &str = "helper-bin-utils";
+pub const BIN_HELPER_VER: &str = BIN_AXO_VER;
+pub const BIN_HELPER_IDX: PackageIdx = PackageIdx(2);
+
+pub const LIB_OTHER_NAME: &str = "other-lib";
+pub const LIB_OTHER_VER: &str = "0.5.0";
+
+pub const BIN_ODDBALL_NAME: &str = "oddball-bin";
+pub const BIN_ODDBALL_VER: &str = "0.1.0";
+pub const BIN_ODDBALL_IDX: PackageIdx = PackageIdx(4);
+
+pub const BIN_FORCED_NAME: &str = "forced-bin";
+pub const BIN_FORCED_VER: &str = BIN_AXO_VER;
+pub const BIN_FORCED_IDX: PackageIdx = PackageIdx(5);
+
+pub const BIN_TEST1_NAME: &str = "test-bin1";
+pub const BIN_TEST1_VER: &str = BIN_AXO_VER;
+
+pub const BIN_TEST2_NAME: &str = "test-bin2";
+pub const BIN_TEST2_VER: &str = BIN_AXO_VER;
+
+pub fn mock_tools() -> Tools {
+    Tools {
+        cargo: CargoInfo {
+            cmd: String::new(),
+            version_line: None,
+            host_target: "x86_64-unknown-linux-gnu".to_owned(),
+        },
+        rustup: None,
+    }
+}
+
+pub fn mock_package(name: &str, ver: &str) -> PackageInfo {
+    PackageInfo {
+        name: name.to_owned(),
+        version: Some(axoproject::Version::Cargo(ver.parse().unwrap())),
+        manifest_path: Default::default(),
+        package_root: Default::default(),
+        description: None,
+        authors: vec![],
+        license: None,
+        publish: true,
+        keywords: None,
+        repository_url: Some(REPO_URL.to_owned()),
+        homepage_url: None,
+        documentation_url: None,
+        readme_file: None,
+        license_files: vec![],
+        changelog_file: None,
+        binaries: vec![],
+        cstaticlibs: vec![],
+        cdylibs: vec![],
+        cargo_metadata_table: None,
+        cargo_package_id: None,
+    }
+}
+
+pub fn mock_workspace(packages: Vec<PackageInfo>) -> WorkspaceInfo {
+    WorkspaceInfo {
+        kind: axoproject::WorkspaceKind::Rust,
+        target_dir: Default::default(),
+        workspace_dir: Default::default(),
+        package_info: packages,
+        manifest_path: Default::default(),
+        repository_url: Some(REPO_URL.to_owned()),
+        root_auto_includes: AutoIncludes {
+            readme: None,
+            licenses: vec![],
+            changelog: None,
+        },
+        warnings: vec![],
+        cargo_metadata_table: None,
+        cargo_profiles: Default::default(),
+    }
+}
+
+/// axolotlsay 1.0.0
+pub fn pkg_axo_bin() -> PackageInfo {
+    PackageInfo {
+        binaries: vec![BIN_AXO_NAME.to_owned()],
+        ..mock_package(BIN_AXO_NAME, BIN_AXO_VER)
+    }
+}
+/// axolotlsay 1.0.0-prerelease.1
+pub fn pkg_axo_bin_alpha() -> PackageInfo {
+    PackageInfo {
+        binaries: vec![BIN_AXO_NAME.to_owned()],
+        ..mock_package(BIN_AXO_NAME, BIN_AXO_VER_ALPHA)
+    }
+}
+pub fn entry_axo_bin() -> (PackageIdx, Vec<String>) {
+    (BIN_AXO_IDX, vec![BIN_AXO_NAME.to_owned()])
+}
+
+/// some-lib 1.0.0
+pub fn pkg_some_lib() -> PackageInfo {
+    PackageInfo {
+        ..mock_package(LIB_SOME_NAME, LIB_SOME_VER)
+    }
+}
+
+/// helper-bin 1.0.0 (has 2 binaries)
+pub fn pkg_helper_bin() -> PackageInfo {
+    PackageInfo {
+        binaries: vec![BIN_HELPER_NAME.to_owned(), BIN_HELPER_NAME2.to_owned()],
+        ..mock_package(BIN_HELPER_NAME, BIN_HELPER_VER)
+    }
+}
+pub fn entry_helper_bin() -> (PackageIdx, Vec<String>) {
+    (
+        BIN_HELPER_IDX,
+        vec![BIN_HELPER_NAME.to_owned(), BIN_HELPER_NAME2.to_owned()],
+    )
+}
+
+/// other-lib 0.5.0 (non-harmonious version)
+pub fn pkg_other_lib() -> PackageInfo {
+    PackageInfo {
+        ..mock_package(LIB_OTHER_NAME, LIB_OTHER_VER)
+    }
+}
+
+/// oddball-bin 0.1.0 (non-harmonious version)
+pub fn pkg_oddball_bin() -> PackageInfo {
+    PackageInfo {
+        binaries: vec![BIN_ODDBALL_NAME.to_owned()],
+        ..mock_package(BIN_ODDBALL_NAME, BIN_ODDBALL_VER)
+    }
+}
+pub fn entry_oddball_bin() -> (PackageIdx, Vec<String>) {
+    (BIN_ODDBALL_IDX, vec![BIN_ODDBALL_NAME.to_owned()])
+}
+
+/// forced-bin 1.0.0
+///
+/// has publish=false and dist=true set
+pub fn pkg_forced_bin() -> PackageInfo {
+    PackageInfo {
+        publish: false,
+        cargo_metadata_table: Some(json!({
+            "dist": {
+                "dist": true
+            }
+        })),
+        binaries: vec![BIN_FORCED_NAME.to_owned()],
+        ..mock_package(BIN_FORCED_NAME, BIN_FORCED_VER)
+    }
+}
+pub fn entry_forced_bin() -> (PackageIdx, Vec<String>) {
+    (BIN_FORCED_IDX, vec![BIN_FORCED_NAME.to_owned()])
+}
+
+/// test-bin1 1.0.0
+///
+/// has publish=false set
+pub fn pkg_test_bin1() -> PackageInfo {
+    PackageInfo {
+        publish: false,
+        binaries: vec![BIN_TEST1_NAME.to_owned()],
+        ..mock_package(BIN_TEST1_NAME, BIN_TEST1_VER)
+    }
+}
+/// test-bin2 1.0.0
+///
+/// has dist=false set
+pub fn pkg_test_bin2() -> PackageInfo {
+    PackageInfo {
+        cargo_metadata_table: Some(json!({
+            "dist": {
+                "dist": false
+            }
+        })),
+        binaries: vec![BIN_TEST2_NAME.to_owned()],
+        ..mock_package(BIN_TEST2_NAME, BIN_TEST2_VER)
+    }
+}
+/// axolotlsay
+pub fn workspace_just_axo() -> WorkspaceInfo {
+    mock_workspace(vec![pkg_axo_bin()])
+}
+
+/// axolotlsay (alpha release)
+pub fn workspace_just_axo_alpha() -> WorkspaceInfo {
+    mock_workspace(vec![pkg_axo_bin_alpha()])
+}
+
+/// axolotlsay, some-lib, helper-bin -- all same version
+pub fn workspace_unified() -> WorkspaceInfo {
+    mock_workspace(vec![pkg_axo_bin(), pkg_some_lib(), pkg_helper_bin()])
+}
+
+/// axolotlsay, some-lib, helper-bin, other-lib, oddball-bin, forced-bin, test-bin1, test-bin2
+///
+/// oddball-bin and other-lib have different version
+/// forced-bin has publish=false AND dist=true, so should be included
+/// test-bin1 has publish=false, so should be ignored
+/// test-bin2 has dist=false, so should be ignored
+pub fn workspace_disjoint() -> WorkspaceInfo {
+    // axolotlsay, a lib
+    mock_workspace(vec![
+        pkg_axo_bin(),
+        pkg_some_lib(),
+        pkg_helper_bin(),
+        pkg_other_lib(),
+        pkg_oddball_bin(),
+        pkg_forced_bin(),
+        pkg_test_bin1(),
+        pkg_test_bin2(),
+    ])
+}

--- a/cargo-dist/src/tests/mod.rs
+++ b/cargo-dist/src/tests/mod.rs
@@ -1,8 +1,2 @@
-// TODO: setup insta snapshotting... hmm this breaks the library/binary boundary
-// i've setup... more thinking required.
-
-#[test]
-fn test_some_op() {
-    // let report = crate::some_op().unwrap();
-    // assert!(report.cats_are_cute);
-}
+mod mock;
+mod tag;

--- a/cargo-dist/src/tests/tag.rs
+++ b/cargo-dist/src/tests/tag.rs
@@ -10,7 +10,6 @@ use semver::Version;
 use crate::{config::ArtifactMode, parse_tag, DistGraphBuilder};
 
 #[test]
-#[should_panic = "NoTagMatch"]
 fn parse_one() {
     // "1.0.0" in a one package workspace
     let workspace = workspace_just_axo();
@@ -21,7 +20,7 @@ fn parse_one() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, Some(version));
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
@@ -38,7 +37,7 @@ fn parse_one_v() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, Some(version));
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
@@ -55,14 +54,13 @@ fn parse_one_package_v() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, None);
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
 }
 
 #[test]
-#[should_panic = "NoTagMatch"]
 fn parse_one_package() {
     // "axolotlsay-1.0.0" in a one package workspace
     let workspace = workspace_just_axo();
@@ -73,7 +71,7 @@ fn parse_one_package() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, None);
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
@@ -90,7 +88,7 @@ fn parse_one_v_alpha() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, true);
+    assert!(announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, Some(version));
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
@@ -107,14 +105,13 @@ fn parse_one_package_v_alpha() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, true);
+    assert!(announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, None);
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
 }
 
 #[test]
-#[should_panic = "NoTagMatch"]
 fn parse_one_prefix_slashv() {
     // "release/v1.0.0" in a one package workspace
     let workspace = workspace_just_axo();
@@ -125,14 +122,13 @@ fn parse_one_prefix_slashv() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, Some(version));
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
 }
 
 #[test]
-#[should_panic = "NoTagMatch"]
 fn parse_one_prefix_slash() {
     // "release/1.0.0" in a one package workspace
     let workspace = workspace_just_axo();
@@ -143,14 +139,13 @@ fn parse_one_prefix_slash() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, Some(version));
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
 }
 
 #[test]
-#[should_panic = "NoTagMatch"]
 fn parse_one_prefix_slash_package_v() {
     // "release/axolotlsay-v1.0.0" in a one package workspace
     let workspace = workspace_just_axo();
@@ -161,14 +156,13 @@ fn parse_one_prefix_slash_package_v() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
-    assert_eq!(announcing.version, Some(version));
+    assert_eq!(announcing.version, None);
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
 }
 
 #[test]
-#[should_panic = "NoTagMatch"]
 fn parse_one_prefix_slash_package_slashv() {
     // "releases/axolotlsay/v1.0.0" in a one package workspace
     let workspace = workspace_just_axo();
@@ -179,7 +173,7 @@ fn parse_one_prefix_slash_package_slashv() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, None);
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
@@ -196,14 +190,13 @@ fn parse_one_package_slashv() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, None);
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
 }
 
 #[test]
-#[should_panic = "NoTagMatch"]
 fn parse_one_prefix_slash_package_slash() {
     // "releases/axolotlsay/v1.0.0" in a one package workspace
     let workspace = workspace_just_axo();
@@ -214,14 +207,30 @@ fn parse_one_prefix_slash_package_slash() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, None);
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
 }
 
 #[test]
-#[should_panic = "NoTagMatch"]
+fn parse_one_prefix_many_slash_package_slash() {
+    // "releases/axolotlsay/v1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("blah/blah/releases/{BIN_AXO_NAME}/{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert!(!announcing.prerelease);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, None);
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
 fn parse_one_package_slash() {
     // "releases/axolotlsay/v1.0.0" in a one package workspace
     let workspace = workspace_just_axo();
@@ -232,7 +241,7 @@ fn parse_one_package_slash() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, None);
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
@@ -249,7 +258,7 @@ fn parse_one_infer() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, None, true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, Some(version));
     assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
@@ -266,7 +275,7 @@ fn parse_unified_v() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, Some(version));
     assert_eq!(
@@ -286,7 +295,7 @@ fn parse_unified_infer() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, None, true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, Some(version));
     assert_eq!(
@@ -306,7 +315,7 @@ fn parse_unified_lib() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, None);
     assert_eq!(announcing.rust_releases, vec![]);
@@ -323,7 +332,7 @@ fn parse_disjoint_v() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, Some(version));
     assert_eq!(
@@ -344,7 +353,7 @@ fn parse_disjoint_infer() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, None, true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, Some(version));
     assert_eq!(
@@ -364,7 +373,7 @@ fn parse_disjoint_v_oddball() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, Some(version));
     assert_eq!(announcing.rust_releases, vec![entry_oddball_bin()]);
@@ -381,7 +390,7 @@ fn parse_disjoint_lib() {
     let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
     let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
 
-    assert_eq!(announcing.prerelease, false);
+    assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
     assert_eq!(announcing.version, None);
     assert_eq!(announcing.rust_releases, vec![]);

--- a/cargo-dist/src/tests/tag.rs
+++ b/cargo-dist/src/tests/tag.rs
@@ -1,0 +1,388 @@
+//! Tests for announcement tag handling
+//!
+//! Note that some of these should_panics are negotiable, in the sense that we might
+//! one day add support for these formats, "fixing" the test. That's good as long
+//! as we intended to do that!
+
+use super::mock::*;
+use semver::Version;
+
+use crate::{config::ArtifactMode, parse_tag, DistGraphBuilder};
+
+#[test]
+#[should_panic = "NoTagMatch"]
+fn parse_one() {
+    // "1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+fn parse_one_v() {
+    // "v1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+fn parse_one_package_v() {
+    // "axolotlsay-v1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("{BIN_AXO_NAME}-v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, None);
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+#[should_panic = "NoTagMatch"]
+fn parse_one_package() {
+    // "axolotlsay-1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("{BIN_AXO_NAME}-{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, None);
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+fn parse_one_v_alpha() {
+    // "v1.0.0-prerelease.1" in a one package workspace
+    let workspace = workspace_just_axo_alpha();
+    let version: Version = BIN_AXO_VER_ALPHA.parse().unwrap();
+    let tag = format!("v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, true);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+fn parse_one_package_v_alpha() {
+    // "axolotlsay-v1.0.0-prerelease.1" in a one package workspace
+    let workspace = workspace_just_axo_alpha();
+    let version: Version = BIN_AXO_VER_ALPHA.parse().unwrap();
+    let tag = format!("{BIN_AXO_NAME}-v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, true);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, None);
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+#[should_panic = "NoTagMatch"]
+fn parse_one_prefix_slashv() {
+    // "release/v1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("release/v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+#[should_panic = "NoTagMatch"]
+fn parse_one_prefix_slash() {
+    // "release/1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("release/{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+#[should_panic = "NoTagMatch"]
+fn parse_one_prefix_slash_package_v() {
+    // "release/axolotlsay-v1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("release/{BIN_AXO_NAME}-v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+#[should_panic = "NoTagMatch"]
+fn parse_one_prefix_slash_package_slashv() {
+    // "releases/axolotlsay/v1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("releases/{BIN_AXO_NAME}/v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, None);
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+fn parse_one_package_slashv() {
+    // "releases/axolotlsay/v1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("{BIN_AXO_NAME}/v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, None);
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+#[should_panic = "NoTagMatch"]
+fn parse_one_prefix_slash_package_slash() {
+    // "releases/axolotlsay/v1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("releases/{BIN_AXO_NAME}/{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, None);
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+#[should_panic = "NoTagMatch"]
+fn parse_one_package_slash() {
+    // "releases/axolotlsay/v1.0.0" in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("{BIN_AXO_NAME}/{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, None);
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+fn parse_one_infer() {
+    // Provide no explicit tag in a one package workspace
+    let workspace = workspace_just_axo();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, None, true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(announcing.rust_releases, vec![entry_axo_bin()]);
+}
+
+#[test]
+fn parse_unified_v() {
+    // "v1.0.0" in a unified workspace
+    let workspace = workspace_unified();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(
+        announcing.rust_releases,
+        vec![entry_axo_bin(), entry_helper_bin()]
+    );
+}
+
+#[test]
+fn parse_unified_infer() {
+    // Provide no explicit tag in a unified workspace
+    let workspace = workspace_unified();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, None, true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(
+        announcing.rust_releases,
+        vec![entry_axo_bin(), entry_helper_bin()]
+    );
+}
+
+#[test]
+fn parse_unified_lib() {
+    // trying to explicitly publish a library in a unified workspace
+    let workspace = workspace_unified();
+    let version: Version = LIB_SOME_VER.parse().unwrap();
+    let tag = format!("{LIB_SOME_NAME}-v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, None);
+    assert_eq!(announcing.rust_releases, vec![]);
+}
+
+#[test]
+fn parse_disjoint_v() {
+    // selecting the bulk packages in a disjoint workspace
+    let workspace = workspace_disjoint();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(
+        announcing.rust_releases,
+        vec![entry_axo_bin(), entry_helper_bin(), entry_forced_bin()]
+    );
+}
+
+#[test]
+#[should_panic = "TooManyUnrelatedApps"]
+fn parse_disjoint_infer() {
+    // Provide no explicit tag in a disjoint workspace (SHOULD FAIL!)
+    let workspace = workspace_disjoint();
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, None, true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(
+        announcing.rust_releases,
+        vec![entry_axo_bin(), entry_helper_bin(), entry_forced_bin()]
+    );
+}
+
+#[test]
+fn parse_disjoint_v_oddball() {
+    // selecting the oddball package in a disjoint workspace
+    let workspace = workspace_disjoint();
+    let version: Version = BIN_ODDBALL_VER.parse().unwrap();
+    let tag = format!("v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, Some(version));
+    assert_eq!(announcing.rust_releases, vec![entry_oddball_bin()]);
+}
+
+#[test]
+fn parse_disjoint_lib() {
+    // trying to explicitly publish a library in a disjoint workspace
+    let workspace = workspace_disjoint();
+    let version: Version = LIB_OTHER_VER.parse().unwrap();
+    let tag = format!("{LIB_OTHER_NAME}-v{version}");
+
+    let tools = mock_tools();
+    let graph = DistGraphBuilder::new(tools, &workspace, ArtifactMode::All).unwrap();
+    let announcing = parse_tag(&graph, Some(&tag), true).unwrap();
+
+    assert_eq!(announcing.prerelease, false);
+    assert_eq!(announcing.tag, tag);
+    assert_eq!(announcing.version, None);
+    assert_eq!(announcing.rust_releases, vec![]);
+}

--- a/cargo-dist/templates/ci/github_ci.yml.j2
+++ b/cargo-dist/templates/ci/github_ci.yml.j2
@@ -4,9 +4,13 @@
 # CI that:
 #
 # * checks for a Git Tag that looks like a release
-# * creates a Github Release™ and fills in its text
-# * builds artifacts with cargo-dist (executable-zips, installers)
+{{%- if create_release %}}
+# * creates a draft Github Release™ and fills in its text
+{{%- endif %}}
+# * builds artifacts with cargo-dist (executable-zips, installers, hashes)
 # * uploads those artifacts to the Github Release™
+# * undrafts the Github Release™ on success
+{{%- if create_release %}}
 #
 # Note that the Github Release™ will be created before the artifacts,
 # so there will be a few minutes where the release has no artifacts
@@ -15,43 +19,52 @@
 # artifacts have been successfully uploaded. This allows you to
 # choose what to do with partial successes and avoids spamming
 # anyone with notifications before the release is actually ready.
+{{%- else %}}
+#
+# Note that a Github Release™ with this tag is assumed to exist as a draft
+# with the appropriate title/body, and will be undrafted for you.
+{{%- endif %}}
 name: Release
 
 permissions:
   contents: write
 
 # This task will run whenever you push a git tag that looks like a version
-# like "v1", "v1.2.0", "v0.1.0-prerelease01", "my-app-v1.0.0", etc.
-# The version will be roughly parsed as ({PACKAGE_NAME}-)?v{VERSION}, where
+# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
-# must be a Cargo-style SemVer Version.
+# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
 #
-# If PACKAGE_NAME is specified, then we will create a Github Release™ for that
+# If PACKAGE_NAME is specified, then the release will be for that
 # package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
 #
-# If PACKAGE_NAME isn't specified, then we will create a Github Release™ for all
+# If PACKAGE_NAME isn't specified, then the release will be for all
 # (cargo-dist-able) packages in the workspace with that version (this mode is
 # intended for workspaces with only one dist-able package, or with all dist-able
 # packages versioned/released in lockstep).
 #
 # If you push multiple tags at once, separate instances of this workflow will
-# spin up, creating an independent Github Release™ for each one.
+# spin up, creating an independent Github Release™ for each one. However Github
+# will hard limit this to 3 tags per commit, as it will assume more tags is a
+# mistake.
 #
 # If there's a prerelease-style suffix to the version, then the Github Release™
 # will be marked as a prerelease.
 on:
   push:
     tags:
-      - '*-?v[0-9]+*'
-      - '*/?v[0-9]+*'
+      - '**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
-  # Create the Github Release™ so the packages have something to be uploaded to
-  create-release:
+  # Run 'cargo dist plan' to determine what tasks we need to do
+  {{%- if create_release %}}
+  # and create a draft github release with the computed title/body
+  {{%- endif %}}
+  plan:
     runs-on: ubuntu-latest
     outputs:
-      has-releases: ${{ steps.create-release.outputs.has-releases }}
-      releases: ${{ steps.create-release.outputs.releases }}
+      has-releases: ${{ steps.plan.outputs.has-releases }}
+      releases: ${{ steps.plan.outputs.releases }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -64,7 +77,7 @@ jobs:
       {{%- endif %}}
       - name: Install cargo-dist
         run: {{{ install_dist_sh }}}
-      - id: create-release
+      - id: plan
         run: |
           cargo dist plan --tag=${{ github.ref_name }} --output-format=json > dist-manifest.json
           echo "dist plan ran successfully"
@@ -80,7 +93,7 @@ jobs:
           echo "created announcement!"
       {{%- else %}}
 
-          # We're assuming a draft Github Release™ with the desired name/tag/body already exists
+          # We're assuming a draft Github Release™ with the desired title/tag/body already exists
       {{%- endif %}}
 
           # Upload the manifest to the Github Release™
@@ -95,8 +108,8 @@ jobs:
   # Build and packages all the platform-specific things
   upload-local-artifacts:
     # Let the initial task tell us to not run (currently very blunt)
-    needs: create-release
-    if: ${{ needs.create-release.outputs.has-releases == 'true' }}
+    needs: plan
+    if: ${{ needs.plan.outputs.has-releases == 'true' }}
     strategy:
       fail-fast: {{{ fail_fast }}}
       matrix:
@@ -138,7 +151,7 @@ jobs:
           gh release upload ${{ github.ref_name }} $(cat uploads.txt)
           echo "uploaded!"
 
-  {{%- if global_task %}}
+{{%- if global_task %}}
 
   # Build and package all the platform-agnostic(ish) things
   upload-global-artifacts:
@@ -161,10 +174,6 @@ jobs:
         run: |
           gh release download ${{ github.ref_name }} --dir target/distrib/
       - name: Run cargo-dist
-        # This logic is a bit janky because it's trying to be a polyglot between
-        # powershell and bash since this will run on windows, macos, and linux!
-        # The two platforms don't agree on how to talk about env vars but they
-        # do agree on 'cat' and '$()' so we use that to marshal values between commands.
         run: |
           cargo dist build --tag=${{ github.ref_name }} --output-format=json {{{ global_task.dist_args }}} > dist-manifest.json
           echo "dist ran successfully"
@@ -177,14 +186,14 @@ jobs:
           gh release upload ${{ github.ref_name }} $(cat uploads.txt)
           echo "uploaded!"
 
-{{%- if 'homebrew' in publish_jobs and tap %}}
+  {{%- if 'homebrew' in publish_jobs and tap %}}
 
   upload-homebrew-formula:
-    needs: [create-release, upload-global-artifacts]
+    needs: [plan, upload-global-artifacts]
     runs-on: {{{ global_task.runner }}}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      RELEASES: ${{ needs.create-release.outputs.releases }}
+      RELEASES: ${{ needs.plan.outputs.releases }}
       GITHUB_USER: "axo bot"
       GITHUB_EMAIL: "admin+bot@axo.dev"
     steps:
@@ -212,13 +221,13 @@ jobs:
 
   {{%- endif %}}
 
-  {{%- endif %}}
+{{%- endif %}}
 
   # Mark the Github Release™ as a non-draft now that everything has succeeded!
   publish-release:
     # Only run after all the other tasks, but it's ok if upload-artifacts was skipped
-    needs: [create-release, upload-local-artifacts {{%- if global_task %}}, upload-global-artifacts{{% endif %}}]
-    if: ${{ always() && needs.create-release.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') {{%- if global_task %}} && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success'){{% endif %}} }}
+    needs: [plan, upload-local-artifacts {{%- if global_task %}}, upload-global-artifacts{{% endif %}}]
+    if: ${{ always() && needs.plan.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') {{%- if global_task %}} && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success'){{% endif %}} }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cargo-dist/templates/ci/github_ci.yml.j2
+++ b/cargo-dist/templates/ci/github_ci.yml.j2
@@ -43,6 +43,7 @@ on:
   push:
     tags:
       - '*-?v[0-9]+*'
+      - '*/?v[0-9]+*'
 
 jobs:
   # Create the Github Release™ so the packages have something to be uploaded to

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -123,6 +123,30 @@ fn test_lib_manifest() {
 }
 
 #[test]
+fn test_lib_manifest_slash() {
+    let version = std::env!("CARGO_PKG_VERSION");
+    let output = Command::new(BIN)
+        .arg("dist")
+        .arg("manifest")
+        .arg("--artifacts=all")
+        .arg("--no-local-paths")
+        .arg("--output-format=json")
+        .arg("--tag")
+        .arg(&format!("cargo-dist-schema/v{}", version))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    // We don't want this to churn every time we do a version bump
+    snapshot_settings_with_dist_manifest_filter().bind(|| {
+        insta::assert_snapshot!(format_outputs(&output));
+    });
+
+    assert!(output.status.success(), "{}", output.status);
+}
+
+#[test]
 fn test_error_manifest() {
     let output = Command::new(BIN)
         .arg("dist")

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1245,9 +1245,10 @@ Install-Binary "$Args"
 # CI that:
 #
 # * checks for a Git Tag that looks like a release
-# * creates a Github Release™ and fills in its text
-# * builds artifacts with cargo-dist (executable-zips, installers)
+# * creates a draft Github Release™ and fills in its text
+# * builds artifacts with cargo-dist (executable-zips, installers, hashes)
 # * uploads those artifacts to the Github Release™
+# * undrafts the Github Release™ on success
 #
 # Note that the Github Release™ will be created before the artifacts,
 # so there will be a few minutes where the release has no artifacts
@@ -1262,37 +1263,39 @@ permissions:
   contents: write
 
 # This task will run whenever you push a git tag that looks like a version
-# like "v1", "v1.2.0", "v0.1.0-prerelease01", "my-app-v1.0.0", etc.
-# The version will be roughly parsed as ({PACKAGE_NAME}-)?v{VERSION}, where
+# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
-# must be a Cargo-style SemVer Version.
+# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
 #
-# If PACKAGE_NAME is specified, then we will create a Github Release™ for that
+# If PACKAGE_NAME is specified, then the release will be for that
 # package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
 #
-# If PACKAGE_NAME isn't specified, then we will create a Github Release™ for all
+# If PACKAGE_NAME isn't specified, then the release will be for all
 # (cargo-dist-able) packages in the workspace with that version (this mode is
 # intended for workspaces with only one dist-able package, or with all dist-able
 # packages versioned/released in lockstep).
 #
 # If you push multiple tags at once, separate instances of this workflow will
-# spin up, creating an independent Github Release™ for each one.
+# spin up, creating an independent Github Release™ for each one. However Github
+# will hard limit this to 3 tags per commit, as it will assume more tags is a
+# mistake.
 #
 # If there's a prerelease-style suffix to the version, then the Github Release™
 # will be marked as a prerelease.
 on:
   push:
     tags:
-      - '*-?v[0-9]+*'
-      - '*/?v[0-9]+*'
+      - '**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
-  # Create the Github Release™ so the packages have something to be uploaded to
-  create-release:
+  # Run 'cargo dist plan' to determine what tasks we need to do
+  # and create a draft github release with the computed title/body
+  plan:
     runs-on: ubuntu-latest
     outputs:
-      has-releases: ${{ steps.create-release.outputs.has-releases }}
-      releases: ${{ steps.create-release.outputs.releases }}
+      has-releases: ${{ steps.plan.outputs.has-releases }}
+      releases: ${{ steps.plan.outputs.releases }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -1303,7 +1306,7 @@ jobs:
         run: rustup update "1.67.1" --no-self-update && rustup default "1.67.1"
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-      - id: create-release
+      - id: plan
         run: |
           cargo dist plan --tag=${{ github.ref_name }} --output-format=json > dist-manifest.json
           echo "dist plan ran successfully"
@@ -1328,8 +1331,8 @@ jobs:
   # Build and packages all the platform-specific things
   upload-local-artifacts:
     # Let the initial task tell us to not run (currently very blunt)
-    needs: create-release
-    if: ${{ needs.create-release.outputs.has-releases == 'true' }}
+    needs: plan
+    if: ${{ needs.plan.outputs.has-releases == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -1395,10 +1398,6 @@ jobs:
         run: |
           gh release download ${{ github.ref_name }} --dir target/distrib/
       - name: Run cargo-dist
-        # This logic is a bit janky because it's trying to be a polyglot between
-        # powershell and bash since this will run on windows, macos, and linux!
-        # The two platforms don't agree on how to talk about env vars but they
-        # do agree on 'cat' and '$()' so we use that to marshal values between commands.
         run: |
           cargo dist build --tag=${{ github.ref_name }} --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
@@ -1412,11 +1411,11 @@ jobs:
           echo "uploaded!"
 
   upload-homebrew-formula:
-    needs: [create-release, upload-global-artifacts]
+    needs: [plan, upload-global-artifacts]
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      RELEASES: ${{ needs.create-release.outputs.releases }}
+      RELEASES: ${{ needs.plan.outputs.releases }}
       GITHUB_USER: "axo bot"
       GITHUB_EMAIL: "admin+bot@axo.dev"
     steps:
@@ -1445,8 +1444,8 @@ jobs:
   # Mark the Github Release™ as a non-draft now that everything has succeeded!
   publish-release:
     # Only run after all the other tasks, but it's ok if upload-artifacts was skipped
-    needs: [create-release, upload-local-artifacts, upload-global-artifacts]
-    if: ${{ always() && needs.create-release.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success') }}
+    needs: [plan, upload-local-artifacts, upload-global-artifacts]
+    if: ${{ always() && needs.plan.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success') }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1284,6 +1284,7 @@ on:
   push:
     tags:
       - '*-?v[0-9]+*'
+      - '*/?v[0-9]+*'
 
 jobs:
   # Create the Github Release™ so the packages have something to be uploaded to

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -1245,9 +1245,10 @@ Install-Binary "$Args"
 # CI that:
 #
 # * checks for a Git Tag that looks like a release
-# * creates a Github Release™ and fills in its text
-# * builds artifacts with cargo-dist (executable-zips, installers)
+# * creates a draft Github Release™ and fills in its text
+# * builds artifacts with cargo-dist (executable-zips, installers, hashes)
 # * uploads those artifacts to the Github Release™
+# * undrafts the Github Release™ on success
 #
 # Note that the Github Release™ will be created before the artifacts,
 # so there will be a few minutes where the release has no artifacts
@@ -1262,37 +1263,39 @@ permissions:
   contents: write
 
 # This task will run whenever you push a git tag that looks like a version
-# like "v1", "v1.2.0", "v0.1.0-prerelease01", "my-app-v1.0.0", etc.
-# The version will be roughly parsed as ({PACKAGE_NAME}-)?v{VERSION}, where
+# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
-# must be a Cargo-style SemVer Version.
+# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
 #
-# If PACKAGE_NAME is specified, then we will create a Github Release™ for that
+# If PACKAGE_NAME is specified, then the release will be for that
 # package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
 #
-# If PACKAGE_NAME isn't specified, then we will create a Github Release™ for all
+# If PACKAGE_NAME isn't specified, then the release will be for all
 # (cargo-dist-able) packages in the workspace with that version (this mode is
 # intended for workspaces with only one dist-able package, or with all dist-able
 # packages versioned/released in lockstep).
 #
 # If you push multiple tags at once, separate instances of this workflow will
-# spin up, creating an independent Github Release™ for each one.
+# spin up, creating an independent Github Release™ for each one. However Github
+# will hard limit this to 3 tags per commit, as it will assume more tags is a
+# mistake.
 #
 # If there's a prerelease-style suffix to the version, then the Github Release™
 # will be marked as a prerelease.
 on:
   push:
     tags:
-      - '*-?v[0-9]+*'
-      - '*/?v[0-9]+*'
+      - '**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
-  # Create the Github Release™ so the packages have something to be uploaded to
-  create-release:
+  # Run 'cargo dist plan' to determine what tasks we need to do
+  # and create a draft github release with the computed title/body
+  plan:
     runs-on: ubuntu-latest
     outputs:
-      has-releases: ${{ steps.create-release.outputs.has-releases }}
-      releases: ${{ steps.create-release.outputs.releases }}
+      has-releases: ${{ steps.plan.outputs.has-releases }}
+      releases: ${{ steps.plan.outputs.releases }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -1303,7 +1306,7 @@ jobs:
         run: rustup update "1.67.1" --no-self-update && rustup default "1.67.1"
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-      - id: create-release
+      - id: plan
         run: |
           cargo dist plan --tag=${{ github.ref_name }} --output-format=json > dist-manifest.json
           echo "dist plan ran successfully"
@@ -1328,8 +1331,8 @@ jobs:
   # Build and packages all the platform-specific things
   upload-local-artifacts:
     # Let the initial task tell us to not run (currently very blunt)
-    needs: create-release
-    if: ${{ needs.create-release.outputs.has-releases == 'true' }}
+    needs: plan
+    if: ${{ needs.plan.outputs.has-releases == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -1395,10 +1398,6 @@ jobs:
         run: |
           gh release download ${{ github.ref_name }} --dir target/distrib/
       - name: Run cargo-dist
-        # This logic is a bit janky because it's trying to be a polyglot between
-        # powershell and bash since this will run on windows, macos, and linux!
-        # The two platforms don't agree on how to talk about env vars but they
-        # do agree on 'cat' and '$()' so we use that to marshal values between commands.
         run: |
           cargo dist build --tag=${{ github.ref_name }} --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
@@ -1412,11 +1411,11 @@ jobs:
           echo "uploaded!"
 
   upload-homebrew-formula:
-    needs: [create-release, upload-global-artifacts]
+    needs: [plan, upload-global-artifacts]
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      RELEASES: ${{ needs.create-release.outputs.releases }}
+      RELEASES: ${{ needs.plan.outputs.releases }}
       GITHUB_USER: "axo bot"
       GITHUB_EMAIL: "admin+bot@axo.dev"
     steps:
@@ -1445,8 +1444,8 @@ jobs:
   # Mark the Github Release™ as a non-draft now that everything has succeeded!
   publish-release:
     # Only run after all the other tasks, but it's ok if upload-artifacts was skipped
-    needs: [create-release, upload-local-artifacts, upload-global-artifacts]
-    if: ${{ always() && needs.create-release.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success') }}
+    needs: [plan, upload-local-artifacts, upload-global-artifacts]
+    if: ${{ always() && needs.plan.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success') }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -1284,6 +1284,7 @@ on:
   push:
     tags:
       - '*-?v[0-9]+*'
+      - '*/?v[0-9]+*'
 
 jobs:
   # Create the Github Release™ so the packages have something to be uploaded to

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2157,6 +2157,7 @@ on:
   push:
     tags:
       - '*-?v[0-9]+*'
+      - '*/?v[0-9]+*'
 
 jobs:
   # Create the Github Release™ so the packages have something to be uploaded to

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2118,9 +2118,10 @@ maybeInstall(true).then(run);
 # CI that:
 #
 # * checks for a Git Tag that looks like a release
-# * creates a Github Release™ and fills in its text
-# * builds artifacts with cargo-dist (executable-zips, installers)
+# * creates a draft Github Release™ and fills in its text
+# * builds artifacts with cargo-dist (executable-zips, installers, hashes)
 # * uploads those artifacts to the Github Release™
+# * undrafts the Github Release™ on success
 #
 # Note that the Github Release™ will be created before the artifacts,
 # so there will be a few minutes where the release has no artifacts
@@ -2135,37 +2136,39 @@ permissions:
   contents: write
 
 # This task will run whenever you push a git tag that looks like a version
-# like "v1", "v1.2.0", "v0.1.0-prerelease01", "my-app-v1.0.0", etc.
-# The version will be roughly parsed as ({PACKAGE_NAME}-)?v{VERSION}, where
+# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
-# must be a Cargo-style SemVer Version.
+# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
 #
-# If PACKAGE_NAME is specified, then we will create a Github Release™ for that
+# If PACKAGE_NAME is specified, then the release will be for that
 # package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
 #
-# If PACKAGE_NAME isn't specified, then we will create a Github Release™ for all
+# If PACKAGE_NAME isn't specified, then the release will be for all
 # (cargo-dist-able) packages in the workspace with that version (this mode is
 # intended for workspaces with only one dist-able package, or with all dist-able
 # packages versioned/released in lockstep).
 #
 # If you push multiple tags at once, separate instances of this workflow will
-# spin up, creating an independent Github Release™ for each one.
+# spin up, creating an independent Github Release™ for each one. However Github
+# will hard limit this to 3 tags per commit, as it will assume more tags is a
+# mistake.
 #
 # If there's a prerelease-style suffix to the version, then the Github Release™
 # will be marked as a prerelease.
 on:
   push:
     tags:
-      - '*-?v[0-9]+*'
-      - '*/?v[0-9]+*'
+      - '**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
-  # Create the Github Release™ so the packages have something to be uploaded to
-  create-release:
+  # Run 'cargo dist plan' to determine what tasks we need to do
+  # and create a draft github release with the computed title/body
+  plan:
     runs-on: ubuntu-latest
     outputs:
-      has-releases: ${{ steps.create-release.outputs.has-releases }}
-      releases: ${{ steps.create-release.outputs.releases }}
+      has-releases: ${{ steps.plan.outputs.has-releases }}
+      releases: ${{ steps.plan.outputs.releases }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -2174,7 +2177,7 @@ jobs:
           submodules: recursive
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-      - id: create-release
+      - id: plan
         run: |
           cargo dist plan --tag=${{ github.ref_name }} --output-format=json > dist-manifest.json
           echo "dist plan ran successfully"
@@ -2199,8 +2202,8 @@ jobs:
   # Build and packages all the platform-specific things
   upload-local-artifacts:
     # Let the initial task tell us to not run (currently very blunt)
-    needs: create-release
-    if: ${{ needs.create-release.outputs.has-releases == 'true' }}
+    needs: plan
+    if: ${{ needs.plan.outputs.has-releases == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -2262,10 +2265,6 @@ jobs:
         run: |
           gh release download ${{ github.ref_name }} --dir target/distrib/
       - name: Run cargo-dist
-        # This logic is a bit janky because it's trying to be a polyglot between
-        # powershell and bash since this will run on windows, macos, and linux!
-        # The two platforms don't agree on how to talk about env vars but they
-        # do agree on 'cat' and '$()' so we use that to marshal values between commands.
         run: |
           cargo dist build --tag=${{ github.ref_name }} --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
@@ -2279,11 +2278,11 @@ jobs:
           echo "uploaded!"
 
   upload-homebrew-formula:
-    needs: [create-release, upload-global-artifacts]
+    needs: [plan, upload-global-artifacts]
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      RELEASES: ${{ needs.create-release.outputs.releases }}
+      RELEASES: ${{ needs.plan.outputs.releases }}
       GITHUB_USER: "axo bot"
       GITHUB_EMAIL: "admin+bot@axo.dev"
     steps:
@@ -2312,8 +2311,8 @@ jobs:
   # Mark the Github Release™ as a non-draft now that everything has succeeded!
   publish-release:
     # Only run after all the other tasks, but it's ok if upload-artifacts was skipped
-    needs: [create-release, upload-local-artifacts, upload-global-artifacts]
-    if: ${{ always() && needs.create-release.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success') }}
+    needs: [plan, upload-local-artifacts, upload-global-artifacts]
+    if: ${{ always() && needs.plan.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success') }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2118,53 +2118,50 @@ maybeInstall(true).then(run);
 # CI that:
 #
 # * checks for a Git Tag that looks like a release
-# * creates a Github Release™ and fills in its text
-# * builds artifacts with cargo-dist (executable-zips, installers)
+# * builds artifacts with cargo-dist (executable-zips, installers, hashes)
 # * uploads those artifacts to the Github Release™
+# * undrafts the Github Release™ on success
 #
-# Note that the Github Release™ will be created before the artifacts,
-# so there will be a few minutes where the release has no artifacts
-# and then they will slowly trickle in, possibly failing. To make
-# this more pleasant we mark the release as a "draft" until all
-# artifacts have been successfully uploaded. This allows you to
-# choose what to do with partial successes and avoids spamming
-# anyone with notifications before the release is actually ready.
+# Note that a Github Release™ with this tag is assumed to exist as a draft
+# with the appropriate title/body, and will be undrafted for you.
 name: Release
 
 permissions:
   contents: write
 
 # This task will run whenever you push a git tag that looks like a version
-# like "v1", "v1.2.0", "v0.1.0-prerelease01", "my-app-v1.0.0", etc.
-# The version will be roughly parsed as ({PACKAGE_NAME}-)?v{VERSION}, where
+# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
-# must be a Cargo-style SemVer Version.
+# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
 #
-# If PACKAGE_NAME is specified, then we will create a Github Release™ for that
+# If PACKAGE_NAME is specified, then the release will be for that
 # package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
 #
-# If PACKAGE_NAME isn't specified, then we will create a Github Release™ for all
+# If PACKAGE_NAME isn't specified, then the release will be for all
 # (cargo-dist-able) packages in the workspace with that version (this mode is
 # intended for workspaces with only one dist-able package, or with all dist-able
 # packages versioned/released in lockstep).
 #
 # If you push multiple tags at once, separate instances of this workflow will
-# spin up, creating an independent Github Release™ for each one.
+# spin up, creating an independent Github Release™ for each one. However Github
+# will hard limit this to 3 tags per commit, as it will assume more tags is a
+# mistake.
 #
 # If there's a prerelease-style suffix to the version, then the Github Release™
 # will be marked as a prerelease.
 on:
   push:
     tags:
-      - '*-?v[0-9]+*'
+      - '**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
-  # Create the Github Release™ so the packages have something to be uploaded to
-  create-release:
+  # Run 'cargo dist plan' to determine what tasks we need to do
+  plan:
     runs-on: ubuntu-latest
     outputs:
-      has-releases: ${{ steps.create-release.outputs.has-releases }}
-      releases: ${{ steps.create-release.outputs.releases }}
+      has-releases: ${{ steps.plan.outputs.has-releases }}
+      releases: ${{ steps.plan.outputs.releases }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -2173,13 +2170,13 @@ jobs:
           submodules: recursive
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-      - id: create-release
+      - id: plan
         run: |
           cargo dist plan --tag=${{ github.ref_name }} --output-format=json > dist-manifest.json
           echo "dist plan ran successfully"
           cat dist-manifest.json
 
-          # We're assuming a draft Github Release™ with the desired name/tag/body already exists
+          # We're assuming a draft Github Release™ with the desired title/tag/body already exists
 
           # Upload the manifest to the Github Release™
           gh release upload ${{ github.ref_name }} dist-manifest.json
@@ -2193,8 +2190,8 @@ jobs:
   # Build and packages all the platform-specific things
   upload-local-artifacts:
     # Let the initial task tell us to not run (currently very blunt)
-    needs: create-release
-    if: ${{ needs.create-release.outputs.has-releases == 'true' }}
+    needs: plan
+    if: ${{ needs.plan.outputs.has-releases == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -2256,10 +2253,6 @@ jobs:
         run: |
           gh release download ${{ github.ref_name }} --dir target/distrib/
       - name: Run cargo-dist
-        # This logic is a bit janky because it's trying to be a polyglot between
-        # powershell and bash since this will run on windows, macos, and linux!
-        # The two platforms don't agree on how to talk about env vars but they
-        # do agree on 'cat' and '$()' so we use that to marshal values between commands.
         run: |
           cargo dist build --tag=${{ github.ref_name }} --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
@@ -2273,11 +2266,11 @@ jobs:
           echo "uploaded!"
 
   upload-homebrew-formula:
-    needs: [create-release, upload-global-artifacts]
+    needs: [plan, upload-global-artifacts]
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      RELEASES: ${{ needs.create-release.outputs.releases }}
+      RELEASES: ${{ needs.plan.outputs.releases }}
       GITHUB_USER: "axo bot"
       GITHUB_EMAIL: "admin+bot@axo.dev"
     steps:
@@ -2306,8 +2299,8 @@ jobs:
   # Mark the Github Release™ as a non-draft now that everything has succeeded!
   publish-release:
     # Only run after all the other tasks, but it's ok if upload-artifacts was skipped
-    needs: [create-release, upload-local-artifacts, upload-global-artifacts]
-    if: ${{ always() && needs.create-release.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success') }}
+    needs: [plan, upload-local-artifacts, upload-global-artifacts]
+    if: ${{ always() && needs.plan.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success') }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -2118,9 +2118,10 @@ maybeInstall(true).then(run);
 # CI that:
 #
 # * checks for a Git Tag that looks like a release
-# * creates a Github Release™ and fills in its text
-# * builds artifacts with cargo-dist (executable-zips, installers)
+# * creates a draft Github Release™ and fills in its text
+# * builds artifacts with cargo-dist (executable-zips, installers, hashes)
 # * uploads those artifacts to the Github Release™
+# * undrafts the Github Release™ on success
 #
 # Note that the Github Release™ will be created before the artifacts,
 # so there will be a few minutes where the release has no artifacts
@@ -2135,36 +2136,39 @@ permissions:
   contents: write
 
 # This task will run whenever you push a git tag that looks like a version
-# like "v1", "v1.2.0", "v0.1.0-prerelease01", "my-app-v1.0.0", etc.
-# The version will be roughly parsed as ({PACKAGE_NAME}-)?v{VERSION}, where
+# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
-# must be a Cargo-style SemVer Version.
+# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
 #
-# If PACKAGE_NAME is specified, then we will create a Github Release™ for that
+# If PACKAGE_NAME is specified, then the release will be for that
 # package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
 #
-# If PACKAGE_NAME isn't specified, then we will create a Github Release™ for all
+# If PACKAGE_NAME isn't specified, then the release will be for all
 # (cargo-dist-able) packages in the workspace with that version (this mode is
 # intended for workspaces with only one dist-able package, or with all dist-able
 # packages versioned/released in lockstep).
 #
 # If you push multiple tags at once, separate instances of this workflow will
-# spin up, creating an independent Github Release™ for each one.
+# spin up, creating an independent Github Release™ for each one. However Github
+# will hard limit this to 3 tags per commit, as it will assume more tags is a
+# mistake.
 #
 # If there's a prerelease-style suffix to the version, then the Github Release™
 # will be marked as a prerelease.
 on:
   push:
     tags:
-      - '*-?v[0-9]+*'
+      - '**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
-  # Create the Github Release™ so the packages have something to be uploaded to
-  create-release:
+  # Run 'cargo dist plan' to determine what tasks we need to do
+  # and create a draft github release with the computed title/body
+  plan:
     runs-on: ubuntu-latest
     outputs:
-      has-releases: ${{ steps.create-release.outputs.has-releases }}
-      releases: ${{ steps.create-release.outputs.releases }}
+      has-releases: ${{ steps.plan.outputs.has-releases }}
+      releases: ${{ steps.plan.outputs.releases }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -2173,7 +2177,7 @@ jobs:
           submodules: recursive
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-      - id: create-release
+      - id: plan
         run: |
           cargo dist plan --tag=${{ github.ref_name }} --output-format=json > dist-manifest.json
           echo "dist plan ran successfully"
@@ -2198,8 +2202,8 @@ jobs:
   # Build and packages all the platform-specific things
   upload-local-artifacts:
     # Let the initial task tell us to not run (currently very blunt)
-    needs: create-release
-    if: ${{ needs.create-release.outputs.has-releases == 'true' }}
+    needs: plan
+    if: ${{ needs.plan.outputs.has-releases == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -2261,10 +2265,6 @@ jobs:
         run: |
           gh release download ${{ github.ref_name }} --dir target/distrib/
       - name: Run cargo-dist
-        # This logic is a bit janky because it's trying to be a polyglot between
-        # powershell and bash since this will run on windows, macos, and linux!
-        # The two platforms don't agree on how to talk about env vars but they
-        # do agree on 'cat' and '$()' so we use that to marshal values between commands.
         run: |
           cargo dist build --tag=${{ github.ref_name }} --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
@@ -2280,8 +2280,8 @@ jobs:
   # Mark the Github Release™ as a non-draft now that everything has succeeded!
   publish-release:
     # Only run after all the other tasks, but it's ok if upload-artifacts was skipped
-    needs: [create-release, upload-local-artifacts, upload-global-artifacts]
-    if: ${{ always() && needs.create-release.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success') }}
+    needs: [plan, upload-local-artifacts, upload-global-artifacts]
+    if: ${{ always() && needs.plan.result == 'success' && (needs.upload-local-artifacts.result == 'skipped' || needs.upload-local-artifacts.result == 'success') && (needs.upload-global-artifacts.result == 'skipped' || needs.upload-global-artifacts.result == 'success') }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -1,0 +1,24 @@
+---
+source: cargo-dist/tests/cli-tests.rs
+expression: format_outputs(&output)
+---
+stdout:
+{
+  "dist_version": "1.0.0-FAKEVERSION",
+  "announcement_tag": "CENSORED",
+  "announcement_is_prerelease": "CENSORED"
+  "announcement_title": "CENSORED"
+  "announcement_github_body": "CENSORED"
+  "system_info": {
+    "cargo_version_line": "CENSORED"
+  }
+}
+
+stderr:
+analyzing workspace:
+  cargo-dist (didn't match tag cargo-dist-schema/v1.0.0-FAKEVERSION)
+    [bin] cargo-dist
+  cargo-dist-schema (no binaries)
+
+ WARN You're trying to explicitly Release a library, only minimal functionality will work
+

--- a/cargo-dist/tests/snapshots/long-help.snap
+++ b/cargo-dist/tests/snapshots/long-help.snap
@@ -74,7 +74,7 @@ GLOBAL OPTIONS:
           
           This tag serves two purposes: defining which apps we are Announcing new Releases for (and therefore building binaries and installers for); and picking an id to use for certain URLs. For instance the git tag associated with a Github Release is part of the URL to fetch artifacts from that release, which needs to be known by some installers!
           
-          The currently accepted formats are "v{VERSION}" and "{PACKAGE_NAME}-v{VERSION}" ("v1.0.0", "v0.1.0-prerelease1", "my-app-v1.0.0", etc).
+          The currently accepted formats are "v{VERSION}", "{PACKAGE_NAME}-v{VERSION}", and "{PACKAGE_NAME}/v{VERSION}" ("v1.0.0", "v0.1.0-prerelease1", "my-app-v1.0.0", "my-app/v1.0.0, etc).
           
           If you use the prefixed version then we will only Announce/Release that package's apps (and return an error if that is not in fact the package's current version). This is appropriate for workspaces that have more than one app.
           

--- a/cargo-dist/tests/snapshots/long-help.snap
+++ b/cargo-dist/tests/snapshots/long-help.snap
@@ -74,11 +74,13 @@ GLOBAL OPTIONS:
           
           This tag serves two purposes: defining which apps we are Announcing new Releases for (and therefore building binaries and installers for); and picking an id to use for certain URLs. For instance the git tag associated with a Github Release is part of the URL to fetch artifacts from that release, which needs to be known by some installers!
           
-          The currently accepted formats are "v{VERSION}", "{PACKAGE_NAME}-v{VERSION}", and "{PACKAGE_NAME}/v{VERSION}" ("v1.0.0", "v0.1.0-prerelease1", "my-app-v1.0.0", "my-app/v1.0.0, etc).
+          Unified Announcement: VERSION selects all packages with the given version (v1.0.0, 0.1.0-prerelease.1, releases/1.2.3, ...)
           
-          If you use the prefixed version then we will only Announce/Release that package's apps (and return an error if that is not in fact the package's current version). This is appropriate for workspaces that have more than one app.
+          Singular Announcement: PACKAGE-VERSION or PACKAGE/VERSION selects only the given package (my-app-v1.0.0, my-app/1.0.0, release/my-app/v1.2.3-alpha, ...)
           
-          If you use the unprefixed version then we will assume you're Announcing/Releasing all packages in the workspace that have that version. This is appropriate for workspaces that only have one app, or for monorepos that version all their apps in lockstep.
+          If you use the singular version then we will only Announce/Release that package's apps (and return an error if that is not in fact the package's current version). This is appropriate for workspaces that have more than one app.
+          
+          If you use the unified version then we will assume you're Announcing/Releasing all packages in the workspace that have that version. This is appropriate for workspaces that only have one app, or for monorepos that version all their apps in lockstep.
           
           If you do not specify this tag we will attempt to infer it by trying to Announce/Release every app in the workspace, succeeding only if they all have the same version. The tag selected will be "v{VERSION}".
           

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -76,11 +76,13 @@ The (git) tag to use for the Announcement that each invocation of cargo-dist is 
 
 This tag serves two purposes: defining which apps we are Announcing new Releases for (and therefore building binaries and installers for); and picking an id to use for certain URLs. For instance the git tag associated with a Github Release is part of the URL to fetch artifacts from that release, which needs to be known by some installers!
 
-The currently accepted formats are "v{VERSION}", "{PACKAGE_NAME}-v{VERSION}", and "{PACKAGE_NAME}/v{VERSION}" ("v1.0.0", "v0.1.0-prerelease1", "my-app-v1.0.0", "my-app/v1.0.0, etc).
+Unified Announcement: VERSION selects all packages with the given version (v1.0.0, 0.1.0-prerelease.1, releases/1.2.3, ...)
 
-If you use the prefixed version then we will only Announce/Release that package's apps (and return an error if that is not in fact the package's current version). This is appropriate for workspaces that have more than one app.
+Singular Announcement: PACKAGE-VERSION or PACKAGE/VERSION selects only the given package (my-app-v1.0.0, my-app/1.0.0, release/my-app/v1.2.3-alpha, ...)
 
-If you use the unprefixed version then we will assume you're Announcing/Releasing all packages in the workspace that have that version. This is appropriate for workspaces that only have one app, or for monorepos that version all their apps in lockstep.
+If you use the singular version then we will only Announce/Release that package's apps (and return an error if that is not in fact the package's current version). This is appropriate for workspaces that have more than one app.
+
+If you use the unified version then we will assume you're Announcing/Releasing all packages in the workspace that have that version. This is appropriate for workspaces that only have one app, or for monorepos that version all their apps in lockstep.
 
 If you do not specify this tag we will attempt to infer it by trying to Announce/Release every app in the workspace, succeeding only if they all have the same version. The tag selected will be "v{VERSION}".
 

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -76,7 +76,7 @@ The (git) tag to use for the Announcement that each invocation of cargo-dist is 
 
 This tag serves two purposes: defining which apps we are Announcing new Releases for (and therefore building binaries and installers for); and picking an id to use for certain URLs. For instance the git tag associated with a Github Release is part of the URL to fetch artifacts from that release, which needs to be known by some installers!
 
-The currently accepted formats are "v{VERSION}" and "{PACKAGE_NAME}-v{VERSION}" ("v1.0.0", "v0.1.0-prerelease1", "my-app-v1.0.0", etc).
+The currently accepted formats are "v{VERSION}", "{PACKAGE_NAME}-v{VERSION}", and "{PACKAGE_NAME}/v{VERSION}" ("v1.0.0", "v0.1.0-prerelease1", "my-app-v1.0.0", "my-app/v1.0.0, etc).
 
 If you use the prefixed version then we will only Announce/Release that package's apps (and return an error if that is not in fact the package's current version). This is appropriate for workspaces that have more than one app.
 


### PR DESCRIPTION
Allows usage in repos that use a slash to separate the crate name from the version.

Examples:
 - `myapp/v1.0.0`
 - `myapp-thing/v1.2.3`

Resolves #343

I built it locally and tested on a repo of mine, and it seems to work as expected (before it would just fail of course, due to the unsupported tag format):

First prepping a release with `cargo-release`:

```
❯ cargo release minor -x       
Release
  facti-lib 0.3.0
  facti-api 0.3.0
  facti 0.3.0
? [y/N] 
y
   Upgrading facti-lib from 0.2.1 to 0.3.0
    Updating facti's dependency from 0.2.1 to 0.3.0
    Updating facti-api's dependency from 0.2.1 to 0.3.0
[feature/cargo-dist-slash 479058c] Release facti-lib v0.3.0
 5 files changed, 8 insertions(+), 5 deletions(-)
   Upgrading facti-api from 0.2.0 to 0.3.0
    Updating facti's dependency from 0.2.0 to 0.3.0
[feature/cargo-dist-slash 9b36f82] Release facti-api v0.3.0
 4 files changed, 7 insertions(+), 4 deletions(-)
   Upgrading facti from 0.2.3 to 0.3.0
    Updating xtask's dependency from 0.2.3 to 0.3.0
[feature/cargo-dist-slash 2ea2b80] Release facti v0.3.0
 4 files changed, 7 insertions(+), 4 deletions(-)
```

Verify the tags indeed contain slashes:

```
❯ git tag | rg v0.3.0                   
'Tipz:' gt | rg v0.3.0
facti-api/v0.3.0
facti-lib/v0.3.0
facti/v0.3.0
```

Generate the plan:

```
❯ cargo dist plan       
analyzing workspace:
  facti-lib (no binaries)
  facti-api (no binaries)
  facti
    [bin] facti
  xtask (publish = false)
    [bin] xtask

announcing v0.3.0
  facti 0.3.0
    facti-installer.sh
    facti-installer.ps1
    facti-aarch64-apple-darwin.tar.xz
      [bin] facti
      [misc] CHANGELOG.md, LICENSE, README.md
      [checksum] facti-aarch64-apple-darwin.tar.xz.sha256
    facti-x86_64-apple-darwin.tar.xz
      [bin] facti
      [misc] CHANGELOG.md, LICENSE, README.md
      [checksum] facti-x86_64-apple-darwin.tar.xz.sha256
    facti-x86_64-pc-windows-msvc.zip
      [bin] facti.exe
      [misc] CHANGELOG.md, LICENSE, README.md
      [checksum] facti-x86_64-pc-windows-msvc.zip.sha256
    facti-x86_64-unknown-linux-gnu.tar.xz
      [bin] facti
      [misc] CHANGELOG.md, LICENSE, README.md
      [checksum] facti-x86_64-unknown-linux-gnu.tar.xz.sha256
```

Also for completeness sake, the manifest JSON as generated by `cargo dist plan --tag="facti/v0.3.0" --output-format=json > dist-manifest.json`:

```json
{
  "dist_version": "0.2.0-prerelease.2",
  "announcement_tag": "facti/v0.3.0",
  "announcement_is_prerelease": false,
  "announcement_title": "facti/v0.3.0",
  "announcement_github_body": "## Install facti 0.3.0\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\nirm https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-installer.ps1 | iex\n```\n\n## Download facti 0.3.0\n\n|        |        |\n|--------|--------|\n| [facti-aarch64-apple-darwin.tar.xz](https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-aarch64-apple-darwin.tar.xz) | [checksum](https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-aarch64-apple-darwin.tar.xz.sha256) |\n| [facti-x86_64-apple-darwin.tar.xz](https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-x86_64-apple-darwin.tar.xz) | [checksum](https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-x86_64-apple-darwin.tar.xz.sha256) |\n| [facti-x86_64-pc-windows-msvc.zip](https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-x86_64-pc-windows-msvc.zip) | [checksum](https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-x86_64-pc-windows-msvc.zip.sha256) |\n| [facti-x86_64-unknown-linux-gnu.tar.xz](https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-x86_64-unknown-linux-gnu.tar.xz) | [checksum](https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n\n",
  "system_info": {
    "cargo_version_line": "cargo 1.71.1 (7f1d04c00 2023-07-29)"
  },
  "releases": [
    {
      "app_name": "facti",
      "app_version": "0.3.0",
      "artifacts": [
        "facti-installer.sh",
        "facti-installer.ps1",
        "facti-aarch64-apple-darwin.tar.xz",
        "facti-aarch64-apple-darwin.tar.xz.sha256",
        "facti-x86_64-apple-darwin.tar.xz",
        "facti-x86_64-apple-darwin.tar.xz.sha256",
        "facti-x86_64-pc-windows-msvc.zip",
        "facti-x86_64-pc-windows-msvc.zip.sha256",
        "facti-x86_64-unknown-linux-gnu.tar.xz",
        "facti-x86_64-unknown-linux-gnu.tar.xz.sha256"
      ]
    }
  ],
  "artifacts": {
    "facti-aarch64-apple-darwin.tar.xz": {
      "name": "facti-aarch64-apple-darwin.tar.xz",
      "kind": "executable-zip",
      "target_triples": [
        "aarch64-apple-darwin"
      ],
      "assets": [
        {
          "name": "CHANGELOG.md",
          "path": "CHANGELOG.md",
          "kind": "changelog"
        },
        {
          "name": "LICENSE",
          "path": "LICENSE",
          "kind": "license"
        },
        {
          "name": "README.md",
          "path": "README.md",
          "kind": "readme"
        },
        {
          "name": "facti",
          "path": "facti",
          "kind": "executable"
        }
      ],
      "checksum": "facti-aarch64-apple-darwin.tar.xz.sha256"
    },
    "facti-aarch64-apple-darwin.tar.xz.sha256": {
      "name": "facti-aarch64-apple-darwin.tar.xz.sha256",
      "kind": "checksum",
      "target_triples": [
        "aarch64-apple-darwin"
      ]
    },
    "facti-installer.ps1": {
      "name": "facti-installer.ps1",
      "kind": "installer",
      "target_triples": [
        "x86_64-pc-windows-msvc"
      ],
      "install_hint": "irm https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-installer.ps1 | iex",
      "description": "Install prebuilt binaries via powershell script"
    },
    "facti-installer.sh": {
      "name": "facti-installer.sh",
      "kind": "installer",
      "target_triples": [
        "aarch64-apple-darwin",
        "x86_64-apple-darwin",
        "x86_64-unknown-linux-gnu"
      ],
      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Sharparam/facti/releases/download/facti/v0.3.0/facti-installer.sh | sh",
      "description": "Install prebuilt binaries via shell script"
    },
    "facti-x86_64-apple-darwin.tar.xz": {
      "name": "facti-x86_64-apple-darwin.tar.xz",
      "kind": "executable-zip",
      "target_triples": [
        "x86_64-apple-darwin"
      ],
      "assets": [
        {
          "name": "CHANGELOG.md",
          "path": "CHANGELOG.md",
          "kind": "changelog"
        },
        {
          "name": "LICENSE",
          "path": "LICENSE",
          "kind": "license"
        },
        {
          "name": "README.md",
          "path": "README.md",
          "kind": "readme"
        },
        {
          "name": "facti",
          "path": "facti",
          "kind": "executable"
        }
      ],
      "checksum": "facti-x86_64-apple-darwin.tar.xz.sha256"
    },
    "facti-x86_64-apple-darwin.tar.xz.sha256": {
      "name": "facti-x86_64-apple-darwin.tar.xz.sha256",
      "kind": "checksum",
      "target_triples": [
        "x86_64-apple-darwin"
      ]
    },
    "facti-x86_64-pc-windows-msvc.zip": {
      "name": "facti-x86_64-pc-windows-msvc.zip",
      "kind": "executable-zip",
      "target_triples": [
        "x86_64-pc-windows-msvc"
      ],
      "assets": [
        {
          "name": "CHANGELOG.md",
          "path": "CHANGELOG.md",
          "kind": "changelog"
        },
        {
          "name": "LICENSE",
          "path": "LICENSE",
          "kind": "license"
        },
        {
          "name": "README.md",
          "path": "README.md",
          "kind": "readme"
        },
        {
          "name": "facti",
          "path": "facti.exe",
          "kind": "executable"
        }
      ],
      "checksum": "facti-x86_64-pc-windows-msvc.zip.sha256"
    },
    "facti-x86_64-pc-windows-msvc.zip.sha256": {
      "name": "facti-x86_64-pc-windows-msvc.zip.sha256",
      "kind": "checksum",
      "target_triples": [
        "x86_64-pc-windows-msvc"
      ]
    },
    "facti-x86_64-unknown-linux-gnu.tar.xz": {
      "name": "facti-x86_64-unknown-linux-gnu.tar.xz",
      "kind": "executable-zip",
      "target_triples": [
        "x86_64-unknown-linux-gnu"
      ],
      "assets": [
        {
          "name": "CHANGELOG.md",
          "path": "CHANGELOG.md",
          "kind": "changelog"
        },
        {
          "name": "LICENSE",
          "path": "LICENSE",
          "kind": "license"
        },
        {
          "name": "README.md",
          "path": "README.md",
          "kind": "readme"
        },
        {
          "name": "facti",
          "path": "facti",
          "kind": "executable"
        }
      ],
      "checksum": "facti-x86_64-unknown-linux-gnu.tar.xz.sha256"
    },
    "facti-x86_64-unknown-linux-gnu.tar.xz.sha256": {
      "name": "facti-x86_64-unknown-linux-gnu.tar.xz.sha256",
      "kind": "checksum",
      "target_triples": [
        "x86_64-unknown-linux-gnu"
      ]
    }
  }
}
```

I added a basic test to make sure it accepts a slash in tag names, and updated documentation in the places I could find that are relevant to update. Let me know if there are places I missed!

The added logic for also matching slash in `tasks.rs` feels maybe a bit basic: https://github.com/axodotdev/cargo-dist/pull/346/files#diff-814fadc3b7172ad99eb612542786697d1a908474a4325311bfd2b7a3839d349b

But also simple, but if there's a suggestion for a perhaps nicer way to do it I'm all ears :)