### PR TITLE
fix(homebrew): add explicit version tag

### DIFF
--- a/cargo-dist/templates/installer/homebrew.rb.j2
+++ b/cargo-dist/templates/installer/homebrew.rb.j2
@@ -24,6 +24,7 @@ class {{ formula_class }} < Formula
     sha256 "{{ x86_64_sha256 }}"
     {%- endif %}
   end
+  version "{{ inner.app_version }}"
   {%- endif %}
   {#- #}
   {%- if license %}

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -707,6 +707,7 @@ class AkaikatanaRepack < Formula
   else
     url "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz"
   end
+  version "0.2.0"
   license "GPL-2.0-or-later"
 
   def install

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -708,6 +708,7 @@ class Axolotlsay < Formula
   else
     url "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz"
   end
+  version "0.1.0"
   license "MIT OR Apache-2.0"
 
   def install

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -708,6 +708,7 @@ class Axolotlsay < Formula
   else
     url "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz"
   end
+  version "0.1.0"
   license "MIT OR Apache-2.0"
 
   def install

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -691,6 +691,7 @@ class Axolotlsay < Formula
   else
     url "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz"
   end
+  version "0.1.0"
   license "MIT OR Apache-2.0"
 
   def install

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -691,6 +691,7 @@ class Axolotlsay < Formula
   else
     url "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz"
   end
+  version "0.1.0"
   license "MIT OR Apache-2.0"
 
   def install

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -691,6 +691,7 @@ class Axolotlsay < Formula
   else
     url "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz"
   end
+  version "0.1.0"
   license "MIT OR Apache-2.0"
 
   def install

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -691,6 +691,7 @@ class Axolotlsay < Formula
   else
     url "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz"
   end
+  version "0.1.0"
   license "MIT OR Apache-2.0"
 
   def install

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -691,6 +691,7 @@ class Axolotlsay < Formula
   else
     url "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz"
   end
+  version "0.1.0"
   license "MIT OR Apache-2.0"
 
   def install

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -691,6 +691,7 @@ class Axolotlsay < Formula
   else
     url "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz"
   end
+  version "0.1.0"
   license "MIT OR Apache-2.0"
 
   def install

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -691,6 +691,7 @@ class Axolotlsay < Formula
   else
     url "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz"
   end
+  version "0.1.0"
   license "MIT OR Apache-2.0"
 
   def install

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -691,6 +691,7 @@ class Axolotlsay < Formula
   else
     url "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz"
   end
+  version "0.1.0"
   license "MIT OR Apache-2.0"
 
   def install


### PR DESCRIPTION
A real-world test indicated that Homebrew is reliably misparsing the version from the URLs. Instead of letting Homebrew guess, let's just be explicit.