### PR TITLE
fix(templates): restore trailing newline

### DIFF
--- a/cargo-dist/templates/ci/github_ci.yml.j2
+++ b/cargo-dist/templates/ci/github_ci.yml.j2
@@ -221,3 +221,4 @@ jobs:
       - name: mark release as non-draft
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
+

--- a/cargo-dist/templates/installer/homebrew.rb.j2
+++ b/cargo-dist/templates/installer/homebrew.rb.j2
@@ -52,3 +52,4 @@ class {{ formula_class }} < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -722,6 +722,7 @@ class AkaikatanaRepack < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -1454,4 +1455,5 @@ jobs:
       - name: mark release as non-draft
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
+
 

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -722,6 +722,7 @@ class AkaikatanaRepack < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -1454,4 +1455,5 @@ jobs:
       - name: mark release as non-draft
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
+
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -723,6 +723,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -2321,4 +2322,5 @@ jobs:
       - name: mark release as non-draft
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
+
 

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -723,6 +723,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your


### PR DESCRIPTION
These were removed as a part of a linting pass and editor auto-save. However, minijinja doesn't have an option to disable stripping a trailing newline, so we still need these right now.