### PR TITLE
fix(templates): append trailing newline if needed

### DIFF
--- a/cargo-dist/src/backend/templates.rs
+++ b/cargo-dist/src/backend/templates.rs
@@ -195,7 +195,11 @@ impl Templates {
         val: &impl Serialize,
     ) -> DistResult<String> {
         let template = self.envs[file.env].get_template(file.path.as_str())?;
-        let rendered = template.render(val)?;
+        let mut rendered = template.render(val)?;
+        // minijinja strips trailing newlines from templates
+        if !rendered.ends_with('\n') {
+            rendered.push('\n');
+        }
         let cleaned = dos2unix(&rendered).into_owned();
         Ok(cleaned)
     }

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -722,6 +722,7 @@ class AkaikatanaRepack < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -1454,4 +1455,5 @@ jobs:
       - name: mark release as non-draft
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
+
 

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -722,6 +722,7 @@ class AkaikatanaRepack < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -1454,4 +1455,5 @@ jobs:
       - name: mark release as non-draft
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
+
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -723,6 +723,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -2321,4 +2322,5 @@ jobs:
       - name: mark release as non-draft
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
+
 

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -723,6 +723,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -706,6 +706,7 @@ class Axolotlsay < Formula
     pkgshare.install *leftover_contents unless leftover_contents.empty?
   end
 end
+
 ================ installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your


### PR DESCRIPTION
Alternate to #354 - append trailing a trailing newline if the rendered template doesn't have one. minijinja always strips trailing newlines; this is likely easier than always remembering to add an extra newline to templates.

Closes #354.