### PR TITLE
chore: regenerate snapshots

### DIFF
--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2144,14 +2144,14 @@ permissions:
 # package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
 #
 # If PACKAGE_NAME isn't specified, then we will create a Github Release™ for all
-# (cargo-dist-able) packages in the workspace with that version (this is mode is
+# (cargo-dist-able) packages in the workspace with that version (this mode is
 # intended for workspaces with only one dist-able package, or with all dist-able
 # packages versioned/released in lockstep).
 #
 # If you push multiple tags at once, separate instances of this workflow will
 # spin up, creating an independent Github Release™ for each one.
 #
-# If there's a prerelease-style suffix to the version then the Github Release™
+# If there's a prerelease-style suffix to the version, then the Github Release™
 # will be marked as a prerelease.
 on:
   push:
@@ -2239,7 +2239,7 @@ jobs:
           gh release upload ${{ github.ref_name }} $(cat uploads.txt)
           echo "uploaded!"
 
-  # Build and packages all the platform-agnostic(ish) things
+  # Build and package all the platform-agnostic(ish) things
   upload-global-artifacts:
     needs: upload-local-artifacts
     runs-on: "ubuntu-20.04"


### PR DESCRIPTION
two merges raced by changing the template and adding a new snapshot