### PR TITLE
feat(ci): cleanup default/init logic for pr_run_mode

### DIFF
--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -119,17 +119,18 @@ pub struct GithubMatrixEntry {
 }
 
 /// Type of job to run on pull request
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
-#[non_exhaustive]
+#[derive(
+    Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq, PartialOrd, Ord,
+)]
 pub enum PrRunMode {
     /// Do not run on pull requests at all
     #[serde(rename = "skip")]
     Skip,
     /// Only run the plan step
+    #[default]
     #[serde(rename = "plan")]
     Plan,
     /// Build and upload artifacts
-    #[default]
     #[serde(rename = "upload")]
     Upload,
 }

--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -91,7 +91,7 @@ impl GithubCiInfo {
             None
         };
 
-        let pr_run_mode = dist.pr_run_mode.clone();
+        let pr_run_mode = dist.pr_run_mode;
         let allow_dirty = dist.allow_dirty.contains(&CiStyle::Github);
 
         let tap = dist.tap.clone();

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -148,7 +148,7 @@ fn build_manifest(cfg: &Config, dist: &DistGraph) -> DistManifest {
         let CiInfo { github } = &dist.ci;
         let github = github.as_ref().map(|info| cargo_dist_schema::GithubCiInfo {
             artifacts_matrix: Some(info.artifacts_matrix.clone()),
-            pr_run_mode: Some(info.pr_run_mode.clone()),
+            pr_run_mode: Some(info.pr_run_mode),
             allow_dirty: Some(info.allow_dirty),
         });
 

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -720,7 +720,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 variants: vec![],
                 releases: vec![],
                 ci: CiInfo::default(),
-                pr_run_mode: workspace_metadata.pr_run_mode.clone().unwrap_or_default(),
+                pr_run_mode: workspace_metadata.pr_run_mode.unwrap_or_default(),
                 tap: workspace_metadata.tap.clone(),
                 publish_jobs,
                 allow_dirty,

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1262,7 +1262,7 @@ Install-Binary "$Args"
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -1262,7 +1262,7 @@ Install-Binary "$Args"
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2135,7 +2135,7 @@ maybeInstall(true).then(run);
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2135,7 +2135,7 @@ maybeInstall(true).then(run);
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -2135,7 +2135,7 @@ maybeInstall(true).then(run);
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1264,7 +1264,7 @@ Install-Binary "$Args"
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1244,7 +1244,7 @@ Install-Binary "$Args"
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1244,7 +1244,7 @@ Install-Binary "$Args"
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1244,7 +1244,7 @@ Install-Binary "$Args"
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1244,7 +1244,7 @@ Install-Binary "$Args"
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1244,7 +1244,7 @@ Install-Binary "$Args"
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1244,7 +1244,7 @@ Install-Binary "$Args"
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1244,7 +1244,7 @@ Install-Binary "$Args"
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1244,7 +1244,7 @@ Install-Binary "$Args"
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": true
     }
   }

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -15,7 +15,7 @@ stdout:
   "ci": {
     "github": {
       "artifacts_matrix": {},
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": false
     }
   }

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -15,7 +15,7 @@ stdout:
   "ci": {
     "github": {
       "artifacts_matrix": {},
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": false
     }
   }

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -258,7 +258,7 @@ stdout:
           }
         ]
       },
-      "pr_run_mode": "upload",
+      "pr_run_mode": "plan",
       "allow_dirty": false
     }
   }


### PR DESCRIPTION
* make plan the default (as originally agreed?)
* make the init code actually remember what you had set before
* make the init code not write a value if it's the default
* make the init code produce compile errors if a new PrRunMode is added
* rework the prompt order/messages to be clearer