### PR TITLE
Correctly set version when found

### DIFF
--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -2286,6 +2286,8 @@ pub(crate) fn parse_tag(
         // Now parse the version out
         match tag_suffix.parse::<Version>() {
             Ok(version) => {
+                announcing_version = Some(version.clone());
+
                 // Register whether we're announcing a prerelease
                 announcing_prerelease = !version.pre.is_empty();
 
@@ -2302,10 +2304,6 @@ pub(crate) fn parse_tag(
                             });
                         }
                     }
-                } else {
-                    // We had no announcing_package, so looks like we're doing a unified release.
-                    // Set this value to indicate that.
-                    announcing_version = Some(version);
                 }
             }
             Err(e) => {


### PR DESCRIPTION
Fixes #394

Looks like we weren't setting the `announcing_version` when:
- There is a pkg_idx in tasks.rs:l2295, but
- There is no error case

This changes the behaviour to set the version before the conditional blocks, since we're erroring out if the condition is hit anyway.

--------------

We could also have solved the issue, like this, if we want to avoid the `.clone()`:
```diff
if let Some(pkg_idx) = announcing_package {
    let package = graph.workspace().package(pkg_idx);
    if let Some(real_version) = &package.version {
        if real_version.cargo() != &version {
            return Err(DistError::ContradictoryTagVersion {
                tag: tag.clone(),
                package_name: package.name.clone(),
                tag_version: version,
                real_version: real_version.clone(),
            });
+        } else {
+            announcing_version = Some(version);
+        }
+    } else {
+        announcing_version = Some(version);
+    }
} else {
    // We had no announcing_package, so looks like we're doing a unified release.
    // Set this value to indicate that.
    announcing_version = Some(version);
}
```