### PR TITLE
docs(install): remove --profile=dist

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -23,10 +23,8 @@ irm https://github.com/axodotdev/cargo-dist/releases/latest/download/cargo-dist-
 ## Build From Source With Cargo
 
 ```sh
-cargo install cargo-dist --locked --profile=dist
+cargo install cargo-dist --locked
 ```
-
-(`--profile=dist` is the profile we build our shippable binaries with, it's optional.)
 
 
 ## Install Prebuilt Binaries With cargo-binstall


### PR DESCRIPTION
This doesn't actually work with the dist profile in the workspace `Cargo.toml`.

Fixes #399.