### PR TITLE
fix(check): analysis uses --artifacts=all

### DIFF
--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -2009,7 +2009,7 @@ impl DistGraph {
 
 /// Precompute all the work this invocation will need to do
 pub fn gather_work(cfg: &Config) -> Result<DistGraph> {
-    eprintln!("analyzing workspace:");
+    info!("analyzing workspace:");
     let tools = tool_info()?;
     let workspace = crate::config::get_project()?;
     let mut graph =
@@ -2405,16 +2405,16 @@ pub(crate) fn parse_tag(
         let sty;
         if let Some(reason) = &disabled_reason {
             sty = &disabled_sty;
-            eprintln!("  {}", sty.apply_to(format!("{pkg_name} ({reason})")));
+            info!("  {}", sty.apply_to(format!("{pkg_name} ({reason})")));
         } else {
             sty = &enabled_sty;
-            eprintln!("  {}", sty.apply_to(pkg_name));
+            info!("  {}", sty.apply_to(pkg_name));
         }
 
         // Report each binary and potentially add it to the Release for this package
         let mut rust_binaries = vec![];
         for binary in &pkg.binaries {
-            eprintln!("    {}", sty.apply_to(format!("[bin] {}", binary)));
+            info!("    {}", sty.apply_to(format!("[bin] {}", binary)));
             // In the future might want to allow this to be granular for each binary
             if disabled_reason.is_none() {
                 rust_binaries.push(binary.to_owned());
@@ -2426,7 +2426,6 @@ pub(crate) fn parse_tag(
             rust_releases.push((pkg_id, rust_binaries));
         }
     }
-    eprintln!();
 
     // Don't proceed if this doesn't make sense
     if rust_releases.is_empty() {

--- a/cargo-dist/tests/snapshots/error_manifest.snap
+++ b/cargo-dist/tests/snapshots/error_manifest.snap
@@ -6,11 +6,6 @@ stdout:
 {"diagnostic": {"message": "This workspace doesn't have anything for cargo-dist to Release!","severity": "error","causes": [],"labels": [],"related": []}}
 
 stderr:
-analyzing workspace:
-  cargo-dist (didn't match tag v1.0.0-FAKEVERSION)
-    [bin] cargo-dist
-  cargo-dist-schema (no binaries)
-
   × This workspace doesn't have anything for cargo-dist to Release!
 
 

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -23,10 +23,5 @@ stdout:
 }
 
 stderr:
-analyzing workspace:
-  cargo-dist (didn't match tag cargo-dist-schema-v1.0.0-FAKEVERSION)
-    [bin] cargo-dist
-  cargo-dist-schema (no binaries)
-
  WARN You're trying to explicitly Release a library, only minimal functionality will work
 

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -23,10 +23,5 @@ stdout:
 }
 
 stderr:
-analyzing workspace:
-  cargo-dist (didn't match tag cargo-dist-schema/v1.0.0-FAKEVERSION)
-    [bin] cargo-dist
-  cargo-dist-schema (no binaries)
-
  WARN You're trying to explicitly Release a library, only minimal functionality will work
 

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -265,9 +265,4 @@ stdout:
 }
 
 stderr:
-analyzing workspace:
-  cargo-dist
-    [bin] cargo-dist
-  cargo-dist-schema (no binaries)
-
 


### PR DESCRIPTION
Fixes an issue where the preflight config check would use whichever artifact options the user had passed. If --artifacts=local was passed, we would be inappropriately flagging GitHub CI as out of date because we'd try to omit the global artifacts.