### PR TITLE
feat(init): various fixes/improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.3.0-prerelease.4/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.3.0-prerelease.5/cargo-dist-installer.sh | sh"
       - id: plan
         run: |
           cargo dist plan ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }} --output-format=json > dist-manifest.json
@@ -131,7 +131,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.3.0-prerelease.4/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.3.0-prerelease.5/cargo-dist-installer.sh | sh"
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.3.0-prerelease.5/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.3.0-prerelease.4/cargo-dist-installer.sh | sh"
       - id: plan
         run: |
           cargo dist plan ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }} --output-format=json > dist-manifest.json
@@ -131,7 +131,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.3.0-prerelease.5/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.3.0-prerelease.4/cargo-dist-installer.sh | sh"
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
         uses: actions/download-artifact@v3

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -314,7 +314,7 @@ fn get_new_dist_metadata(
         // Prettify/sort things
         let desc = move |triple: &str| -> String {
             let pretty = triple_to_display_name(triple).unwrap_or("[unknown]");
-            format!("{pretty} - {triple}")
+            format!("{pretty} ({triple})")
         };
         known.sort_by_cached_key(|k| desc(k).to_uppercase());
 

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -759,14 +759,12 @@ pub fn default_desktop_targets() -> Vec<String> {
     vec![
         // Everyone can build x64!
         axoproject::platforms::TARGET_X64_LINUX_GNU.to_owned(),
-        axoproject::platforms::TARGET_ARM64_LINUX_GNU.to_owned(),
+        axoproject::platforms::TARGET_X64_WINDOWS.to_owned(),
         axoproject::platforms::TARGET_X64_MAC.to_owned(),
         // Apple is really easy to cross from Apple
-        axoproject::platforms::TARGET_ARM64_MAC
-            .to_owned()
-            .to_owned(),
+        axoproject::platforms::TARGET_ARM64_MAC.to_owned(),
         // other cross-compiles not yet supported
-        // axoproject::platforms::TARGET_X64_WINDOWS.to_owned(),
+        // axoproject::platforms::TARGET_ARM64_LINUX_GNU.to_owned(),
         // axoproject::platforms::TARGET_ARM64_WINDOWS.to_owned(),
     ]
 }

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -753,3 +753,20 @@ fn generate_installer(dist: &DistGraph, style: &InstallerImpl) -> Result<()> {
     }
     Ok(())
 }
+
+/// Get the default list of targets
+pub fn default_desktop_targets() -> Vec<String> {
+    vec![
+        // Everyone can build x64!
+        axoproject::platforms::TARGET_X64_LINUX_GNU.to_owned(),
+        axoproject::platforms::TARGET_ARM64_LINUX_GNU.to_owned(),
+        axoproject::platforms::TARGET_X64_MAC.to_owned(),
+        // Apple is really easy to cross from Apple
+        axoproject::platforms::TARGET_ARM64_MAC
+            .to_owned()
+            .to_owned(),
+        // other cross-compiles not yet supported
+        // axoproject::platforms::TARGET_X64_WINDOWS.to_owned(),
+        // axoproject::platforms::TARGET_ARM64_WINDOWS.to_owned(),
+    ]
+}

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -202,18 +202,12 @@ fn cmd_plan(cli: &Cli, _args: &PlanArgs) -> Result<(), miette::Report> {
 }
 
 fn cmd_init(cli: &Cli, args: &InitArgs) -> Result<(), miette::Report> {
-    // This command is more automagic, so provide default targets if none are chosen
-    let targets = if cli.target.is_empty() {
-        default_desktop_targets()
-    } else {
-        cli.target.clone()
-    };
     let config = cargo_dist::config::Config {
         needs_coherent_announcement_tag: false,
         artifact_mode: cargo_dist::config::ArtifactMode::All,
         no_local_paths: cli.no_local_paths,
         allow_all_dirty: cli.allow_dirty,
-        targets,
+        targets: cli.target.clone(),
         ci: cli.ci.iter().map(|ci| ci.to_lib()).collect(),
         installers: cli.installer.iter().map(|ins| ins.to_lib()).collect(),
         announcement_tag: cli.tag.clone(),
@@ -252,20 +246,6 @@ fn cmd_generate_ci(cli: &Cli, args: &GenerateCiArgs) -> Result<(), miette::Repor
             mode: vec![GenerateMode::Ci],
         },
     )
-}
-
-fn default_desktop_targets() -> Vec<String> {
-    vec![
-        // Everyone can build x64!
-        "x86_64-unknown-linux-gnu".to_owned(),
-        "x86_64-apple-darwin".to_owned(),
-        "x86_64-pc-windows-msvc".to_owned(),
-        // Apple is really easy to cross from Apple
-        "aarch64-apple-darwin".to_owned(),
-        // other cross-compiles not yet supported
-        // "aarch64-gnu-unknown-linux".to_owned(),
-        // "aarch64-pc-windows-msvc".to_owned(),
-    ]
 }
 
 fn cmd_help_md(_args: &Cli, _sub_args: &HelpMarkdownArgs) -> Result<(), miette::Report> {


### PR DESCRIPTION
* new target selection UI
* if you have Github CI enabled, we won't ask anymore
* if you have pr-run-mode set, we won't ask anymore (we also no longer omit it from output when the default is selected, so that we can distinguish new init from made-a-decision)
* extra unimportant words removed
* if you have no CI backend enabled we will still allow you to turn on msi
* we will always run generate at the end (unless --no-generate-ci is set) because generate now detects which parts need to run on its own (and the current logic was preventing CI-less MSI from working).
* `[profile]` de-emphasized, sent to the end, not mentioned if unchanged