### PR TITLE
chore: add oranda to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /target
 *.snap.new
 /book/book/
-oranda-debug.log
-cargo-dist/public
 cargo-dist/wix
+
+# Oranda
+oranda-debug.log
+/public
+cargo-dist/public


### PR DESCRIPTION
This ensures that `oranda dev` doesn't generate untracked changes visible to `git status`.