### PR TITLE
chore(docs): Fix link in cargo-dist-schema readme

### DIFF
--- a/cargo-dist-schema/README.md
+++ b/cargo-dist-schema/README.md
@@ -5,7 +5,7 @@
 
 Schema reporting/parsing for cargo-dist's `dist-manifest.json`, which is the result you get from `--output-format=json` when running `cargo dist build` or `cargo dist plan`.
 
-[Read the schema and docs here!][https://axodotdev.github.io/cargo-dist/book/schema.html]
+[Read our documentation here!](https://opensource.axo.dev/cargo-dist/book/)
 
 This can be used to parse the machine-readable manifests produced by cargo-dist. Ideally it should be forward and backward compatible with newer and older versions of the manifests.
 


### PR DESCRIPTION
Fix link to the book. The linked target did not exist anymore. The used markdown  was not correctly rendered on crates.io.
Screenshot of the previous state:
![image](https://github.com/axodotdev/cargo-dist/assets/905857/e6147ceb-33c6-460a-9bf9-b60136047c04)

I adapted the target to a site that exists. Because the schema is not described (anymore?) in the book I also updated the link text.