### PR TITLE
chore(docs): Fix formating in cargo_dist::GenerateArgs doc comment

### DIFF
--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -612,7 +612,7 @@ fn zip_dir(
     Ok(())
 }
 
-/// Arguments for `cargo dist generate` ([`do_generate][])
+/// Arguments for `cargo dist generate` ([`do_generate`][])
 #[derive(Debug)]
 pub struct GenerateArgs {
     /// Check whether the output differs without writing to disk


### PR DESCRIPTION
Add missing backtick in doc comment of cargo_dist::GenerateArgs.

Previous rendering on docs.rs:
![image](https://github.com/axodotdev/cargo-dist/assets/905857/16790e54-c66b-442d-8906-e3ed9a7d1ea8)

Rendering on my PC with the proposed change:
![image](https://github.com/axodotdev/cargo-dist/assets/905857/e1ee5e6a-04f0-4f39-a2be-bf0fac755273)
