### PR TITLE
chore: update with latest clippy fixes

### DIFF
--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -266,7 +266,7 @@ fn get_new_dist_metadata(
             if response {
                 meta.cargo_dist_version = Some(current_version);
             } else {
-                return Err(DistError::NoUpdateVersion {
+                Err(DistError::NoUpdateVersion {
                     project_version: desired_version.clone(),
                     running_version: current_version,
                 })?;
@@ -451,10 +451,10 @@ fn get_new_dist_metadata(
             }
         });
         if let Some(inner) = conflict {
-            return Err(DistError::CantEnableGithubUrlInconsistent { inner })?;
+            Err(DistError::CantEnableGithubUrlInconsistent { inner })?;
         } else {
             // Otherwise assume no URL
-            return Err(DistError::CantEnableGithubNoUrl)?;
+            Err(DistError::CantEnableGithubNoUrl)?;
         }
     }
 
@@ -691,7 +691,7 @@ fn get_new_dist_metadata(
                 meta.unix_archive = TAR_GZ;
                 meta.windows_archive = TAR_GZ;
             } else {
-                return Err(DistError::MustEnableTarGz)?;
+                Err(DistError::MustEnableTarGz)?;
             }
         }
     }

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -671,7 +671,7 @@ pub fn run_generate(dist: &DistGraph, args: &GenerateArgs) -> Result<()> {
             if !dist.allow_dirty.should_run(mode)
                 && matches!(dist.allow_dirty, DirtyMode::AllowList(..))
             {
-                return Err(DistError::ContradictoryGenerateModes {
+                Err(DistError::ContradictoryGenerateModes {
                     generate_mode: mode,
                 })?;
             }


### PR DESCRIPTION
The new clippy included with Rust 1.73.0 flags some more things in our `main` branch. We need this to make CI green again.