### PR TITLE
feat(homebrew): use linkage to infer deps

### DIFF
--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -108,6 +108,9 @@ pub struct GithubMatrix {
 /// Entry for a github matrix
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct GithubMatrixEntry {
+    /// Targets to build for
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub targets: Option<Vec<String>>,
     /// Github Runner to user
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner: Option<String>,

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -426,6 +426,16 @@ expression: json_schema
             "string",
             "null"
           ]
+        },
+        "targets": {
+          "description": "Targets to build for",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -86,6 +86,7 @@ impl GithubCiInfo {
         // fast/cheap, so that's a reasonable choice.s
         let global_task = if needs_global_build {
             Some(GithubMatrixEntry {
+                targets: None,
                 runner: Some(GITHUB_LINUX_RUNNER.into()),
                 dist_args: Some("--artifacts=global".into()),
                 install_dist: Some(install_dist_sh.clone()),
@@ -116,6 +117,7 @@ impl GithubCiInfo {
                 write!(dist_args, " --target={target}").unwrap();
             }
             tasks.push(GithubMatrixEntry {
+                targets: Some(targets.iter().map(|s| s.to_string()).collect()),
                 runner: Some(runner.to_owned()),
                 dist_args: Some(dist_args),
                 install_dist: Some(install_dist.to_owned()),

--- a/cargo-dist/src/backend/installer/homebrew.rs
+++ b/cargo-dist/src/backend/installer/homebrew.rs
@@ -1,7 +1,8 @@
 //! Code for generating installer.sh
 
-use axoasset::LocalAsset;
+use axoasset::{LocalAsset, SourceFile};
 use camino::Utf8PathBuf;
+use cargo_dist_schema::DistManifest;
 use serde::Serialize;
 
 use super::InstallerInfo;
@@ -48,6 +49,41 @@ pub(crate) fn write_homebrew_formula(
     source_info: &HomebrewInstallerInfo,
 ) -> DistResult<()> {
     let mut info = source_info.clone();
+
+    // Collect all dist-manifests and fetch the appropriate Mac ones
+    let mut manifests = vec![];
+    for file in graph.dist_dir.read_dir()? {
+        let path = file?.path();
+        if let Some(filename) = path.file_name() {
+            if !filename.to_string_lossy().ends_with("-dist-manifest.json") {
+                continue;
+            }
+        }
+
+        let json_path = Utf8PathBuf::try_from(path)?;
+        let data = SourceFile::load_local(json_path)?;
+        let manifest: DistManifest = data.deserialize_json()?;
+
+        if manifest.linkage.iter().any(|l| {
+            info.arm64.is_some() && l.target == "aarch64-apple-darwin"
+                || info.x86_64.is_some() && l.target == "x86_64-apple-darwin"
+        }) {
+            manifests.push(manifest);
+        }
+    }
+
+    // Fetch any detected dependencies from the linkage data
+    let dependencies = manifests.into_iter().flat_map(|m| {
+        m.linkage.into_iter().map(|l| {
+            l.homebrew
+                .into_iter()
+                .filter_map(|lib| lib.source)
+                .collect()
+        })
+    });
+
+    // Merge with the manually-specified deps
+    info.dependencies.extend(dependencies);
 
     // Generate sha256 as late as possible; the artifacts might not exist
     // earlier to do that.

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -259,6 +259,10 @@ pub enum DistError {
     /// random i/o error
     #[error(transparent)]
     Goblin(#[from] goblin::error::Error),
+
+    /// random camino conversion error
+    #[error(transparent)]
+    FromPathBufError(#[from] camino::FromPathBufError),
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/templates/ci/github_ci.yml.j2
+++ b/cargo-dist/templates/ci/github_ci.yml.j2
@@ -104,6 +104,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -141,11 +142,15 @@ jobs:
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
-          path: ${{ steps.cargo-dist.outputs.paths }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
 
 {{%- if global_task %}}
 
@@ -327,6 +332,10 @@ jobs:
         with:
           name: artifacts
           path: artifacts
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm artifacts/*-dist-manifest.json
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1242,21 +1242,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
@@ -1366,6 +1378,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1401,11 +1414,15 @@ jobs:
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
-          path: ${{ steps.cargo-dist.outputs.paths }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
 
   # Build and package all the platform-agnostic(ish) things
   upload-global-artifacts:
@@ -1503,6 +1520,10 @@ jobs:
         with:
           name: artifacts
           path: artifacts
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm artifacts/*-dist-manifest.json
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -1242,21 +1242,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
@@ -1366,6 +1378,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1401,11 +1414,15 @@ jobs:
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
-          path: ${{ steps.cargo-dist.outputs.paths }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
 
   # Build and package all the platform-agnostic(ish) things
   upload-global-artifacts:
@@ -1503,6 +1520,10 @@ jobs:
         with:
           name: artifacts
           path: artifacts
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm artifacts/*-dist-manifest.json
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2141,21 +2141,33 @@ maybeInstall(true).then(run);
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
@@ -2263,6 +2275,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -2296,11 +2309,15 @@ jobs:
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
-          path: ${{ steps.cargo-dist.outputs.paths }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
 
   # Build and package all the platform-agnostic(ish) things
   upload-global-artifacts:
@@ -2396,6 +2413,10 @@ jobs:
         with:
           name: artifacts
           path: artifacts
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm artifacts/*-dist-manifest.json
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2116,21 +2116,33 @@ maybeInstall(true).then(run);
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
@@ -2238,6 +2250,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -2271,11 +2284,15 @@ jobs:
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
-          path: ${{ steps.cargo-dist.outputs.paths }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
 
   # Build and package all the platform-agnostic(ish) things
   upload-global-artifacts:
@@ -2371,6 +2388,10 @@ jobs:
         with:
           name: artifacts
           path: artifacts
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm artifacts/*-dist-manifest.json
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -2116,21 +2116,33 @@ maybeInstall(true).then(run);
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
@@ -2238,6 +2250,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -2271,11 +2284,15 @@ jobs:
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
-          path: ${{ steps.cargo-dist.outputs.paths }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
 
   # Build and package all the platform-agnostic(ish) things
   upload-global-artifacts:
@@ -2337,6 +2354,10 @@ jobs:
         with:
           name: artifacts
           path: artifacts
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm artifacts/*-dist-manifest.json
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1234,21 +1234,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
@@ -1356,6 +1368,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1389,11 +1402,15 @@ jobs:
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
-          path: ${{ steps.cargo-dist.outputs.paths }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
 
   # Build and package all the platform-agnostic(ish) things
   upload-global-artifacts:
@@ -1510,6 +1527,10 @@ jobs:
         with:
           name: artifacts
           path: artifacts
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm artifacts/*-dist-manifest.json
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1234,21 +1234,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
@@ -1356,6 +1368,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1389,11 +1402,15 @@ jobs:
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
-          path: ${{ steps.cargo-dist.outputs.paths }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
 
   # Build and package all the platform-agnostic(ish) things
   upload-global-artifacts:
@@ -1510,6 +1527,10 @@ jobs:
         with:
           name: artifacts
           path: artifacts
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm artifacts/*-dist-manifest.json
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -2116,21 +2116,33 @@ maybeInstall(true).then(run);
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
@@ -2238,6 +2250,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -2271,11 +2284,15 @@ jobs:
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
-          path: ${{ steps.cargo-dist.outputs.paths }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
 
   # Build and package all the platform-agnostic(ish) things
   upload-global-artifacts:
@@ -2387,6 +2404,10 @@ jobs:
         with:
           name: artifacts
           path: artifacts
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm artifacts/*-dist-manifest.json
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1244,21 +1244,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1224,21 +1224,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1224,21 +1224,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1224,21 +1224,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1224,21 +1224,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1224,21 +1224,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1224,21 +1224,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1224,21 +1224,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1224,21 +1224,33 @@ Install-Binary "$Args"
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -238,21 +238,33 @@ stdout:
       "artifacts_matrix": {
         "include": [
           {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
           },
           {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "runner": "windows-2019",
             "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.ps1 | iex",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"


### PR DESCRIPTION
As planned in #426 and #428, this leverages the linkage reporter to detect which packages to add as dependencies to the Homebrew formula. Even if the user doesn't specify them as runtime dependencies, if we saw that a Homebrew package was dynamically linked against, we'll add it to the list of dependencies.

This requires us to store linkage data between runs so we can fetch it later. We do that by storing the dist metadata after each build in the temporary artifact bucket, and then download it at the time we build the Homebrew formula in order to gain access to linkage data for every build.

For a sample of how this was used, I tested with a package which specified two Mac dependencies:

```toml
[workspace.metadata.dist.dependencies.homebrew]
cmake = { targets = ["x86_64-apple-darwin"] }
libcue = { version = "2.2.1", targets = ["x86_64-apple-darwin"] }
```

Neither is marked as a runtime dependency. The linkage report was able to correctly determine that libcue would be needed at runtime, and add it as a dependency, while cmake would not. https://github.com/mistydemeo/homebrew-cargodisttest/commit/c5127d36c12e985d53a2d7c5501cd1a5e15338ac