### PR TITLE
feat(installers): pass data from local builds to global

### DIFF
--- a/cargo-dist/src/backend/installer/homebrew.rs
+++ b/cargo-dist/src/backend/installer/homebrew.rs
@@ -47,11 +47,12 @@ pub(crate) fn write_homebrew_formula(
     templates: &Templates,
     graph: &DistGraph,
     source_info: &HomebrewInstallerInfo,
+    manifests: &[DistManifest],
 ) -> DistResult<()> {
     let mut info = source_info.clone();
 
     // Collect all dist-manifests and fetch the appropriate Mac ones
-    let mut manifests = vec![];
+    let mut manifests = manifests.to_owned();
     for file in graph.dist_dir.read_dir()? {
         let path = file?.path();
         if let Some(filename) = path.file_name() {

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -72,8 +72,13 @@ pub fn do_build(cfg: &Config) -> Result<DistManifest> {
     }
     eprintln!();
 
-    // Run all the build steps
-    for step in &dist.build_steps {
+    // Run all the local build steps first
+    for step in &dist.local_build_steps {
+        run_build_step(&dist, step)?;
+    }
+
+    // Next the global steps
+    for step in &dist.global_build_steps {
         run_build_step(&dist, step)?;
     }
 

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -187,9 +187,9 @@ pub struct DistGraph {
     /// Base URL that artifacts are downloadable from ("{artifact_download_url}/{artifact.id}")
     pub artifact_download_url: Option<String>,
 
-    /// Targets we need to build
+    /// Targets we need to build (local artifacts)
     pub local_build_steps: Vec<BuildStep>,
-    /// Targets we need to build
+    /// Targets we need to build (global artifacts)
     pub global_build_steps: Vec<BuildStep>,
     /// Distributable artifacts we want to produce for the releases
     pub artifacts: Vec<Artifact>,


### PR DESCRIPTION
This is a followup to #475. In that PR, I enabled reusing previous dist manifests from previous builds in a CI environment. It doesn't, however, cover the case where the previous builds happened within the *same run*. This fixes that. I've split local/global builds into separate categories from each other, instead of just by ordering them within a single array. I then added a temporary computation of dist manifests after local builds are run, but before global builds are run; that temporary manifest is then passed to any global job that cares to ask for it. Currently, it's only consumed by the Homebrew installer, but it might be wanted by something else later.