### PR TITLE
fix(linkage): handle static executables

### DIFF
--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -1108,6 +1108,13 @@ fn do_ldd(path: &Utf8PathBuf) -> DistResult<Vec<String>> {
 
     for line in lines {
         let line = line.trim();
+
+        // There's no dynamic linkage at all; we can safely break,
+        // there will be nothing useful to us here.
+        if line.starts_with("not a dynamic executable") {
+            break;
+        }
+
         // Not a library that actually concerns us
         if line.starts_with("linux-vdso") {
             continue;


### PR DESCRIPTION
We don't currently have a supported path that produces these, but musl builds will encounter it. Rather than try to parse a file like this, if we see this message we can immediately return from the `ldd` parser.