### PR TITLE
release: 0.4.0-prerelease.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-This release contains several major features related to package dependencies. cargo-dist can now install dependencies for you in CI, ensure your users have those dependencies in their installers, and provide you insights into what external libraries your package links against!
+This release contains several major features related to package dependencies. cargo-dist can now install dependencies for you in CI, ensure your users have those dependencies in their installers, and provide you insights into what external libraries your package links against! It also enables support for statically-built musl binaries on Linux.
 
 ## Features
 
@@ -37,6 +37,15 @@ This feature has full support for macOS and Linux. On Windows, we're not able to
     * @mistydemeo [infer dependencies via linkage](https://github.com/axodotdev/cargo-dist/pull/475)
     * @mistydemeo [fetch full name of Homebrew tap](https://github.com/axodotdev/cargo-dist/pull/474)
 
+
+### musl support
+
+This release adds support for a long-requested feature, creating Linux binaries statically linked against musl instead of glibc. These can be enabled adding the `x86_64-unknown-linux-musl` target triple to your list of desired targets.
+
+Note that because these binaries are statically linked, they cannot dynamically link against any other C libraries &mdash; including C libraries installed using the system dependency feature mentioned above. If your software links against system libraries, please ensure that a static library is available to the build.
+
+* impl
+    * @mistydemeo [initial impl](https://github.com/axodotdev/cargo-dist/pull/483)
 
 
 # Version 0.3.1 (2023-09-28)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.4.0-prerelease.1"
+version = "0.4.0-prerelease.2"
 dependencies = [
  "axoasset",
  "axocli",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.4.0-prerelease.1"
+version = "0.4.0-prerelease.2"
 dependencies = [
  "camino",
  "insta",

--- a/cargo-dist-schema/Cargo.toml
+++ b/cargo-dist-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-dist-schema"
 description = "Schema information for cargo-dist's dist-manifest.json"
-version = "0.4.0-prerelease.1"
+version = "0.4.0-prerelease.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-dist"
 description = "Shippable application packaging for Rust"
-version = "0.4.0-prerelease.1"
+version = "0.4.0-prerelease.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
@@ -30,7 +30,7 @@ clap-cargo = { version = "0.10.0", optional = true }
 axocli = { version = "0.1.0", optional = true }
 
 # Features used by the cli and library
-cargo-dist-schema = { version = "=0.4.0-prerelease.1", path = "../cargo-dist-schema" }
+cargo-dist-schema = { version = "=0.4.0-prerelease.2", path = "../cargo-dist-schema" }
 
 axoasset = { version = "0.5.1", features = ["json-serde", "toml-serde", "toml-edit", "compression"] }
 axoproject = { version = "0.4.7", default-features = false, features = ["cargo-projects"] }


### PR DESCRIPTION
This incorporates the static musl builds. We probably want to wait to release this until #486 and #485 are addressed.