### PR TITLE
fix(homebrew): correct map for inferred linkage

### DIFF
--- a/cargo-dist/src/backend/installer/homebrew.rs
+++ b/cargo-dist/src/backend/installer/homebrew.rs
@@ -75,12 +75,9 @@ pub(crate) fn write_homebrew_formula(
 
     // Fetch any detected dependencies from the linkage data
     let dependencies = manifests.into_iter().flat_map(|m| {
-        m.linkage.into_iter().map(|l| {
-            l.homebrew
-                .into_iter()
-                .filter_map(|lib| lib.source)
-                .collect()
-        })
+        m.linkage
+            .into_iter()
+            .flat_map(|l| l.homebrew.into_iter().filter_map(|lib| lib.source))
     });
 
     // Merge with the manually-specified deps


### PR DESCRIPTION
This fixes the one empty string that was being produced per manifest file being read.

Fixes #485.