### PR TITLE
Installers: add musl detection

### DIFF
--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1202,8 +1202,16 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         // Still, we think this is better than not trying at all.)
         const X64_MACOS: &str = "x86_64-apple-darwin";
         const ARM64_MACOS: &str = "aarch64-apple-darwin";
+        const X64_GNU: &str = "x86_64-unknown-linux-gnu";
+        const X64_MUSL: &str = "x86_64-unknown-linux-musl";
+        const X64_MUSL_STATIC: &str = "x86_64-unknown-linux-musl-static";
+        const X64_MUSL_DYNAMIC: &str = "x86_64-unknown-linux-musl-dynamic";
         let mut has_x64_apple = false;
         let mut has_arm_apple = false;
+        let mut has_gnu_linux = false;
+        let mut has_static_musl_linux = false;
+        // Currently always false, someday this build will exist
+        let has_dynamic_musl_linux = false;
         for &variant_idx in &release.variants {
             let variant = self.variant(variant_idx);
             let target = &variant.target;
@@ -1213,8 +1221,16 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             if target == ARM64_MACOS {
                 has_arm_apple = true;
             }
+            if target == X64_GNU {
+                has_gnu_linux = true;
+            }
+            if target == X64_MUSL {
+                has_static_musl_linux = true;
+            }
         }
         let do_rosetta_fallback = has_x64_apple && !has_arm_apple;
+        let do_gnu_to_musl_fallback = !has_gnu_linux && has_static_musl_linux;
+        let do_musl_to_musl_fallback = has_static_musl_linux && !has_dynamic_musl_linux;
 
         // Gather up the bundles the installer supports
         let mut artifacts = vec![];
@@ -1231,7 +1247,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             let (artifact, binaries) =
                 self.make_executable_zip_for_variant(to_release, variant_idx);
             target_triples.insert(target.clone());
-            let fragment = ExecutableZipFragment {
+            let mut fragment = ExecutableZipFragment {
                 id: artifact.id,
                 target_triples: artifact.target_triples,
                 zip_style: artifact.archive.as_ref().unwrap().zip_style,
@@ -1246,8 +1262,28 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 arm_fragment.target_triples = vec![ARM64_MACOS.to_owned()];
                 artifacts.push(arm_fragment);
             }
+            if target == X64_MUSL {
+                // musl-static is actually kind of a fake triple we've invented
+                // to let us specify which is which; we want to ensure it exists
+                // for the installer to act on
+                fragment.target_triples = vec![X64_MUSL_STATIC.to_owned()];
+            }
+            if do_gnu_to_musl_fallback && target == X64_MUSL {
+                // Copy the info but lie that it's actually glibc
+                let mut musl_fragment = fragment.clone();
+                musl_fragment.target_triples = vec![X64_GNU.to_owned()];
+                artifacts.push(musl_fragment);
+            }
+            if do_musl_to_musl_fallback && target == X64_MUSL {
+                // Copy the info but lie that it's actually dynamic musl
+                let mut musl_fragment = fragment.clone();
+                musl_fragment.target_triples = vec![X64_MUSL_DYNAMIC.to_owned()];
+                artifacts.push(musl_fragment);
+            }
+
             artifacts.push(fragment);
         }
+
         if artifacts.is_empty() {
             warn!("skipping shell installer: not building any supported platforms (use --artifacts=global)");
             return;

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -23,6 +23,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -445,13 +451,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 
@@ -716,4 +734,3 @@ downloader() {
 }
 
 download_binary_and_run_installer "$@" || exit 1
-

--- a/cargo-dist/templates/installer/npm/binary.js.j2
+++ b/cargo-dist/templates/installer/npm/binary.js.j2
@@ -13,13 +13,16 @@ const { version } = require("./package.json");
 const name = {{ inner.app_name }};
 const artifact_download_url = {{ inner.base_url }};
 
+const builder_glibc_major_version = 2;
+const builder_glibc_minor_version = 35;
+
 const supportedPlatforms = {
   {%- for artifact in inner.artifacts %}
   {{ artifact.target_triples[0] }}: {
     "artifact_name": {{ artifact.id }},
     "bins": {{ artifact.binaries }},
     "zip_ext": {{ artifact.zip_style }}
-  }{% if not loop.last %},{% endif %} 
+  }{% if not loop.last %},{% endif %}
   {%- endfor %}
 };
 
@@ -52,6 +55,29 @@ const getPlatform = () => {
       break;
   }
 
+  if (raw_os_type === "Linux") {
+    if (libc.familySync() == 'musl') {
+      os_type = "unknown-linux-musl-dynamic";
+    } else if (libc.isNonGlibcLinuxSync()) {
+        console.warn("Your libc is neither glibc nor musl; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+    } else {
+      let libc_version = libc.versionSync();
+      let split_libc_version = libc_version.split(".");
+      let libc_major_version = split_libc_version[0];
+      let libc_minor_version = split_libc_version[1];
+      if (
+        libc_major_version != builder_glibc_major_version ||
+        libc_minor_version < builder_glibc_minor_version
+      ) {
+        // We can't run the glibc binaries, but we can run the static musl ones
+        // if they exist
+        console.warn("Your glibc isn't compatible; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+      }
+    }
+  }
+
   // Assume the above succeeded and build a target triple to look things up with.
   // If any of it failed, this lookup will fail and we'll handle it like normal.
   let target_triple = `${arch}-${os_type}`;
@@ -61,28 +87,6 @@ const getPlatform = () => {
     error(
       `Platform with type "${raw_os_type}" and architecture "${raw_architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${Object.keys(supportedPlatforms).join(",")}`
     );
-  }
-
-  // These are both situation where you might toggle to unknown-linux-musl but we don't support that yet
-  if (raw_os_type === "Linux") {
-    if (libc.isNonGlibcLinuxSync()) {
-      error("This operating system does not support dynamic linking to glibc.");
-    } else {
-      let libc_version = libc.versionSync();
-      let split_libc_version = libc_version.split(".");
-      let libc_major_version = split_libc_version[0];
-      let libc_minor_version = split_libc_version[1];
-      let min_major_version = 2;
-      let min_minor_version = 17;
-      if (
-        libc_major_version < min_major_version ||
-        libc_minor_version < min_minor_version
-      ) {
-        error(
-          `This operating system needs glibc >= ${min_major_version}.${min_minor_version}, but only has ${libc_version} installed.`
-        );
-      }
-    }
   }
 
   return platform;
@@ -118,4 +122,3 @@ module.exports = {
   run,
   getBinary,
 };
-

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -226,68 +226,6 @@ scope = "@axodotdev"
 }
 
 #[test]
-fn axolotlsay_musl() -> Result<(), miette::Report> {
-    let test_name = _function_name!();
-    AXOLOTLSAY.run_test(|ctx| {
-        let dist_version = ctx.tools.cargo_dist.version().unwrap();
-        ctx.patch_cargo_toml(format!(
-            r#"
-[workspace.metadata.dist]
-cargo-dist-version = "{dist_version}"
-installers = ["shell", "npm"]
-targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "aarch64-apple-darwin", "x86_64-apple-darwin"]
-ci = ["github"]
-unix-archive = ".tar.gz"
-windows-archive = ".tar.gz"
-scope = "@axodotdev"
-
-"#
-        ))?;
-
-        // Run generate to make sure stuff is up to date before running other commands
-        let ci_result = ctx.cargo_dist_generate(test_name)?;
-        let ci_snap = ci_result.check_all()?;
-        // Do usual build+plan checks
-        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
-        let main_snap = main_result.check_all(ctx, ".cargo/bin/")?;
-        // snapshot all
-        main_snap.join(ci_snap).snap();
-        Ok(())
-    })
-}
-
-#[test]
-fn axolotlsay_musl_no_gnu() -> Result<(), miette::Report> {
-    let test_name = _function_name!();
-    AXOLOTLSAY.run_test(|ctx| {
-        let dist_version = ctx.tools.cargo_dist.version().unwrap();
-        ctx.patch_cargo_toml(format!(
-            r#"
-[workspace.metadata.dist]
-cargo-dist-version = "{dist_version}"
-installers = ["shell", "npm"]
-targets = ["x86_64-unknown-linux-musl", "aarch64-apple-darwin", "x86_64-apple-darwin"]
-ci = ["github"]
-unix-archive = ".tar.gz"
-windows-archive = ".tar.gz"
-scope = "@axodotdev"
-
-"#
-        ))?;
-
-        // Run generate to make sure stuff is up to date before running other commands
-        let ci_result = ctx.cargo_dist_generate(test_name)?;
-        let ci_snap = ci_result.check_all()?;
-        // Do usual build+plan checks
-        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
-        let main_snap = main_result.check_all(ctx, ".cargo/bin/")?;
-        // snapshot all
-        main_snap.join(ci_snap).snap();
-        Ok(())
-    })
-}
-
-#[test]
 fn akaikatana_basic() -> Result<(), miette::Report> {
     let test_name = _function_name!();
     AKAIKATANA_REPACK.run_test(|ctx| {
@@ -377,66 +315,6 @@ windows-archive = ".tar.gz"
         let results = ctx.cargo_dist_build_and_plan(test_name)?;
         results.check_all(ctx, ".cargo/bin/")?.snap();
 
-        Ok(())
-    })
-}
-
-#[test]
-fn akaikatana_musl() -> Result<(), miette::Report> {
-    let test_name = _function_name!();
-    AKAIKATANA_REPACK.run_test(|ctx| {
-        let dist_version = ctx.tools.cargo_dist.version().unwrap();
-
-        ctx.patch_cargo_toml(format!(
-            r#"
-[workspace.metadata.dist]
-cargo-dist-version = "{dist_version}"
-rust-toolchain-version = "1.67.1"
-ci = ["github"]
-installers = ["shell"]
-targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "aarch64-apple-darwin", "x86_64-apple-darwin"]
-
-"#
-        ))?;
-
-        // Run generate to make sure stuff is up to date before running other commands
-        let ci_result = ctx.cargo_dist_generate(test_name)?;
-        let ci_snap = ci_result.check_all()?;
-        // Do usual build+plan checks
-        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
-        let main_snap = main_result.check_all(ctx, ".cargo/bin/")?;
-        // snapshot all
-        main_snap.join(ci_snap).snap();
-        Ok(())
-    })
-}
-
-#[test]
-fn akaikatana_musl_no_gnu() -> Result<(), miette::Report> {
-    let test_name = _function_name!();
-    AKAIKATANA_REPACK.run_test(|ctx| {
-        let dist_version = ctx.tools.cargo_dist.version().unwrap();
-
-        ctx.patch_cargo_toml(format!(
-            r#"
-[workspace.metadata.dist]
-cargo-dist-version = "{dist_version}"
-rust-toolchain-version = "1.67.1"
-ci = ["github"]
-installers = ["shell"]
-targets = ["x86_64-unknown-linux-musl", "aarch64-apple-darwin", "x86_64-apple-darwin"]
-
-"#
-        ))?;
-
-        // Run generate to make sure stuff is up to date before running other commands
-        let ci_result = ctx.cargo_dist_generate(test_name)?;
-        let ci_snap = ci_result.check_all()?;
-        // Do usual build+plan checks
-        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
-        let main_snap = main_result.check_all(ctx, ".cargo/bin/")?;
-        // snapshot all
-        main_snap.join(ci_snap).snap();
         Ok(())
     })
 }

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -257,6 +257,37 @@ scope = "@axodotdev"
 }
 
 #[test]
+fn axolotlsay_musl_no_gnu() -> Result<(), miette::Report> {
+    let test_name = _function_name!();
+    AXOLOTLSAY.run_test(|ctx| {
+        let dist_version = ctx.tools.cargo_dist.version().unwrap();
+        ctx.patch_cargo_toml(format!(
+            r#"
+[workspace.metadata.dist]
+cargo-dist-version = "{dist_version}"
+installers = ["shell", "npm"]
+targets = ["x86_64-unknown-linux-musl", "aarch64-apple-darwin", "x86_64-apple-darwin"]
+ci = ["github"]
+unix-archive = ".tar.gz"
+windows-archive = ".tar.gz"
+scope = "@axodotdev"
+
+"#
+        ))?;
+
+        // Run generate to make sure stuff is up to date before running other commands
+        let ci_result = ctx.cargo_dist_generate(test_name)?;
+        let ci_snap = ci_result.check_all()?;
+        // Do usual build+plan checks
+        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
+        let main_snap = main_result.check_all(ctx, ".cargo/bin/")?;
+        // snapshot all
+        main_snap.join(ci_snap).snap();
+        Ok(())
+    })
+}
+
+#[test]
 fn akaikatana_basic() -> Result<(), miette::Report> {
     let test_name = _function_name!();
     AKAIKATANA_REPACK.run_test(|ctx| {
@@ -364,6 +395,36 @@ rust-toolchain-version = "1.67.1"
 ci = ["github"]
 installers = ["shell"]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "aarch64-apple-darwin", "x86_64-apple-darwin"]
+
+"#
+        ))?;
+
+        // Run generate to make sure stuff is up to date before running other commands
+        let ci_result = ctx.cargo_dist_generate(test_name)?;
+        let ci_snap = ci_result.check_all()?;
+        // Do usual build+plan checks
+        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
+        let main_snap = main_result.check_all(ctx, ".cargo/bin/")?;
+        // snapshot all
+        main_snap.join(ci_snap).snap();
+        Ok(())
+    })
+}
+
+#[test]
+fn akaikatana_musl_no_gnu() -> Result<(), miette::Report> {
+    let test_name = _function_name!();
+    AKAIKATANA_REPACK.run_test(|ctx| {
+        let dist_version = ctx.tools.cargo_dist.version().unwrap();
+
+        ctx.patch_cargo_toml(format!(
+            r#"
+[workspace.metadata.dist]
+cargo-dist-version = "{dist_version}"
+rust-toolchain-version = "1.67.1"
+ci = ["github"]
+installers = ["shell"]
+targets = ["x86_64-unknown-linux-musl", "aarch64-apple-darwin", "x86_64-apple-darwin"]
 
 "#
         ))?;

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -428,13 +434,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/akaikatana_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl_no_gnu.snap
@@ -143,7 +143,7 @@ download_binary_and_run_installer() {
             _bins="akextract akmetadata akrepack"
             ;;
         "x86_64-unknown-linux-gnu")
-            _artifact_name="akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz"
+            _artifact_name="akaikatana-repack-x86_64-unknown-linux-musl.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             ;;
@@ -734,7 +734,7 @@ download_binary_and_run_installer "$@" || exit 1
   "announcement_tag": "v0.2.0",
   "announcement_is_prerelease": false,
   "announcement_title": "v0.2.0",
-  "announcement_github_body": "## Install akaikatana-repack 0.2.0\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh\n```\n\n## Download akaikatana-repack 0.2.0\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [akaikatana-repack-aarch64-apple-darwin.tar.xz](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-aarch64-apple-darwin.tar.xz) | macOS Apple Silicon | [checksum](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-aarch64-apple-darwin.tar.xz.sha256) |\n| [akaikatana-repack-x86_64-apple-darwin.tar.xz](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz) | macOS Intel | [checksum](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz.sha256) |\n| [akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz) | Linux x64 | [checksum](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n| [akaikatana-repack-x86_64-unknown-linux-musl.tar.xz](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-musl.tar.xz) | musl Linux x64 | [checksum](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-musl.tar.xz.sha256) |\n\n",
+  "announcement_github_body": "## Install akaikatana-repack 0.2.0\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh\n```\n\n## Download akaikatana-repack 0.2.0\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [akaikatana-repack-aarch64-apple-darwin.tar.xz](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-aarch64-apple-darwin.tar.xz) | macOS Apple Silicon | [checksum](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-aarch64-apple-darwin.tar.xz.sha256) |\n| [akaikatana-repack-x86_64-apple-darwin.tar.xz](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz) | macOS Intel | [checksum](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz.sha256) |\n| [akaikatana-repack-x86_64-unknown-linux-musl.tar.xz](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-musl.tar.xz) | musl Linux x64 | [checksum](https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-musl.tar.xz.sha256) |\n\n",
   "system_info": {
     "cargo_version_line": "CENSORED"
   },
@@ -748,8 +748,6 @@ download_binary_and_run_installer "$@" || exit 1
         "akaikatana-repack-aarch64-apple-darwin.tar.xz.sha256",
         "akaikatana-repack-x86_64-apple-darwin.tar.xz",
         "akaikatana-repack-x86_64-apple-darwin.tar.xz.sha256",
-        "akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz",
-        "akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz.sha256",
         "akaikatana-repack-x86_64-unknown-linux-musl.tar.xz",
         "akaikatana-repack-x86_64-unknown-linux-musl.tar.xz.sha256"
       ]
@@ -804,7 +802,6 @@ download_binary_and_run_installer "$@" || exit 1
       "target_triples": [
         "aarch64-apple-darwin",
         "x86_64-apple-darwin",
-        "x86_64-unknown-linux-gnu",
         "x86_64-unknown-linux-musl"
       ],
       "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh",
@@ -850,48 +847,6 @@ download_binary_and_run_installer "$@" || exit 1
       "kind": "checksum",
       "target_triples": [
         "x86_64-apple-darwin"
-      ]
-    },
-    "akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz": {
-      "name": "akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "x86_64-unknown-linux-gnu"
-      ],
-      "assets": [
-        {
-          "name": "LICENSE",
-          "path": "LICENSE",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "name": "akextract",
-          "path": "akextract",
-          "kind": "executable"
-        },
-        {
-          "name": "akmetadata",
-          "path": "akmetadata",
-          "kind": "executable"
-        },
-        {
-          "name": "akrepack",
-          "path": "akrepack",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz.sha256"
-    },
-    "akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz.sha256": {
-      "name": "akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "x86_64-unknown-linux-gnu"
       ]
     },
     "akaikatana-repack-x86_64-unknown-linux-musl.tar.xz": {
@@ -957,14 +912,6 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
-          },
-          {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
-            "runner": "ubuntu-20.04",
-            "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
           },
           {
             "targets": [

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -428,13 +434,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1311,6 +1311,9 @@ const { version } = require("./package.json");
 const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0";
 
+const builder_glibc_major_version = 2;
+const builder_glibc_minor_version = 35;
+
 const supportedPlatforms = {
   "aarch64-apple-darwin": {
     "artifact_name": "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1363,6 +1366,29 @@ const getPlatform = () => {
       break;
   }
 
+  if (raw_os_type === "Linux") {
+    if (libc.familySync() == 'musl') {
+      os_type = "unknown-linux-musl-dynamic";
+    } else if (libc.isNonGlibcLinuxSync()) {
+        console.warn("Your libc is neither glibc nor musl; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+    } else {
+      let libc_version = libc.versionSync();
+      let split_libc_version = libc_version.split(".");
+      let libc_major_version = split_libc_version[0];
+      let libc_minor_version = split_libc_version[1];
+      if (
+        libc_major_version != builder_glibc_major_version ||
+        libc_minor_version < builder_glibc_minor_version
+      ) {
+        // We can't run the glibc binaries, but we can run the static musl ones
+        // if they exist
+        console.warn("Your glibc isn't compatible; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+      }
+    }
+  }
+
   // Assume the above succeeded and build a target triple to look things up with.
   // If any of it failed, this lookup will fail and we'll handle it like normal.
   let target_triple = `${arch}-${os_type}`;
@@ -1372,28 +1398,6 @@ const getPlatform = () => {
     error(
       `Platform with type "${raw_os_type}" and architecture "${raw_architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${Object.keys(supportedPlatforms).join(",")}`
     );
-  }
-
-  // These are both situation where you might toggle to unknown-linux-musl but we don't support that yet
-  if (raw_os_type === "Linux") {
-    if (libc.isNonGlibcLinuxSync()) {
-      error("This operating system does not support dynamic linking to glibc.");
-    } else {
-      let libc_version = libc.versionSync();
-      let split_libc_version = libc_version.split(".");
-      let libc_major_version = split_libc_version[0];
-      let libc_minor_version = split_libc_version[1];
-      let min_major_version = 2;
-      let min_minor_version = 17;
-      if (
-        libc_major_version < min_major_version ||
-        libc_minor_version < min_minor_version
-      ) {
-        error(
-          `This operating system needs glibc >= ${min_major_version}.${min_minor_version}, but only has ${libc_version} installed.`
-        );
-      }
-    }
   }
 
   return platform;

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -428,13 +434,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1311,6 +1311,9 @@ const { version } = require("./package.json");
 const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0";
 
+const builder_glibc_major_version = 2;
+const builder_glibc_minor_version = 35;
+
 const supportedPlatforms = {
   "aarch64-apple-darwin": {
     "artifact_name": "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1363,6 +1366,29 @@ const getPlatform = () => {
       break;
   }
 
+  if (raw_os_type === "Linux") {
+    if (libc.familySync() == 'musl') {
+      os_type = "unknown-linux-musl-dynamic";
+    } else if (libc.isNonGlibcLinuxSync()) {
+        console.warn("Your libc is neither glibc nor musl; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+    } else {
+      let libc_version = libc.versionSync();
+      let split_libc_version = libc_version.split(".");
+      let libc_major_version = split_libc_version[0];
+      let libc_minor_version = split_libc_version[1];
+      if (
+        libc_major_version != builder_glibc_major_version ||
+        libc_minor_version < builder_glibc_minor_version
+      ) {
+        // We can't run the glibc binaries, but we can run the static musl ones
+        // if they exist
+        console.warn("Your glibc isn't compatible; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+      }
+    }
+  }
+
   // Assume the above succeeded and build a target triple to look things up with.
   // If any of it failed, this lookup will fail and we'll handle it like normal.
   let target_triple = `${arch}-${os_type}`;
@@ -1372,28 +1398,6 @@ const getPlatform = () => {
     error(
       `Platform with type "${raw_os_type}" and architecture "${raw_architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${Object.keys(supportedPlatforms).join(",")}`
     );
-  }
-
-  // These are both situation where you might toggle to unknown-linux-musl but we don't support that yet
-  if (raw_os_type === "Linux") {
-    if (libc.isNonGlibcLinuxSync()) {
-      error("This operating system does not support dynamic linking to glibc.");
-    } else {
-      let libc_version = libc.versionSync();
-      let split_libc_version = libc_version.split(".");
-      let libc_major_version = split_libc_version[0];
-      let libc_minor_version = split_libc_version[1];
-      let min_major_version = 2;
-      let min_minor_version = 17;
-      if (
-        libc_major_version < min_major_version ||
-        libc_minor_version < min_minor_version
-      ) {
-        error(
-          `This operating system needs glibc >= ${min_major_version}.${min_minor_version}, but only has ${libc_version} installed.`
-        );
-      }
-    }
   }
 
   return platform;

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -428,13 +434,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1013,6 +1013,9 @@ const { version } = require("./package.json");
 const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0";
 
+const builder_glibc_major_version = 2;
+const builder_glibc_minor_version = 35;
+
 const supportedPlatforms = {
   "aarch64-apple-darwin": {
     "artifact_name": "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1029,7 +1032,12 @@ const supportedPlatforms = {
     "bins": ["axolotlsay"],
     "zip_ext": ".tar.gz"
   },
-  "x86_64-unknown-linux-musl": {
+  "x86_64-unknown-linux-musl-dynamic": {
+    "artifact_name": "axolotlsay-x86_64-unknown-linux-musl.tar.gz",
+    "bins": ["axolotlsay"],
+    "zip_ext": ".tar.gz"
+  },
+  "x86_64-unknown-linux-musl-static": {
     "artifact_name": "axolotlsay-x86_64-unknown-linux-musl.tar.gz",
     "bins": ["axolotlsay"],
     "zip_ext": ".tar.gz"
@@ -1065,6 +1073,29 @@ const getPlatform = () => {
       break;
   }
 
+  if (raw_os_type === "Linux") {
+    if (libc.familySync() == 'musl') {
+      os_type = "unknown-linux-musl-dynamic";
+    } else if (libc.isNonGlibcLinuxSync()) {
+        console.warn("Your libc is neither glibc nor musl; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+    } else {
+      let libc_version = libc.versionSync();
+      let split_libc_version = libc_version.split(".");
+      let libc_major_version = split_libc_version[0];
+      let libc_minor_version = split_libc_version[1];
+      if (
+        libc_major_version != builder_glibc_major_version ||
+        libc_minor_version < builder_glibc_minor_version
+      ) {
+        // We can't run the glibc binaries, but we can run the static musl ones
+        // if they exist
+        console.warn("Your glibc isn't compatible; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+      }
+    }
+  }
+
   // Assume the above succeeded and build a target triple to look things up with.
   // If any of it failed, this lookup will fail and we'll handle it like normal.
   let target_triple = `${arch}-${os_type}`;
@@ -1074,28 +1105,6 @@ const getPlatform = () => {
     error(
       `Platform with type "${raw_os_type}" and architecture "${raw_architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${Object.keys(supportedPlatforms).join(",")}`
     );
-  }
-
-  // These are both situation where you might toggle to unknown-linux-musl but we don't support that yet
-  if (raw_os_type === "Linux") {
-    if (libc.isNonGlibcLinuxSync()) {
-      error("This operating system does not support dynamic linking to glibc.");
-    } else {
-      let libc_version = libc.versionSync();
-      let split_libc_version = libc_version.split(".");
-      let libc_major_version = split_libc_version[0];
-      let libc_minor_version = split_libc_version[1];
-      let min_major_version = 2;
-      let min_minor_version = 17;
-      if (
-        libc_major_version < min_major_version ||
-        libc_minor_version < min_minor_version
-      ) {
-        error(
-          `This operating system needs glibc >= ${min_major_version}.${min_minor_version}, but only has ${libc_version} installed.`
-        );
-      }
-    }
   }
 
   return platform;

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -141,7 +147,12 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             ;;
-        "x86_64-unknown-linux-musl")
+        "x86_64-unknown-linux-musl-dynamic")
+            _artifact_name="axolotlsay-x86_64-unknown-linux-musl.tar.gz"
+            _zip_ext=".tar.gz"
+            _bins="axolotlsay"
+            ;;
+        "x86_64-unknown-linux-musl-static")
             _artifact_name="axolotlsay-x86_64-unknown-linux-musl.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
@@ -433,13 +444,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -143,7 +143,17 @@ download_binary_and_run_installer() {
             _bins="axolotlsay"
             ;;
         "x86_64-unknown-linux-gnu")
-            _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
+            _artifact_name="axolotlsay-x86_64-unknown-linux-musl.tar.gz"
+            _zip_ext=".tar.gz"
+            _bins="axolotlsay"
+            ;;
+        "x86_64-unknown-linux-musl-dynamic")
+            _artifact_name="axolotlsay-x86_64-unknown-linux-musl.tar.gz"
+            _zip_ext=".tar.gz"
+            _bins="axolotlsay"
+            ;;
+        "x86_64-unknown-linux-musl-static")
+            _artifact_name="axolotlsay-x86_64-unknown-linux-musl.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             ;;
@@ -718,289 +728,807 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ installer.ps1 ================
-# Licensed under the MIT license
-# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-# option. This file may not be copied, modified, or distributed
-# except according to those terms.
+================ npm-package.tar.gz/package/.gitignore ================
+/node_modules
 
-<#
-.SYNOPSIS
+================ npm-package.tar.gz/package/CHANGELOG.md ================
+# Version 0.1.0
 
-The installer for axolotlsay 0.1.0
+```text
+         +------------------------+
+         | the initial release!!! |
+         +------------------------+
+        /
+≽(◕ ᴗ ◕)≼
+```
+================ npm-package.tar.gz/package/LICENSE-APACHE ================
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
 
-.DESCRIPTION
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-This script detects what platform you're on and fetches an appropriate archive from
-https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0
-then unpacks the binaries and installs them to $env:CARGO_HOME\bin ($HOME\.cargo\bin)
+1. Definitions.
 
-It will then add that dir to PATH by editing your Environment.Path registry key
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
 
-.PARAMETER ArtifactDownloadUrl
-The URL of the directory where artifacts can be fetched from
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
 
-.PARAMETER NoModifyPath
-Don't add the install directory to PATH
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
 
-.PARAMETER Help
-Print help
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
 
-#>
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
 
-param (
-    [Parameter(HelpMessage = "The URL of the directory where artifacts can be fetched from")]
-    [string]$ArtifactDownloadUrl = 'https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0',
-    [Parameter(HelpMessage = "Don't add the install directory to PATH")]
-    [switch]$NoModifyPath,
-    [Parameter(HelpMessage = "Print Help")]
-    [switch]$Help
-)
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
 
-$app_name = 'axolotlsay'
-$app_version = '0.1.0'
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
 
-function Install-Binary($install_args) {
-  if ($Help) {
-    Get-Help $PSCommandPath -Detailed
-    Exit
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2023 Axo Developer Co.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+================ npm-package.tar.gz/package/LICENSE-MIT ================
+Copyright (c) 2023 Axo Developer Co.
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+================ npm-package.tar.gz/package/README.md ================
+# axolotlsay
+> 💬 a CLI for learning to distribute CLIs in rust
+
+
+## Usage
+
+```sh
+> axolotlsay "hello world"
+
+         +-------------+
+         | hello world |
+         +-------------+
+        /
+≽(◕ ᴗ ◕)≼
+```
+
+## License
+
+Licensed under either of
+
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or [apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0))
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or [opensource.org/licenses/MIT](https://opensource.org/licenses/MIT))
+
+at your option.
+
+================ npm-package.tar.gz/package/binary.js ================
+const { Binary } = require("binary-install");
+const os = require("os");
+const cTable = require("console.table");
+const libc = require("detect-libc");
+const { configureProxy } = require("axios-proxy-builder");
+
+const error = (msg) => {
+  console.error(msg);
+  process.exit(1);
+};
+
+const { version } = require("./package.json");
+const name = "axolotlsay";
+const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0";
+
+const supportedPlatforms = {
+  "aarch64-apple-darwin": {
+    "artifact_name": "axolotlsay-aarch64-apple-darwin.tar.gz",
+    "bins": ["axolotlsay"],
+    "zip_ext": ".tar.gz"
+  },
+  "x86_64-apple-darwin": {
+    "artifact_name": "axolotlsay-x86_64-apple-darwin.tar.gz",
+    "bins": ["axolotlsay"],
+    "zip_ext": ".tar.gz"
+  },
+  "x86_64-unknown-linux-musl": {
+    "artifact_name": "axolotlsay-x86_64-unknown-linux-musl.tar.gz",
+    "bins": ["axolotlsay"],
+    "zip_ext": ".tar.gz"
   }
-  $old_erroractionpreference = $ErrorActionPreference
-  $ErrorActionPreference = 'stop'
+};
 
-  Initialize-Environment
+const getPlatform = () => {
+  const raw_os_type = os.type();
+  const raw_architecture = os.arch();
 
-  # Platform info injected by cargo-dist
-  $platforms = @{
-    "x86_64-pc-windows-msvc" = @{
-      "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
-      "zip_ext" = ".tar.gz"
+  // We want to use rust-style target triples as the canonical key
+  // for a platform, so translate the "os" library's concepts into rust ones
+  let os_type = "";
+  switch (raw_os_type) {
+    case "Windows_NT":
+      os_type = "pc-windows-msvc";
+      break;
+    case "Darwin":
+      os_type = "apple-darwin";
+      break;
+    case "Linux":
+      os_type = "unknown-linux-gnu"
+      break;
+  }
+
+  let arch = "";
+  switch (raw_architecture) {
+    case "x64":
+      arch = "x86_64";
+      break;
+    case "arm64":
+      arch = "aarch64";
+      break;
+  }
+
+  // Assume the above succeeded and build a target triple to look things up with.
+  // If any of it failed, this lookup will fail and we'll handle it like normal.
+  let target_triple = `${arch}-${os_type}`;
+  let platform = supportedPlatforms[target_triple];
+
+  if (!platform) {
+    error(
+      `Platform with type "${raw_os_type}" and architecture "${raw_architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${Object.keys(supportedPlatforms).join(",")}`
+    );
+  }
+
+  // These are both situation where you might toggle to unknown-linux-musl but we don't support that yet
+  if (raw_os_type === "Linux") {
+    if (libc.isNonGlibcLinuxSync()) {
+      error("This operating system does not support dynamic linking to glibc.");
+    } else {
+      let libc_version = libc.versionSync();
+      let split_libc_version = libc_version.split(".");
+      let libc_major_version = split_libc_version[0];
+      let libc_minor_version = split_libc_version[1];
+      let min_major_version = 2;
+      let min_minor_version = 17;
+      if (
+        libc_major_version < min_major_version ||
+        libc_minor_version < min_minor_version
+      ) {
+        error(
+          `This operating system needs glibc >= ${min_major_version}.${min_minor_version}, but only has ${libc_version} installed.`
+        );
+      }
     }
   }
 
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
-  # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  return platform;
+};
 
-  $ErrorActionPreference = $old_erroractionpreference
-}
+const getBinary = () => {
+  const platform = getPlatform();
+  const url = `${artifact_download_url}/${platform.artifact_name}`;
 
-function Get-TargetTriple() {
-  try {
-    # NOTE: this might return X64 on ARM64 Windows, which is OK since emulation is available.
-    # It works correctly starting in PowerShell Core 7.3 and Windows PowerShell in Win 11 22H2.
-    # Ideally this would just be
-    #   [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-    # but that gets a type from the wrong assembly on Windows PowerShell (i.e. not Core)
-    $a = [System.Reflection.Assembly]::LoadWithPartialName("System.Runtime.InteropServices.RuntimeInformation")
-    $t = $a.GetType("System.Runtime.InteropServices.RuntimeInformation")
-    $p = $t.GetProperty("OSArchitecture")
-    # Possible OSArchitecture Values: https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.architecture
-    # Rust supported platforms: https://doc.rust-lang.org/stable/rustc/platform-support.html
-    switch ($p.GetValue($null).ToString())
-    {
-      "X86" { return "i686-pc-windows-msvc" }
-      "X64" { return "x86_64-pc-windows-msvc" }
-      "Arm" { return "thumbv7a-pc-windows-msvc" }
-      "Arm64" { return "aarch64-pc-windows-msvc" }
+  if (platform.bins.length > 1) {
+    // Not yet supported
+    error("this app has multiple binaries, which isn't yet implemented");
+  }
+  let binary = new Binary(platform.bins[0], url);
+
+  return binary;
+};
+
+const install = (suppressLogs) => {
+  const binary = getBinary();
+  const proxy = configureProxy(binary.url);
+
+  return binary.install(proxy, suppressLogs);
+};
+
+const run = () => {
+  const binary = getBinary();
+  binary.run();
+};
+
+module.exports = {
+  install,
+  run,
+  getBinary,
+};
+
+================ npm-package.tar.gz/package/install.js ================
+#!/usr/bin/env node
+
+const { install } = require("./binary");
+install(false);
+
+================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+{
+  "name": "axolotlsay",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "axolotlsay",
+      "version": "0.1.0",
+      "license": "MIT OR Apache-2.0",
+      "hasInstallScript": true,
+      "dependencies": {
+        "axios-proxy-builder": "^0.1.1",
+        "binary-install": "^1.0.6",
+        "console.table": "^0.10.0",
+        "detect-libc": "^2.0.0"
+      },
+      "bin": {
+        "rover": "run.js"
+      },
+      "devDependencies": {
+        "prettier": "2.8.4"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/axios-proxy-builder": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/axios-proxy-builder/-/axios-proxy-builder-0.1.2.tgz",
+      "integrity": "sha512-6uBVsBZzkB3tCC8iyx59mCjQckhB8+GQrI9Cop8eC7ybIsvs/KtnNgEBfRMSEa7GqK2VBGUzgjNYMdPIfotyPA==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/binary-install": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.0.6.tgz",
+      "integrity": "sha512-h3K4jaC4jEauK3csXI9GxGBJldkpuJlHCIBv8i+XBNhPuxnlERnD1PWVczQYDqvhJfv0IHUbB3lhDrZUMHvSgw==",
+      "dependencies": {
+        "axios": "^0.26.1",
+        "rimraf": "^3.0.2",
+        "tar": "^6.1.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/console.table": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/console.table/-/console.table-0.10.0.tgz",
+      "integrity": "sha512-dPyZofqggxuvSf7WXvNjuRfnsOk1YazkVP8FdxH4tcH2c37wc79/Yl6Bhr7Lsu00KMgy2ql/qCMuNu8xctZM8g==",
+      "dependencies": {
+        "easy-table": "1.1.0"
+      },
+      "engines": {
+        "node": "> 0.10"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "optional": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/easy-table": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
+      "integrity": "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA==",
+      "optionalDependencies": {
+        "wcwidth": ">=1.0.1"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.4.tgz",
+      "integrity": "sha512-lwycX3cBMTvcejsHITUgYj6Gy6A7Nh4Q6h9NP4sTHY1ccJlC7yKzDmiShEHsJ16Jf1nKGDEaiHxiltsJEvk0nQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^4.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "optional": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
-  } catch {
-    # The above was added in .NET 4.7.1, so Windows PowerShell in versions of Windows
-    # prior to Windows 10 v1709 may not have this API.
-    Write-Verbose "Get-TargetTriple: Exception when trying to determine OS architecture."
-    Write-Verbose $_
-  }
-
-  # This is available in .NET 4.0. We already checked for PS 5, which requires .NET 4.5.
-  Write-Verbose("Get-TargetTriple: falling back to Is64BitOperatingSystem.")
-  if ([System.Environment]::Is64BitOperatingSystem) {
-    return "x86_64-pc-windows-msvc"
-  } else {
-    return "i686-pc-windows-msvc"
   }
 }
 
-function Download($download_url, $platforms) {
-  $arch = Get-TargetTriple
-
-  if (-not $platforms.ContainsKey($arch)) {
-    # X64 is well-supported, including in emulation on ARM64
-    Write-Verbose "$arch is not availablem falling back to X64"
-    $arch = "x86_64-pc-windows-msvc"
-  }
-
-  if (-not $platforms.ContainsKey($arch)) {
-    # should not be possible, as currently we always produce X64 binaries.
-    $platforms_json = ConvertTo-Json $platforms
-    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
-  }
-
-  # Lookup what we expect this platform to look like
-  $info = $platforms[$arch]
-  $zip_ext = $info["zip_ext"]
-  $bin_names = $info["bins"]
-  $artifact_name = $info["artifact_name"]
-
-  # Make a new temp dir to unpack things to
-  $tmp = New-Temp-Dir
-  $dir_path = "$tmp\$app_name$zip_ext"
-
-  # Download and unpack!
-  $url = "$download_url/$artifact_name"
-  Write-Information "Downloading $app_name $app_version ($arch)"
-  Write-Verbose "  from $url"
-  Write-Verbose "  to $dir_path"
-  $wc = New-Object Net.Webclient
-  $wc.downloadFile($url, $dir_path)
-
-  Write-Verbose "Unpacking to $tmp"
-
-  # Select the tool to unpack the files with.
-  #
-  # As of windows 10(?), powershell comes with tar preinstalled, but in practice
-  # it only seems to support .tar.gz, and not xz/zstd. Still, we should try to
-  # forward all tars to it in case the user has a machine that can handle it!
-  switch -Wildcard ($zip_ext) {
-    ".zip" {
-      Expand-Archive -Path $dir_path -DestinationPath "$tmp";
-      Break
-    }
-    ".tar.*" {
-      tar xf $dir_path --strip-components 1 -C "$tmp";
-      Break
-    }
-    Default {
-      throw "ERROR: unknown archive format $zip_ext"
-    }
-  }
-
-  # Let the next step know what to copy
-  $bin_paths = @()
-  foreach ($bin_name in $bin_names) {
-    Write-Verbose "  Unpacked $bin_name"
-    $bin_paths += "$tmp\$bin_name"
-  }
-  return $bin_paths
-}
-
-function Invoke-Installer($bin_paths) {
-
-  # first try CARGO_HOME, then fallback to HOME
-  # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
-  } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
-  } else {
-    throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
-  }
-
-  $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
-  Write-Information "Installing to $dest_dir"
-  # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
-    $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
-    Write-Information "  $installed_file"
-  }
-
-  Write-Information "Everything's installed!"
-  if (-not $NoModifyPath) {
-    if (Add-Path $dest_dir) {
-        Write-Information ""
-        Write-Information "$dest_dir was added to your PATH, you may need to restart your shell for that to take effect."
-    }
+================ npm-package.tar.gz/package/package.json ================
+{
+  "name": "axolotlsay",
+  "version": "0.1.0",
+  "description": "💬 a CLI for learning to distribute CLIs in rust",
+  "repository": "https://github.com/axodotdev/axolotlsay",
+  "license": "MIT OR Apache-2.0",
+  "author": "axo.dev",
+  "bin": {
+    "axolotlsay": "run.js"
+  },
+  "scripts": {
+    "postinstall": "node ./install.js",
+    "fmt": "prettier --write **/*.js",
+    "fmt:check": "prettier --check **/*.js"
+  },
+  "engines": {
+    "node": ">=14",
+    "npm": ">=6"
+  },
+  "volta": {
+    "node": "18.14.1",
+    "npm": "9.5.0"
+  },
+  "dependencies": {
+    "axios-proxy-builder": "^0.1.1",
+    "binary-install": "^1.0.6",
+    "console.table": "^0.10.0",
+    "detect-libc": "^2.0.0"
+  },
+  "devDependencies": {
+    "prettier": "2.8.4"
   }
 }
 
-# Try to add the given path to PATH via the registry
-#
-# Returns true if the registry was modified, otherwise returns false
-# (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+================ npm-package.tar.gz/package/run.js ================
+#!/usr/bin/env node
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
-
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "Adding $PropertyName Property to $RegistryPath"
-  }
-
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
-    return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Adding $OrigPathToAdd to your PATH"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
-  }
-}
-
-function Initialize-Environment() {
-  If (($PSVersionTable.PSVersion.Major) -lt 5) {
-    Write-Error "PowerShell 5 or later is required to install $app_name."
-    Write-Error "Upgrade PowerShell: https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell"
-    break
-  }
-
-  # show notification to change execution policy:
-  $allowedExecutionPolicy = @('Unrestricted', 'RemoteSigned', 'ByPass')
-  If ((Get-ExecutionPolicy).ToString() -notin $allowedExecutionPolicy) {
-    Write-Error "PowerShell requires an execution policy in [$($allowedExecutionPolicy -join ", ")] to run $app_name."
-    Write-Error "For example, to set the execution policy to 'RemoteSigned' please run :"
-    Write-Error "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"
-    break
-  }
-
-  # GitHub requires TLS 1.2
-  If ([System.Enum]::GetNames([System.Net.SecurityProtocolType]) -notcontains 'Tls12') {
-    Write-Error "Installing $app_name requires at least .NET Framework 4.5"
-    Write-Error "Please download and install it first:"
-    Write-Error "https://www.microsoft.com/net/download"
-    break
-  }
-}
-
-function New-Temp-Dir() {
-  [CmdletBinding(SupportsShouldProcess)]
-  param()
-  $parent = [System.IO.Path]::GetTempPath()
-  [string] $name = [System.Guid]::NewGuid()
-  New-Item -ItemType Directory -Path (Join-Path $parent $name)
-}
-
-# PSScriptAnalyzer doesn't like how we use our params as globals, this calms it
-$Null = $ArtifactDownloadUrl, $NoModifyPath, $Help
-# Make Write-Information statements be visible
-$InformationPreference = "Continue"
-Install-Binary "$Args"
+const { run, install: maybeInstall } = require("./binary");
+maybeInstall(true).then(run);
 
 ================ dist-manifest.json ================
 {
@@ -1009,7 +1537,7 @@ Install-Binary "$Args"
   "announcement_is_prerelease": false,
   "announcement_title": "Version 0.1.0",
   "announcement_changelog": "```text\n         +------------------------+\n         | the initial release!!! |\n         +------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```",
-  "announcement_github_body": "## Release Notes\n\n```text\n         +------------------------+\n         | the initial release!!! |\n         +------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Install axolotlsay 0.1.0\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\nirm https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 | iex\n```\n\n## Download axolotlsay 0.1.0\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-aarch64-apple-darwin.tar.gz) | macOS Apple Silicon | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-aarch64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz) | macOS Intel | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-pc-windows-msvc.tar.gz) | Windows x64 | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-unknown-linux-gnu.tar.gz) | Linux x64 | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.msi](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-pc-windows-msvc.msi) | Windows x64 | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-pc-windows-msvc.msi.sha256) |\n\n",
+  "announcement_github_body": "## Release Notes\n\n```text\n         +------------------------+\n         | the initial release!!! |\n         +------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Install axolotlsay 0.1.0\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh\n```\n\n### Install prebuilt binaries into your npm project\n\n```sh\nnpm install axolotlsay@0.1.0\n```\n\n## Download axolotlsay 0.1.0\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-aarch64-apple-darwin.tar.gz) | macOS Apple Silicon | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-aarch64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz) | macOS Intel | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-musl.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-unknown-linux-musl.tar.gz) | musl Linux x64 | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-unknown-linux-musl.tar.gz.sha256) |\n\n",
   "system_info": {
     "cargo_version_line": "CENSORED"
   },
@@ -1019,17 +1547,13 @@ Install-Binary "$Args"
       "app_version": "0.1.0",
       "artifacts": [
         "axolotlsay-installer.sh",
-        "axolotlsay-installer.ps1",
+        "axolotlsay-npm-package.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
         "axolotlsay-x86_64-apple-darwin.tar.gz.sha256",
-        "axolotlsay-x86_64-pc-windows-msvc.tar.gz",
-        "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256",
-        "axolotlsay-x86_64-pc-windows-msvc.msi",
-        "axolotlsay-x86_64-pc-windows-msvc.msi.sha256",
-        "axolotlsay-x86_64-unknown-linux-gnu.tar.gz",
-        "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256"
+        "axolotlsay-x86_64-unknown-linux-musl.tar.gz",
+        "axolotlsay-x86_64-unknown-linux-musl.tar.gz.sha256"
       ]
     }
   ],
@@ -1076,25 +1600,79 @@ Install-Binary "$Args"
         "aarch64-apple-darwin"
       ]
     },
-    "axolotlsay-installer.ps1": {
-      "name": "axolotlsay-installer.ps1",
-      "kind": "installer",
-      "target_triples": [
-        "x86_64-pc-windows-msvc"
-      ],
-      "install_hint": "irm https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 | iex",
-      "description": "Install prebuilt binaries via powershell script"
-    },
     "axolotlsay-installer.sh": {
       "name": "axolotlsay-installer.sh",
       "kind": "installer",
       "target_triples": [
         "aarch64-apple-darwin",
         "x86_64-apple-darwin",
-        "x86_64-unknown-linux-gnu"
+        "x86_64-unknown-linux-musl"
       ],
       "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh",
       "description": "Install prebuilt binaries via shell script"
+    },
+    "axolotlsay-npm-package.tar.gz": {
+      "name": "axolotlsay-npm-package.tar.gz",
+      "kind": "installer",
+      "target_triples": [
+        "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-musl"
+      ],
+      "assets": [
+        {
+          "name": ".gitignore",
+          "path": ".gitignore",
+          "kind": "unknown"
+        },
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "name": "binary.js",
+          "path": "binary.js",
+          "kind": "unknown"
+        },
+        {
+          "name": "install.js",
+          "path": "install.js",
+          "kind": "unknown"
+        },
+        {
+          "name": "npm-shrinkwrap.json",
+          "path": "npm-shrinkwrap.json",
+          "kind": "unknown"
+        },
+        {
+          "name": "package.json",
+          "path": "package.json",
+          "kind": "unknown"
+        },
+        {
+          "name": "run.js",
+          "path": "run.js",
+          "kind": "unknown"
+        }
+      ],
+      "install_hint": "npm install axolotlsay@0.1.0",
+      "description": "Install prebuilt binaries into your npm project"
     },
     "axolotlsay-x86_64-apple-darwin.tar.gz": {
       "name": "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -1138,76 +1716,11 @@ Install-Binary "$Args"
         "x86_64-apple-darwin"
       ]
     },
-    "axolotlsay-x86_64-pc-windows-msvc.msi": {
-      "name": "axolotlsay-x86_64-pc-windows-msvc.msi",
-      "kind": "installer",
-      "target_triples": [
-        "x86_64-pc-windows-msvc"
-      ],
-      "assets": [
-        {
-          "name": "axolotlsay",
-          "path": "axolotlsay.exe",
-          "kind": "executable"
-        }
-      ],
-      "description": "install via msi",
-      "checksum": "axolotlsay-x86_64-pc-windows-msvc.msi.sha256"
-    },
-    "axolotlsay-x86_64-pc-windows-msvc.msi.sha256": {
-      "name": "axolotlsay-x86_64-pc-windows-msvc.msi.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "x86_64-pc-windows-msvc"
-      ]
-    },
-    "axolotlsay-x86_64-pc-windows-msvc.tar.gz": {
-      "name": "axolotlsay-x86_64-pc-windows-msvc.tar.gz",
+    "axolotlsay-x86_64-unknown-linux-musl.tar.gz": {
+      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.gz",
       "kind": "executable-zip",
       "target_triples": [
-        "x86_64-pc-windows-msvc"
-      ],
-      "assets": [
-        {
-          "name": "CHANGELOG.md",
-          "path": "CHANGELOG.md",
-          "kind": "changelog"
-        },
-        {
-          "name": "LICENSE-APACHE",
-          "path": "LICENSE-APACHE",
-          "kind": "license"
-        },
-        {
-          "name": "LICENSE-MIT",
-          "path": "LICENSE-MIT",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "name": "axolotlsay",
-          "path": "axolotlsay.exe",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256"
-    },
-    "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256": {
-      "name": "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "x86_64-pc-windows-msvc"
-      ]
-    },
-    "axolotlsay-x86_64-unknown-linux-gnu.tar.gz": {
-      "name": "axolotlsay-x86_64-unknown-linux-gnu.tar.gz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "x86_64-unknown-linux-gnu"
+        "x86_64-unknown-linux-musl"
       ],
       "assets": [
         {
@@ -1236,13 +1749,13 @@ Install-Binary "$Args"
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256"
+      "checksum": "axolotlsay-x86_64-unknown-linux-musl.tar.gz.sha256"
     },
-    "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256": {
-      "name": "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256",
+    "axolotlsay-x86_64-unknown-linux-musl.tar.gz.sha256": {
+      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.gz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "x86_64-unknown-linux-gnu"
+        "x86_64-unknown-linux-musl"
       ]
     }
   },
@@ -1269,19 +1782,12 @@ Install-Binary "$Args"
           },
           {
             "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
-            "runner": "windows-2019",
-            "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
-          },
-          {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
+              "x86_64-unknown-linux-musl"
             ],
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
+            "packages_install": "sudo apt-get install musl-tools"
           }
         ]
       },
@@ -1464,66 +1970,11 @@ jobs:
           name: artifacts
           path: ${{ steps.cargo-dist.outputs.paths }}
 
-  # Sign Windows artifacts with ssl.com
-  sign-windows-artifacts:
-    needs:
-      - plan
-      - upload-local-artifacts
-      - upload-global-artifacts
-    runs-on: "ubuntu-20.04"
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SIGN_DIR_IN: target/distrib/sign-input
-      SIGN_DIR_OUT: target/distrib/sign-output
-    steps:
-      # Get all the artifacts for the signing tasks to use
-      - name: Fetch local artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifacts
-          path: target/distrib/
-      # Only try to sign files that the tool can handle
-      - name: Select Signable Artifacts
-        run: |
-          mkdir -p "$SIGN_DIR_IN"
-          mkdir -p "$SIGN_DIR_OUT"
-          for file in target/distrib/*.{msi,ps1}; do
-            [[ -e $file ]] && mv "$file" "$SIGN_DIR_IN" && echo "signing $file";
-          done
-      # Sign the files
-      - name: Sign Artifacts with CodeSignTool
-        uses: sslcom/esigner-codesign@develop
-        with:
-          command: batch_sign
-          username: ${{ secrets.SSLDOTCOM_USERNAME }}
-          password: ${{ secrets.SSLDOTCOM_PASSWORD }}
-          credential_id: ${{ secrets.SSLDOTCOM_CREDENTIAL_ID }}
-          totp_secret: ${{ secrets.SSLDOTCOM_TOTP_SECRET }}
-          dir_path: ${{ env.SIGN_DIR_IN }}
-          output_path: ${{ env.SIGN_DIR_OUT }}
-          environment_name: TEST
-      # Regenerate checksum files for things that have been signed
-      - name: Regenerate Checksums
-        run: |
-          pushd "$SIGN_DIR_OUT"
-          for filename in *; do
-            echo "checksuming $filename"
-            sha256sum --binary "$filename" > "$filename.sha256"
-          done
-          popd
-      # Upload the result, overwriting old files
-      - name: "Upload artifacts"
-        uses: actions/upload-artifact@v3
-        with:
-          name: artifacts
-          path: ${{ env.SIGN_DIR_OUT }}
-
   should-publish:
     needs:
       - plan
       - upload-local-artifacts
       - upload-global-artifacts
-      - sign-windows-artifacts
     if: ${{ needs.plan.outputs.publishing == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -1557,235 +2008,5 @@ jobs:
           body: ${{ fromJson(needs.plan.outputs.val).announcement_github_body }}
           prerelease: ${{ fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
-
-================ main.wxs ================
-<?xml version='1.0' encoding='windows-1252'?>
-<!--
-  Copyright (C) 2017 Christopher R. Field.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
-
-<!--
-  The "cargo wix" subcommand provides a variety of predefined variables available
-  for customization of this template. The values for each variable are set at
-  installer creation time. The following variables are available:
-
-  TargetTriple      = The rustc target triple name.
-  TargetEnv         = The rustc target environment. This is typically either
-                      "msvc" or "gnu" depending on the toolchain downloaded and
-                      installed.
-  TargetVendor      = The rustc target vendor. This is typically "pc", but Rust
-                      does support other vendors, like "uwp".
-  CargoTargetBinDir = The complete path to the directory containing the
-                      binaries (exes) to include. The default would be
-                      "target\release\". If an explicit rustc target triple is
-                      used, i.e. cross-compiling, then the default path would
-                      be "target\<CARGO_TARGET>\<CARGO_PROFILE>",
-                      where "<CARGO_TARGET>" is replaced with the "CargoTarget"
-                      variable value and "<CARGO_PROFILE>" is replaced with the
-                      value from the "CargoProfile" variable. This can also
-                      be overriden manually with tne "target-bin-dir" flag.
-  CargoTargetDir    = The path to the directory for the build artifacts, i.e.
-                      "target".
-  CargoProfile      = The cargo profile used to build the binaries
-                      (usually "debug" or "release").
-  Version           = The version for the installer. The default is the
-                      "Major.Minor.Fix" semantic versioning number of the Rust
-                      package.
--->
-
-<!--
-  Please do not remove these pre-processor If-Else blocks. These are used with
-  the `cargo wix` subcommand to automatically determine the installation
-  destination for 32-bit versus 64-bit installers. Removal of these lines will
-  cause installation errors.
--->
-<?if $(sys.BUILDARCH) = x64 or $(sys.BUILDARCH) = arm64 ?>
-    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
-<?else ?>
-    <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
-<?endif ?>
-
-<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
-
-    <Product
-        Id='*'
-        Name='axolotlsay'
-        UpgradeCode='B36177BE-EA4D-44FB-B05C-EDDABDAA95CA'
-        Manufacturer='axo.dev'
-        Language='1033'
-        Codepage='1252'
-        Version='$(var.Version)'>
-
-        <Package Id='*'
-            Keywords='Installer'
-            Description='💬 a CLI for learning to distribute CLIs in rust'
-            Manufacturer='axo.dev'
-            InstallerVersion='450'
-            Languages='1033'
-            Compressed='yes'
-            InstallScope='perMachine'
-            SummaryCodepage='1252'
-            />
-
-        <MajorUpgrade
-            Schedule='afterInstallInitialize'
-            DowngradeErrorMessage='A newer version of [ProductName] is already installed. Setup will now exit.'/>
-
-        <Media Id='1' Cabinet='media1.cab' EmbedCab='yes' DiskPrompt='CD-ROM #1'/>
-        <Property Id='DiskPrompt' Value='axolotlsay Installation'/>
-
-        <Directory Id='TARGETDIR' Name='SourceDir'>
-            <Directory Id='$(var.PlatformProgramFilesFolder)' Name='PFiles'>
-                <Directory Id='APPLICATIONFOLDER' Name='axolotlsay'>
-                    
-                    <!--
-                      Enabling the license sidecar file in the installer is a four step process:
-
-                      1. Uncomment the `Component` tag and its contents.
-                      2. Change the value for the `Source` attribute in the `File` tag to a path
-                         to the file that should be included as the license sidecar file. The path
-                         can, and probably should be, relative to this file.
-                      3. Change the value for the `Name` attribute in the `File` tag to the
-                         desired name for the file when it is installed alongside the `bin` folder
-                         in the installation directory. This can be omitted if the desired name is
-                         the same as the file name.
-                      4. Uncomment the `ComponentRef` tag with the Id attribute value of "License"
-                         further down in this file.
-                    -->
-                    <!--
-                    <Component Id='License' Guid='*'>
-                        <File Id='LicenseFile' Name='ChangeMe' DiskId='1' Source='C:\Path\To\File' KeyPath='yes'/>
-                    </Component>
-                    -->
-
-                    <Directory Id='Bin' Name='bin'>
-                        <Component Id='Path' Guid='BFD25009-65A4-4D1E-97F1-0030465D90D6' KeyPath='yes'>
-                            <Environment
-                                Id='PATH'
-                                Name='PATH'
-                                Value='[Bin]'
-                                Permanent='no'
-                                Part='last'
-                                Action='set'
-                                System='yes'/>
-                        </Component>
-                        <Component Id='binary0' Guid='*'>
-                            <File
-                                Id='exe0'
-                                Name='axolotlsay.exe'
-                                DiskId='1'
-                                Source='$(var.CargoTargetBinDir)\axolotlsay.exe'
-                                KeyPath='yes'/>
-                        </Component>
-                    </Directory>
-                </Directory>
-            </Directory>
-        </Directory>
-
-        <Feature
-            Id='Binaries'
-            Title='Application'
-            Description='Installs all binaries and the license.'
-            Level='1'
-            ConfigurableDirectory='APPLICATIONFOLDER'
-            AllowAdvertise='no'
-            Display='expand'
-            Absent='disallow'>
-            
-            <!--
-              Uncomment the following `ComponentRef` tag to add the license
-              sidecar file to the installer.
-            -->
-            <!--<ComponentRef Id='License'/>-->
-
-            <ComponentRef Id='binary0'/>
-
-            <Feature
-                Id='Environment'
-                Title='PATH Environment Variable'
-                Description='Add the install location of the [ProductName] executable to the PATH system environment variable. This allows the [ProductName] executable to be called from any location.'
-                Level='1'
-                Absent='allow'>
-                <ComponentRef Id='Path'/>
-            </Feature>
-        </Feature>
-
-        <SetProperty Id='ARPINSTALLLOCATION' Value='[APPLICATIONFOLDER]' After='CostFinalize'/>
-
-        
-        <!--
-          Uncomment the following `Icon` and `Property` tags to change the product icon.
-
-          The product icon is the graphic that appears in the Add/Remove
-          Programs control panel for the application.
-        -->
-        <!--<Icon Id='ProductICO' SourceFile='wix\Product.ico'/>-->
-        <!--<Property Id='ARPPRODUCTICON' Value='ProductICO' />-->
-
-        <Property Id='ARPHELPLINK' Value='https://github.com/axodotdev/axolotlsay'/>
-        
-        <UI>
-            <UIRef Id='WixUI_FeatureTree'/>
-            
-            <!--
-              Enabling the EULA dialog in the installer is a three step process:
-
-                1. Comment out or remove the two `Publish` tags that follow the
-                   `WixVariable` tag.
-                2. Uncomment the `<WixVariable Id='WixUILicenseRtf' Value='Path\to\Eula.rft'>` tag futher down
-                3. Replace the `Value` attribute of the `WixVariable` tag with
-                   the path to a RTF file that will be used as the EULA and
-                   displayed in the license agreement dialog.
-            -->
-            <Publish Dialog='WelcomeDlg' Control='Next' Event='NewDialog' Value='CustomizeDlg' Order='99'>1</Publish>
-            <Publish Dialog='CustomizeDlg' Control='Back' Event='NewDialog' Value='WelcomeDlg' Order='99'>1</Publish>
-
-        </UI>
-
-        
-        <!--
-          Enabling the EULA dialog in the installer requires uncommenting
-          the following `WixUILicenseRTF` tag and changing the `Value`
-          attribute.
-        -->
-        <!-- <WixVariable Id='WixUILicenseRtf' Value='Relative\Path\to\Eula.rtf'/> -->
-
-        
-        <!--
-          Uncomment the next `WixVariable` tag to customize the installer's
-          Graphical User Interface (GUI) and add a custom banner image across
-          the top of each screen. See the WiX Toolset documentation for details
-          about customization.
-
-          The banner BMP dimensions are 493 x 58 pixels.
-        -->
-        <!--<WixVariable Id='WixUIBannerBmp' Value='wix\Banner.bmp'/>-->
-
-        
-        <!--
-          Uncomment the next `WixVariable` tag to customize the installer's
-          Graphical User Interface (GUI) and add a custom image to the first
-          dialog, or screen. See the WiX Toolset documentation for details about
-          customization.
-
-          The dialog BMP dimensions are 493 x 312 pixels.
-        -->
-        <!--<WixVariable Id='WixUIDialogBmp' Value='wix\Dialog.bmp'/>-->
-
-    </Product>
-
-</Wix>
 
 

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1013,6 +1013,9 @@ const { version } = require("./package.json");
 const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0";
 
+const builder_glibc_major_version = 2;
+const builder_glibc_minor_version = 35;
+
 const supportedPlatforms = {
   "aarch64-apple-darwin": {
     "artifact_name": "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1024,7 +1027,17 @@ const supportedPlatforms = {
     "bins": ["axolotlsay"],
     "zip_ext": ".tar.gz"
   },
-  "x86_64-unknown-linux-musl": {
+  "x86_64-unknown-linux-gnu": {
+    "artifact_name": "axolotlsay-x86_64-unknown-linux-musl.tar.gz",
+    "bins": ["axolotlsay"],
+    "zip_ext": ".tar.gz"
+  },
+  "x86_64-unknown-linux-musl-dynamic": {
+    "artifact_name": "axolotlsay-x86_64-unknown-linux-musl.tar.gz",
+    "bins": ["axolotlsay"],
+    "zip_ext": ".tar.gz"
+  },
+  "x86_64-unknown-linux-musl-static": {
     "artifact_name": "axolotlsay-x86_64-unknown-linux-musl.tar.gz",
     "bins": ["axolotlsay"],
     "zip_ext": ".tar.gz"
@@ -1060,6 +1073,29 @@ const getPlatform = () => {
       break;
   }
 
+  if (raw_os_type === "Linux") {
+    if (libc.familySync() == 'musl') {
+      os_type = "unknown-linux-musl-dynamic";
+    } else if (libc.isNonGlibcLinuxSync()) {
+        console.warn("Your libc is neither glibc nor musl; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+    } else {
+      let libc_version = libc.versionSync();
+      let split_libc_version = libc_version.split(".");
+      let libc_major_version = split_libc_version[0];
+      let libc_minor_version = split_libc_version[1];
+      if (
+        libc_major_version != builder_glibc_major_version ||
+        libc_minor_version < builder_glibc_minor_version
+      ) {
+        // We can't run the glibc binaries, but we can run the static musl ones
+        // if they exist
+        console.warn("Your glibc isn't compatible; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+      }
+    }
+  }
+
   // Assume the above succeeded and build a target triple to look things up with.
   // If any of it failed, this lookup will fail and we'll handle it like normal.
   let target_triple = `${arch}-${os_type}`;
@@ -1069,28 +1105,6 @@ const getPlatform = () => {
     error(
       `Platform with type "${raw_os_type}" and architecture "${raw_architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${Object.keys(supportedPlatforms).join(",")}`
     );
-  }
-
-  // These are both situation where you might toggle to unknown-linux-musl but we don't support that yet
-  if (raw_os_type === "Linux") {
-    if (libc.isNonGlibcLinuxSync()) {
-      error("This operating system does not support dynamic linking to glibc.");
-    } else {
-      let libc_version = libc.versionSync();
-      let split_libc_version = libc_version.split(".");
-      let libc_major_version = split_libc_version[0];
-      let libc_minor_version = split_libc_version[1];
-      let min_major_version = 2;
-      let min_minor_version = 17;
-      if (
-        libc_major_version < min_major_version ||
-        libc_minor_version < min_minor_version
-      ) {
-        error(
-          `This operating system needs glibc >= ${min_major_version}.${min_minor_version}, but only has ${libc_version} installed.`
-        );
-      }
-    }
   }
 
   return platform;

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1311,6 +1311,9 @@ const { version } = require("./package.json");
 const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0";
 
+const builder_glibc_major_version = 2;
+const builder_glibc_minor_version = 35;
+
 const supportedPlatforms = {
   "aarch64-apple-darwin": {
     "artifact_name": "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1363,6 +1366,29 @@ const getPlatform = () => {
       break;
   }
 
+  if (raw_os_type === "Linux") {
+    if (libc.familySync() == 'musl') {
+      os_type = "unknown-linux-musl-dynamic";
+    } else if (libc.isNonGlibcLinuxSync()) {
+        console.warn("Your libc is neither glibc nor musl; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+    } else {
+      let libc_version = libc.versionSync();
+      let split_libc_version = libc_version.split(".");
+      let libc_major_version = split_libc_version[0];
+      let libc_minor_version = split_libc_version[1];
+      if (
+        libc_major_version != builder_glibc_major_version ||
+        libc_minor_version < builder_glibc_minor_version
+      ) {
+        // We can't run the glibc binaries, but we can run the static musl ones
+        // if they exist
+        console.warn("Your glibc isn't compatible; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+      }
+    }
+  }
+
   // Assume the above succeeded and build a target triple to look things up with.
   // If any of it failed, this lookup will fail and we'll handle it like normal.
   let target_triple = `${arch}-${os_type}`;
@@ -1372,28 +1398,6 @@ const getPlatform = () => {
     error(
       `Platform with type "${raw_os_type}" and architecture "${raw_architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${Object.keys(supportedPlatforms).join(",")}`
     );
-  }
-
-  // These are both situation where you might toggle to unknown-linux-musl but we don't support that yet
-  if (raw_os_type === "Linux") {
-    if (libc.isNonGlibcLinuxSync()) {
-      error("This operating system does not support dynamic linking to glibc.");
-    } else {
-      let libc_version = libc.versionSync();
-      let split_libc_version = libc_version.split(".");
-      let libc_major_version = split_libc_version[0];
-      let libc_minor_version = split_libc_version[1];
-      let min_major_version = 2;
-      let min_minor_version = 17;
-      if (
-        libc_major_version < min_major_version ||
-        libc_minor_version < min_minor_version
-      ) {
-        error(
-          `This operating system needs glibc >= ${min_major_version}.${min_minor_version}, but only has ${libc_version} installed.`
-        );
-      }
-    }
   }
 
   return platform;

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -428,13 +434,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -428,13 +434,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1311,6 +1311,9 @@ const { version } = require("./package.json");
 const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0";
 
+const builder_glibc_major_version = 2;
+const builder_glibc_minor_version = 35;
+
 const supportedPlatforms = {
   "aarch64-apple-darwin": {
     "artifact_name": "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1363,6 +1366,29 @@ const getPlatform = () => {
       break;
   }
 
+  if (raw_os_type === "Linux") {
+    if (libc.familySync() == 'musl') {
+      os_type = "unknown-linux-musl-dynamic";
+    } else if (libc.isNonGlibcLinuxSync()) {
+        console.warn("Your libc is neither glibc nor musl; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+    } else {
+      let libc_version = libc.versionSync();
+      let split_libc_version = libc_version.split(".");
+      let libc_major_version = split_libc_version[0];
+      let libc_minor_version = split_libc_version[1];
+      if (
+        libc_major_version != builder_glibc_major_version ||
+        libc_minor_version < builder_glibc_minor_version
+      ) {
+        // We can't run the glibc binaries, but we can run the static musl ones
+        // if they exist
+        console.warn("Your glibc isn't compatible; trying static musl binary instead");
+        os_type = "unknown-linux-musl-static";
+      }
+    }
+  }
+
   // Assume the above succeeded and build a target triple to look things up with.
   // If any of it failed, this lookup will fail and we'll handle it like normal.
   let target_triple = `${arch}-${os_type}`;
@@ -1372,28 +1398,6 @@ const getPlatform = () => {
     error(
       `Platform with type "${raw_os_type}" and architecture "${raw_architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${Object.keys(supportedPlatforms).join(",")}`
     );
-  }
-
-  // These are both situation where you might toggle to unknown-linux-musl but we don't support that yet
-  if (raw_os_type === "Linux") {
-    if (libc.isNonGlibcLinuxSync()) {
-      error("This operating system does not support dynamic linking to glibc.");
-    } else {
-      let libc_version = libc.versionSync();
-      let split_libc_version = libc_version.split(".");
-      let libc_major_version = split_libc_version[0];
-      let libc_minor_version = split_libc_version[1];
-      let min_major_version = 2;
-      let min_minor_version = 17;
-      if (
-        libc_major_version < min_major_version ||
-        libc_minor_version < min_minor_version
-      ) {
-        error(
-          `This operating system needs glibc >= ${min_major_version}.${min_minor_version}, but only has ${libc_version} installed.`
-        );
-      }
-    }
   }
 
   return platform;

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -428,13 +434,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -428,13 +434,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -411,13 +417,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -411,13 +417,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -411,13 +417,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -411,13 +417,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -411,13 +417,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -411,13 +417,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -411,13 +417,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -28,6 +28,12 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 
+# glibc provided by our Ubuntu 22.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="35"
+
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
     cat <<EOF
@@ -411,13 +417,25 @@ get_architecture() {
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     local _clibtype="gnu"
+    local _local_glibc
 
     if [ "$_ostype" = Linux ]; then
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
         if ldd --version 2>&1 | grep -q 'musl'; then
-            _clibtype="musl"
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                _clibtype="musl-static"
+            fi
         fi
     fi
 


### PR DESCRIPTION
Now that we have musl binaries, we should teach the installers to use them. In particular, we want to ensure musl gets used in the following circumstances:

* The user is running a non-glibc-based distro, in which case the glibc binaries are guaranteed not to run
* The user is running a glibc-based distro, but their glibc is too old to run the glibc binaries we built

This makes the following changes:

* `install.sh` uses musl
* npm uses musl
* npm inherits the macOS Rosetta code that it was missing