### PR TITLE
feat(msvc-crt-static): add msvc-crt-static config for changing the default

### DIFF
--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -126,6 +126,13 @@ pub struct DistMetadata {
     #[serde(rename = "auto-includes")]
     pub auto_includes: Option<bool>,
 
+    /// Whether msvc targets should statically link the crt
+    ///
+    /// Defaults to true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "msvc-crt-static")]
+    pub msvc_crt_static: Option<bool>,
+
     /// The archive format to use for windows builds (defaults .zip)
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "windows-archive")]
@@ -306,6 +313,7 @@ impl DistMetadata {
             pr_run_mode: _,
             allow_dirty: _,
             ssldotcom_windows_sign: _,
+            msvc_crt_static: _,
         } = self;
         if let Some(include) = include {
             for include in include {
@@ -349,6 +357,7 @@ impl DistMetadata {
             pr_run_mode,
             allow_dirty,
             ssldotcom_windows_sign,
+            msvc_crt_static,
         } = self;
 
         // Check for global settings on local packages
@@ -386,6 +395,9 @@ impl DistMetadata {
         }
         if ssldotcom_windows_sign.is_some() {
             warn!("package.metadata.dist.ssldotcom-windows-sign is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
+        }
+        if msvc_crt_static.is_some() {
+            warn!("package.metadata.dist.msvc-crt-static is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
         }
 
         // Merge non-global settings

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -223,6 +223,7 @@ fn get_new_dist_metadata(
             pr_run_mode: None,
             allow_dirty: None,
             ssldotcom_windows_sign: None,
+            msvc_crt_static: None,
         }
     };
 
@@ -740,6 +741,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         pr_run_mode,
         allow_dirty,
         ssldotcom_windows_sign,
+        msvc_crt_static,
     } = &meta;
 
     apply_optional_value(
@@ -910,6 +912,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "allow-dirty",
         "# Skip checking whether the specified configuration files are up to date\n",
         allow_dirty.as_ref(),
+    );
+
+    apply_optional_value(
+        table,
+        "msvc-crt-static",
+        "Whether +crt-static should be used on msvc\n",
+        *msvc_crt_static,
     );
 
     apply_optional_value(


### PR DESCRIPTION
This is a very simplistic flag because in the future we need to do some more principled/complex design work for dynamic vs static libc, and its relationship to system dependencies and installers.

For now it's basically an escape hatch for people who want to roll the dice.