### PR TITLE
fix(sysdeps): handle empty Linux packages

### DIFF
--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -1173,10 +1173,15 @@ impl Library {
                 let output = String::from_utf8(output.stdout)?;
 
                 let package = output.split(':').nth(0).unwrap();
+                let source = if package.is_empty() {
+                    None
+                } else {
+                    Some(package.to_owned())
+                };
 
                 Ok(Self {
                     path: library,
-                    source: Some(package.to_owned()),
+                    source,
                 })
             }
             // Couldn't find a package for this file


### PR DESCRIPTION
We've seen a minor UI issue with Linux dependencies. I anticipated catching the error status output from `dpkg -S` and reacting to that, but we were still getting cases where not finding the package and accidentally returning an empty string as the "package". This checks for that case and properly handles it.

Before this fix, the linkage reporter was giving us outputs like:

```
/path/to/lib ()
```

And with this fix, it looks like:

```
/path/to/lib
```