### PR TITLE
fix(config): handle missing PackageId

### DIFF
--- a/cargo-dist/src/cargo_build.rs
+++ b/cargo-dist/src/cargo_build.rs
@@ -227,7 +227,11 @@ pub fn build_cargo_target(dist_graph: &DistGraph, target: &CargoBuildStep) -> Re
         FastMap::<String, FastMap<String, Vec<(Utf8PathBuf, Utf8PathBuf)>>>::new();
     for &binary_idx in &target.expected_binaries {
         let binary = &dist_graph.binary(binary_idx);
-        let package_id = binary.pkg_id.to_string();
+        let package_id = binary
+            .pkg_id
+            .clone()
+            .expect("pkg_id is mandatory for cargo builds")
+            .to_string();
         let exe_name = binary.name.clone();
         for exe_dest in &binary.copy_exe_to {
             expected_exes

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -236,7 +236,7 @@ pub struct Binary {
     ///
     /// This is an "opaque" string that will show up in things like cargo machine-readable output,
     /// but **this is not the format that cargo -p flags expect**. Use pkg_spec for that.
-    pub pkg_id: PackageId,
+    pub pkg_id: Option<PackageId>,
     /// An ideally unambiguous way to refer to a package for the purpose of cargo -p flags.
     pub pkg_spec: String,
     /// The name of the binary (as defined by the Cargo.toml)
@@ -889,8 +889,12 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         for (pkg_idx, binary_name) in bins.clone() {
             let package = self.workspace.package(pkg_idx);
             let package_metadata = self.package_metadata(pkg_idx);
-            let version = package.version.as_ref().unwrap().cargo();
-            let pkg_id = package.cargo_package_id.clone().unwrap();
+            let version = package
+                .version
+                .as_ref()
+                .expect("Package version is mandatory!")
+                .cargo();
+            let pkg_id = package.cargo_package_id.clone();
             // For now we just use the name of the package as its package_spec.
             // I'm not sure if there are situations where this is ambiguous when
             // referring to a package in your workspace that you want to build an app for.


### PR DESCRIPTION
This is an `Option`, we shouldn't `unwrap()` in case it's actually missing.

I added an `expect()` to the version since that field's actually mandatory, but it seems like we can cope with the package ID being missing.