### PR TITLE
feat: enable generic builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,16 +155,16 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13503c331b8e2d419c29a0614ec8f9b7c95ace01b045cafd7c465d2fe777e1a"
+checksum = "8da04fda61e491249006babba8a2f32927369edfb3328abef9590ef97c24a564"
 dependencies = [
  "axoasset",
  "camino",
  "clap",
  "console",
  "guppy",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "miette",
  "parse-changelog",
  "pathdiff",
@@ -1150,15 +1150,6 @@ name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -34,7 +34,7 @@ axotag = "0.1.0"
 cargo-dist-schema = { version = "=0.4.2", path = "../cargo-dist-schema" }
 
 axoasset = { version = "0.6.0", features = ["json-serde", "toml-serde", "toml-edit", "compression"] }
-axoproject = { version = "0.5.0", default-features = false, features = ["cargo-projects"] }
+axoproject = { version = "0.6.0", default-features = false, features = ["cargo-projects", "generic-projects"] }
 
 comfy-table = "7.0.1"
 miette = { version = "5.6.0" }

--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -263,7 +263,7 @@ fn check_dist_package(
             }
         }
         ReleaseType::Version(ver) => {
-            if pkg.version.as_ref().unwrap().cargo() != ver {
+            if pkg.version.as_ref().unwrap().semver() != ver {
                 return Some(format!("didn't match tag {}", announcing.tag));
             }
         }
@@ -438,7 +438,7 @@ fn possible_tags<'a>(
     let mut versions = SortedMap::<&Version, Vec<PackageIdx>>::new();
     for pkg_idx in rust_releases {
         let info = graph.workspace().package(pkg_idx);
-        let version = info.version.as_ref().unwrap().cargo();
+        let version = info.version.as_ref().unwrap().semver();
         versions.entry(version).or_default().push(pkg_idx);
     }
     versions
@@ -486,7 +486,7 @@ fn tag_help(
     let some_tag = format!(
         "--tag={}-v{}",
         info.name,
-        info.version.as_ref().unwrap().cargo()
+        info.version.as_ref().unwrap().semver()
     );
 
     writeln!(

--- a/cargo-dist/src/cargo_build.rs
+++ b/cargo-dist/src/cargo_build.rs
@@ -3,10 +3,11 @@
 use std::env;
 use std::process::Command;
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8PathBuf;
 use miette::{miette, Context, IntoDiagnostic};
 use tracing::{info, warn};
 
+use crate::env::{calculate_ldflags, fetch_brew_env, parse_env, select_brew_env};
 use crate::{
     copy_file, CargoBuildStep, CargoTargetFeatureList, CargoTargetPackages, DistGraph, FastMap,
     RustupStep, SortedMap,
@@ -142,22 +143,8 @@ pub fn build_cargo_target(dist_graph: &DistGraph, target: &CargoBuildStep) -> Re
     let mut rustflags = target.rustflags.clone();
     let mut desired_extra_env = vec![];
     let skip_brewfile = env::var("DO_NOT_USE_BREWFILE").is_ok();
-    if let Some(brew) = &dist_graph.tools.brew {
-        if Utf8Path::new("Brewfile").exists() && !skip_brewfile {
-            // Uses `brew bundle exec` to just print its own environment,
-            // allowing us to capture what it generated and decide what
-            // to do with it.
-            let result = Command::new(&brew.cmd)
-                .arg("bundle")
-                .arg("exec")
-                .arg("--")
-                .arg("/usr/bin/env")
-                .output()
-                .into_diagnostic()
-                .wrap_err_with(|| "failed to exec brew bundle exec".to_string())?;
-
-            let env_output = String::from_utf8_lossy(&result.stdout).to_string();
-
+    if !skip_brewfile {
+        if let Some(env_output) = fetch_brew_env(dist_graph)? {
             let brew_env = parse_env(&env_output)?;
             desired_extra_env = select_brew_env(&brew_env);
             rustflags = determine_brew_rustflags(&rustflags, &brew_env);
@@ -357,108 +344,10 @@ pub fn rustup_toolchain(_dist_graph: &DistGraph, cmd: &RustupStep) -> Result<()>
     Ok(())
 }
 
-// Takes a string in KEY=value environment variable format and
-// parses it into a BTreeMap. The string syntax is sh-compatible, and also the
-// format returned by `env`.
-// Note that we trust the parsed string to contain a given key only once;
-// if specified more than once, only the final occurrence will be included.
-fn parse_env(env_string: &str) -> DistResult<SortedMap<&str, &str>> {
-    let mut parsed = SortedMap::new();
-    for line in env_string.trim_end().split('\n') {
-        let Some((key, value)) = line.split_once('=') else {
-            return Err(DistError::EnvParseError {
-                line: line.to_owned(),
-            });
-        };
-        parsed.insert(key, value);
-    }
-
-    Ok(parsed)
-}
-
-/// Given the environment captured from `brew bundle exec -- env`, returns
-/// a list of all dependencies from that environment and the opt prefixes
-/// to those packages.
-fn formulas_from_env(environment: &SortedMap<&str, &str>) -> Vec<(String, String)> {
-    let mut packages = vec![];
-
-    // Set by Homebrew/brew bundle - a comma-separated list of all
-    // dependencies in the recursive tree calculated from the dependencies
-    // in the Brewfile.
-    if let Some(formulastring) = environment.get("HOMEBREW_DEPENDENCIES") {
-        // Set by Homebrew/brew bundle - the path to Homebrew's "opt"
-        // directory, which is where links to the private cellar of every
-        // installed package lives.
-        // Usually /opt/homebrew/opt or /usr/local/opt.
-        if let Some(opt_prefix) = environment.get("HOMEBREW_OPT") {
-            for dep in formulastring.split(',') {
-                // Unwrap here is safe because `split` will always return
-                // a collection of at least one item.
-                let short_name = dep.split('/').last().unwrap();
-                let pkg_opt = format!("{opt_prefix}/{short_name}");
-                packages.push((dep.to_owned(), pkg_opt));
-            }
-        }
-    }
-
-    packages
-}
-
-/// Takes a BTreeMap of key/value environment variables produced by
-/// `brew bundle exec` and decides which ones we want to keep for our own builds.
-/// Returns a Vec containing (KEY, value) tuples.
-fn select_brew_env(environment: &SortedMap<&str, &str>) -> Vec<(String, String)> {
-    let mut desired_env = vec![];
-
-    // Several of Homebrew's environment variables are safe for us to use
-    // unconditionally, so pick those in their entirety.
-    if let Some(value) = environment.get("PKG_CONFIG_PATH") {
-        desired_env.push(("PKG_CONFIG_PATH".to_owned(), value.to_string()))
-    }
-    if let Some(value) = environment.get("PKG_CONFIG_LIBDIR") {
-        desired_env.push(("PKG_CONFIG_LIBDIR".to_owned(), value.to_string()))
-    }
-    if let Some(value) = environment.get("CMAKE_INCLUDE_PATH") {
-        desired_env.push(("CMAKE_INCLUDE_PATH".to_owned(), value.to_string()))
-    }
-    if let Some(value) = environment.get("CMAKE_LIBRARY_PATH") {
-        desired_env.push(("CMAKE_LIBRARY_PATH".to_owned(), value.to_string()))
-    }
-    let mut paths = vec![];
-
-    // For each listed dependency, add it to the PATH
-    for (_, pkg_opt) in formulas_from_env(environment) {
-        // Not every package will have a /bin or /sbin directory,
-        // but it's safe to add both to the PATH just in case.
-        paths.push(format!("{pkg_opt}/bin"));
-        paths.push(format!("{pkg_opt}/sbin"));
-    }
-
-    if !paths.is_empty() {
-        let our_path = env!("PATH");
-        let desired_path = format!("{our_path}:{}", paths.join(":"));
-
-        desired_env.insert(0, ("PATH".to_owned(), desired_path));
-    }
-
-    desired_env
-}
-
 /// Similar to the above, we read Homebrew's recursive dependency tree and
 /// then append link flags to cargo-dist's rustflags.
 /// These ensure that Rust can find C libraries that may exist within
 /// each package's prefix.
 fn determine_brew_rustflags(base_rustflags: &str, environment: &SortedMap<&str, &str>) -> String {
-    let mut rustflags = base_rustflags.to_owned();
-    // For each listed dependency, add it to CFLAGS/LDFLAGS
-    for (_, pkg_opt) in formulas_from_env(environment) {
-        // Note that this path might not actually exist; not every
-        // package contains libraries. However, it's safe to
-        // append this flag anyway; Rust passes it on to the
-        // compiler/linker, which tolerate missing directories
-        // just fine.
-        rustflags = format!("{rustflags} -L{pkg_opt}/lib");
-    }
-
-    rustflags
+    format!("{base_rustflags} {}", calculate_ldflags(environment))
 }

--- a/cargo-dist/src/env.rs
+++ b/cargo-dist/src/env.rs
@@ -1,0 +1,147 @@
+//! Functions to parse and manipulate the environment
+
+use std::process::Command;
+
+use camino::Utf8Path;
+use miette::{Context, IntoDiagnostic};
+
+use crate::{
+    errors::{DistError, DistResult, Result},
+    DistGraph, SortedMap,
+};
+
+/// Fetches the Homebrew environment from `brew bundle exec`
+pub fn fetch_brew_env(dist_graph: &DistGraph) -> Result<Option<String>> {
+    if let Some(brew) = &dist_graph.tools.brew {
+        if Utf8Path::new("Brewfile").exists() {
+            // Uses `brew bundle exec` to just print its own environment,
+            // allowing us to capture what it generated and decide what
+            // to do with it.
+            let result = Command::new(&brew.cmd)
+                .arg("bundle")
+                .arg("exec")
+                .arg("--")
+                .arg("/usr/bin/env")
+                .output()
+                .into_diagnostic()
+                .wrap_err_with(|| "failed to exec brew bundle exec".to_string())?;
+
+            return Ok(Some(String::from_utf8_lossy(&result.stdout).to_string()));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Takes a string in KEY=value environment variable format and
+/// parses it into a BTreeMap. The string syntax is sh-compatible, and also the
+/// format returned by `env`.
+/// Note that we trust the parsed string to contain a given key only once;
+/// if specified more than once, only the final occurrence will be included.
+pub fn parse_env(env_string: &str) -> DistResult<SortedMap<&str, &str>> {
+    let mut parsed = SortedMap::new();
+    for line in env_string.trim_end().split('\n') {
+        let Some((key, value)) = line.split_once('=') else {
+            return Err(DistError::EnvParseError {
+                line: line.to_owned(),
+            });
+        };
+        parsed.insert(key, value);
+    }
+
+    Ok(parsed)
+}
+
+/// Given the environment captured from `brew bundle exec -- env`, returns
+/// a list of all dependencies from that environment and the opt prefixes
+/// to those packages.
+fn formulas_from_env(environment: &SortedMap<&str, &str>) -> Vec<(String, String)> {
+    let mut packages = vec![];
+
+    // Set by Homebrew/brew bundle - a comma-separated list of all
+    // dependencies in the recursive tree calculated from the dependencies
+    // in the Brewfile.
+    if let Some(formulastring) = environment.get("HOMEBREW_DEPENDENCIES") {
+        // Set by Homebrew/brew bundle - the path to Homebrew's "opt"
+        // directory, which is where links to the private cellar of every
+        // installed package lives.
+        // Usually /opt/homebrew/opt or /usr/local/opt.
+        if let Some(opt_prefix) = environment.get("HOMEBREW_OPT") {
+            for dep in formulastring.split(',') {
+                // Unwrap here is safe because `split` will always return
+                // a collection of at least one item.
+                let short_name = dep.split('/').last().unwrap();
+                let pkg_opt = format!("{opt_prefix}/{short_name}");
+                packages.push((dep.to_owned(), pkg_opt));
+            }
+        }
+    }
+
+    packages
+}
+
+/// Takes a BTreeMap of key/value environment variables produced by
+/// `brew bundle exec` and decides which ones we want to keep for our own builds.
+/// Returns a Vec containing (KEY, value) tuples.
+pub fn select_brew_env(environment: &SortedMap<&str, &str>) -> Vec<(String, String)> {
+    let mut desired_env = vec![];
+
+    // Several of Homebrew's environment variables are safe for us to use
+    // unconditionally, so pick those in their entirety.
+    if let Some(value) = environment.get("PKG_CONFIG_PATH") {
+        desired_env.push(("PKG_CONFIG_PATH".to_owned(), value.to_string()))
+    }
+    if let Some(value) = environment.get("PKG_CONFIG_LIBDIR") {
+        desired_env.push(("PKG_CONFIG_LIBDIR".to_owned(), value.to_string()))
+    }
+    if let Some(value) = environment.get("CMAKE_INCLUDE_PATH") {
+        desired_env.push(("CMAKE_INCLUDE_PATH".to_owned(), value.to_string()))
+    }
+    if let Some(value) = environment.get("CMAKE_LIBRARY_PATH") {
+        desired_env.push(("CMAKE_LIBRARY_PATH".to_owned(), value.to_string()))
+    }
+    let mut paths = vec![];
+
+    // For each listed dependency, add it to the PATH
+    for (_, pkg_opt) in formulas_from_env(environment) {
+        // Not every package will have a /bin or /sbin directory,
+        // but it's safe to add both to the PATH just in case.
+        paths.push(format!("{pkg_opt}/bin"));
+        paths.push(format!("{pkg_opt}/sbin"));
+    }
+
+    if !paths.is_empty() {
+        let our_path = env!("PATH");
+        let desired_path = format!("{our_path}:{}", paths.join(":"));
+
+        desired_env.insert(0, ("PATH".to_owned(), desired_path));
+    }
+
+    desired_env
+}
+
+/// Determines the flags needed by the linker to link against
+/// Homebrew packages in the provided environment.
+/// Note that this may reference directories which don't exist;
+/// this function doesn't validate the existence of directories in the
+/// generated flags.
+pub fn calculate_ldflags(environment: &SortedMap<&str, &str>) -> String {
+    formulas_from_env(environment)
+        .iter()
+        .map(|(_, pkg_opt)| format!("-L{pkg_opt}/lib"))
+        .collect::<Vec<String>>()
+        .join(" ")
+}
+
+/// Determines the flags needed by the compiler to locate headers
+/// from Homebrew packages in the provided environment.
+/// Note that this may reference directories which don't exist;
+/// this function doesn't validate the existence of directories in the
+/// generated flags.
+pub fn calculate_cflags(environment: &SortedMap<&str, &str>) -> String {
+    formulas_from_env(environment)
+        .iter()
+        .map(|(_, pkg_opt)| format!("-I{pkg_opt}/include"))
+        .collect::<Vec<String>>()
+        .join(" ")
+}

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -248,6 +248,14 @@ pub enum DistError {
     /// random axotag error
     #[error(transparent)]
     AxotagError(#[from] axotag::errors::TagError),
+
+    /// No workspace found from axoproject
+    #[error("No workspace found; either your project doesn't have a Cargo.toml/dist.toml, or we couldn't read it")]
+    ProjectMissing {
+        /// axoproject's error for the unidentified project
+        #[related]
+        sources: Vec<AxoprojectError>,
+    },
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/src/generic_build.rs
+++ b/cargo-dist/src/generic_build.rs
@@ -1,0 +1,117 @@
+//! Functionality required to invoke a generic build's `build-command`
+
+use std::{env, process::Command};
+
+use camino::Utf8Path;
+use miette::{miette, Context, IntoDiagnostic};
+use tracing::info;
+
+use crate::{
+    copy_file,
+    env::{calculate_cflags, calculate_ldflags, fetch_brew_env, parse_env, select_brew_env},
+    errors::Result,
+    BinaryIdx, BuildStep, DistGraph, DistGraphBuilder, GenericBuildStep, SortedMap, TargetTriple,
+};
+
+impl<'a> DistGraphBuilder<'a> {
+    pub(crate) fn compute_generic_builds(&mut self) -> Vec<BuildStep> {
+        let mut targets = SortedMap::<TargetTriple, Vec<BinaryIdx>>::new();
+        for (binary_idx, binary) in self.inner.binaries.iter().enumerate() {
+            targets
+                .entry(binary.target.clone())
+                .or_default()
+                .push(BinaryIdx(binary_idx));
+        }
+
+        let mut builds = vec![];
+        for (target, binaries) in targets {
+            builds.push(BuildStep::Generic(GenericBuildStep {
+                target_triple: target.clone(),
+                expected_binaries: binaries,
+                build_command: self
+                    .workspace
+                    .build_command
+                    .clone()
+                    .expect("A build command is mandatory for generic builds"),
+            }));
+        }
+
+        builds
+    }
+}
+
+/// Build a generic target
+pub fn build_generic_target(dist_graph: &DistGraph, target: &GenericBuildStep) -> Result<()> {
+    let mut command_string = target.build_command.clone();
+    eprintln!(
+        "building generic target ({} via {})",
+        target.target_triple,
+        command_string.join(" ")
+    );
+
+    let mut desired_extra_env = vec![];
+    let mut cflags = None;
+    let mut ldflags = None;
+    let skip_brewfile = env::var("DO_NOT_USE_BREWFILE").is_ok();
+    if !skip_brewfile {
+        if let Some(env_output) = fetch_brew_env(dist_graph)? {
+            let brew_env = parse_env(&env_output)?;
+            desired_extra_env = select_brew_env(&brew_env);
+            cflags = Some(calculate_cflags(&brew_env));
+            ldflags = Some(calculate_ldflags(&brew_env));
+        }
+    }
+
+    let args = command_string.split_off(1);
+    let mut command = Command::new(
+        command_string
+            .first()
+            .expect("The build command must contain at least one entry"),
+    );
+    for arg in args {
+        command.arg(arg);
+    }
+    // If we generated any extra environment variables to
+    // inject into the environment, apply them now.
+    command.envs(desired_extra_env);
+
+    // Ensure we inform the build what architecture and platform
+    // it's building for.
+    command.env("CARGO_DIST_TARGET", &target.target_triple);
+
+    // Pass CFLAGS/LDFLAGS for C builds
+    if let Some(cflags) = cflags {
+        // These typically contain the same values as each other.
+        // Properly speaking, CPPFLAGS is for C++ software and CFLAGS is for
+        // C software, but many buildsystems treat them as interchangeable.
+        command.env("CFLAGS", &cflags);
+        command.env("CPPFLAGS", &cflags);
+    }
+    if let Some(ldflags) = ldflags {
+        command.env("LDFLAGS", &ldflags);
+    }
+
+    info!("exec: {:?}", command);
+    command
+        .output()
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to exec generic build: {command:?}"))?;
+
+    // Check that we got everything we expected, and normalize to ArtifactIdx => Artifact Path
+    for binary_idx in &target.expected_binaries {
+        let binary = dist_graph.binary(*binary_idx);
+        let binary_path = Utf8Path::new(&binary.file_name);
+        if binary_path.exists() {
+            for dest in &binary.copy_exe_to {
+                copy_file(binary_path, dest)?;
+            }
+        } else {
+            return Err(miette!(
+                "failed to find bin {} -- did the build above have errors?",
+                binary_path
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -21,6 +21,7 @@ use cargo_dist_schema::DistManifest;
 use config::{
     ArtifactMode, ChecksumStyle, CompressionImpl, Config, DirtyMode, GenerateMode, ZipStyle,
 };
+use generic_build::build_generic_target;
 use semver::Version;
 use tracing::info;
 
@@ -33,7 +34,9 @@ pub mod announce;
 pub mod backend;
 pub mod cargo_build;
 pub mod config;
+pub mod env;
 pub mod errors;
+pub mod generic_build;
 mod init;
 pub mod linkage;
 pub mod manifest;
@@ -96,6 +99,7 @@ fn run_build_step(
     manifest: &DistManifest,
 ) -> Result<()> {
     match target {
+        BuildStep::Generic(target) => build_generic_target(dist_graph, target),
         BuildStep::Cargo(target) => build_cargo_target(dist_graph, target),
         BuildStep::Rustup(cmd) => rustup_toolchain(dist_graph, cmd),
         BuildStep::CopyFile(CopyStep {

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -88,6 +88,7 @@ pub fn mock_workspace(packages: Vec<PackageInfo>) -> WorkspaceInfo {
             changelog: None,
         },
         warnings: vec![],
+        build_command: None,
         cargo_metadata_table: None,
         cargo_profiles: Default::default(),
     }


### PR DESCRIPTION
This PR adds a new "generic" build type. Most of the process is identical to Cargo builds, but I've extended our build logic to add a new `GenericBuildStep` that encapsulates a large part of the different behaviour.

This is an MVP, and it's missing some features we likely want to see in the future:

* Only workspaces are supported; we don't have a concept of packages yet. Since we don't inherit anything like that from Cargo, we'll have to think about what this looks like.
* The user has to manually specify all of the binaries that the build output will contain, since we don't have Cargo to get that information from. In the future, we probably want to make these globs instead of literal paths so that we can accommodate more complex builds.

We defer most of the project loading and parsing logic to axoproject, like we do with Cargo projects.

Depends on https://github.com/axodotdev/axoproject/pull/45 being in a release before this is mergeable.