### PR TITLE
fix(homebrew): reimplement Homebrew class code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,6 @@ dependencies = [
  "clap-cargo",
  "comfy-table",
  "console",
- "cruet",
  "dialoguer",
  "flate2",
  "goblin",
@@ -604,16 +603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "cruet"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113a9e83d8f614be76de8df1f25bf9d0ea6e85ea573710a3d3f3abe1438ae49c"
-dependencies = [
- "once_cell",
- "regex",
 ]
 
 [[package]]

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -41,7 +41,6 @@ thiserror = "1.0.35"
 tracing = { version = "0.1.36", features = ["log"] }
 serde = { version = "1.0.192", features = ["derive"] }
 cargo_metadata = "0.18.1"
-cruet = "0.13.3"
 camino = "1.1.1"
 semver = "1.0.14"
 newline-converter = "0.3.0"

--- a/cargo-dist/src/backend/installer/homebrew.rs
+++ b/cargo-dist/src/backend/installer/homebrew.rs
@@ -81,3 +81,158 @@ pub(crate) fn write_homebrew_formula(
     LocalAsset::write_new(&script, &info.inner.dest_path)?;
     Ok(())
 }
+
+/// Converts the provided app name into a Ruby class-compatible
+/// string suitable for use as the class in a Homebrew formula.
+// Homebrew implementation is Formulary.class_s:
+// https://github.com/Homebrew/brew/blob/8c7cd3c0fd46f7808e782e40359c19271f950a75/Library/Homebrew/formulary.rb#L447-L453
+pub fn to_class_case(app_name: &str) -> String {
+    if app_name.is_empty() {
+        return app_name.to_owned();
+    }
+
+    let mut out = app_name.to_owned();
+    // First, we uppercase the first character in the string
+    out[..1].make_ascii_uppercase();
+
+    let mut chars = vec![];
+    let mut iter = out.chars().peekable();
+    let mut el = iter.next();
+    let mut at_replaced = false;
+    while el.is_some() {
+        let char = el.unwrap();
+        // -, _ and . are invalid characters in Ruby classes.
+        // Homebrew handles these by stripping them, then uppercasing
+        // the following character
+        match char {
+            '-' | '_' | '.' => {
+                // Only perform a replacement if the following character is
+                // in the range [a-zA-Z0-9]
+                if let Some(next) = iter.peek() {
+                    if next.is_ascii_digit() || next.is_ascii_alphabetic() {
+                        chars.push(next.to_ascii_uppercase());
+                        iter.next();
+                    } else {
+                        chars.push(char);
+                    }
+                } else {
+                    chars.push(char);
+                }
+            }
+            // Perform an @ replacement, but only if followed by a digit
+            // We also perform this replacement only once
+            '@' => {
+                if let Some(next) = iter.peek() {
+                    if next.is_ascii_digit() && !at_replaced {
+                        chars.push('A');
+                        chars.push('T');
+                        chars.push(*next);
+                        iter.next();
+                        at_replaced = true;
+                    } else {
+                        chars.push(char);
+                    }
+                } else {
+                    chars.push(char);
+                }
+            }
+            // So that things like c++ become cxx
+            '+' => {
+                chars.push('x');
+            }
+            _ => chars.push(char),
+        }
+
+        el = iter.next();
+    }
+    chars.iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_class_case;
+
+    fn run_comparison(in_str: &str, expected: &str) {
+        let out_str = to_class_case(in_str);
+
+        assert_eq!(out_str, expected);
+    }
+
+    #[test]
+    fn class_case_basic() {
+        run_comparison("ccd2cue", "Ccd2cue");
+    }
+
+    #[test]
+    fn handles_dashes() {
+        run_comparison("akaikatana-repack", "AkaikatanaRepack");
+    }
+
+    #[test]
+    fn handles_single_letter_then_dash() {
+        run_comparison("c-lang", "CLang");
+    }
+
+    #[test]
+    fn handles_underscores() {
+        run_comparison("abc_def", "AbcDef");
+    }
+
+    #[test]
+    fn handles_strings_with_dots() {
+        run_comparison("last.fm", "LastFm");
+    }
+
+    #[test]
+    fn replaces_plus_with_x() {
+        run_comparison("c++", "Cxx");
+    }
+
+    #[test]
+    fn replaces_ampersand_with_at() {
+        run_comparison("openssl@3", "OpensslAT3");
+    }
+
+    // The following are some extra test cases not covered in Homebrew's specs
+    // to ensure we remain quirk-for-quirk compatible.
+    #[test]
+    fn class_caps_after_numbers() {
+        run_comparison("mni2mz3", "Mni2mz3");
+    }
+
+    #[test]
+    fn handles_pluralization() {
+        run_comparison("tetanes", "Tetanes");
+    }
+
+    #[test]
+    fn multiple_underscores() {
+        run_comparison("abc__def", "Abc_Def");
+    }
+
+    // Yes, it's correct that Homebrew produces a class-incompatible string
+    #[test]
+    fn multiple_periods() {
+        run_comparison("abc..def", "Abc.Def");
+    }
+
+    #[test]
+    fn multiple_special_chars() {
+        run_comparison("abc-.def", "Abc-Def");
+    }
+
+    #[test]
+    fn ends_with_dash() {
+        run_comparison("abc-", "Abc-");
+    }
+
+    #[test]
+    fn multiple_ampersands() {
+        run_comparison("openssl@@3", "Openssl@AT3");
+    }
+
+    #[test]
+    fn ampersand_but_no_digit() {
+        run_comparison("openssl@blah", "Openssl@blah");
+    }
+}

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -51,7 +51,6 @@
 use axoproject::{PackageId, PackageIdx, WorkspaceInfo};
 use camino::Utf8PathBuf;
 use cargo_dist_schema::{DistManifest, Hosting};
-use cruet::to_class_case;
 use miette::{miette, Context, IntoDiagnostic};
 use semver::Version;
 use std::process::Command;
@@ -64,7 +63,9 @@ use crate::config::{DependencyKind, DirtyMode, ProductionMode, SystemDependencie
 use crate::{
     backend::{
         installer::{
-            homebrew::HomebrewInstallerInfo, msi::MsiInstallerInfo, npm::NpmInstallerInfo,
+            homebrew::{to_class_case, HomebrewInstallerInfo},
+            msi::MsiInstallerInfo,
+            npm::NpmInstallerInfo,
             ExecutableZipFragment, InstallerImpl, InstallerInfo,
         },
         templates::Templates,


### PR DESCRIPTION
We previously depended on an external crate, but its implementation wasn't 100% identical to Homebrew's. This replaces that with a custom function that implements Homebrew's logic precisely, along with a test case that covers all of Homebrew's test cases plus the two recently reported bugs.

Fixes #541.
Fixes #551.