### PR TITLE
feat(installer): add additional shell config

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -313,6 +313,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -328,11 +350,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -345,7 +369,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -48,7 +48,7 @@ then unpacks the binaries and installs them to {% if install_path.kind == "Cargo
     {{ error("unimplemented install_path format: " ~ install_path.kind) }}
 {%- endif %}
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     {{ app_name }}-installer.sh [OPTIONS]
@@ -307,7 +307,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -322,8 +324,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -349,14 +373,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/gallery/dist.rs
+++ b/cargo-dist/tests/gallery/dist.rs
@@ -370,6 +370,7 @@ impl DistResult {
             let app_home = tempdir.join(format!(".{app_name}"));
             let _output = script.output_checked(|cmd| {
                 cmd.env("HOME", &tempdir)
+                    .env("ZDOTDIR", &tempdir)
                     .env("MY_ENV_VAR", &app_home)
                     .env_remove("CARGO_HOME")
             })?;

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     akaikatana-repack-installer.sh [OPTIONS]
@@ -290,7 +290,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -305,8 +307,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -332,14 +356,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -296,6 +296,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -311,11 +333,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -328,7 +352,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     akaikatana-repack-installer.sh [OPTIONS]
@@ -300,7 +300,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -315,8 +317,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -342,14 +366,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -306,6 +306,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -321,11 +343,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -338,7 +362,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     akaikatana-repack-installer.sh [OPTIONS]
@@ -290,7 +290,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -305,8 +307,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -332,14 +356,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -296,6 +296,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -311,11 +333,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -328,7 +352,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -290,7 +290,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -305,8 +307,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -332,14 +356,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -296,6 +296,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -311,11 +333,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -328,7 +352,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -290,7 +290,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -305,8 +307,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -332,14 +356,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -296,6 +296,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -311,11 +333,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -328,7 +352,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -296,6 +296,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -311,11 +333,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -328,7 +352,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -290,7 +290,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -305,8 +307,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -332,14 +356,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -296,6 +296,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -311,11 +333,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -328,7 +352,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -290,7 +290,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -305,8 +307,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -332,14 +356,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -306,6 +306,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -321,11 +343,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -338,7 +362,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -300,7 +300,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -315,8 +317,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -342,14 +366,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -306,6 +306,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -321,11 +343,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -338,7 +362,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -300,7 +300,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -315,8 +317,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -342,14 +366,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -296,6 +296,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -311,11 +333,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -328,7 +352,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -290,7 +290,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -305,8 +307,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -332,14 +356,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -296,6 +296,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -311,11 +333,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -328,7 +352,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -290,7 +290,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -305,8 +307,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -332,14 +356,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -296,6 +296,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -311,11 +333,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -328,7 +352,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -290,7 +290,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -305,8 +307,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -332,14 +356,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -296,6 +296,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -311,11 +333,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -328,7 +352,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -290,7 +290,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -305,8 +307,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -332,14 +356,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -296,6 +296,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -311,11 +333,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -328,7 +352,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$CARGO_HOME/bin (\$HOME/.cargo/bin)
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -290,7 +290,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -305,8 +307,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -332,14 +356,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$MY_ENV_VAR/
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -273,7 +273,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -288,8 +290,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -315,14 +339,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -279,6 +279,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -294,11 +316,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -311,7 +335,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -279,6 +279,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -294,11 +316,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -311,7 +335,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$MY_ENV_VAR/bin
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -273,7 +273,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -288,8 +290,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -315,14 +339,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$MY_ENV_VAR/My Axolotlsay Documents
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -273,7 +273,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -288,8 +290,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -315,14 +339,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -279,6 +279,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -294,11 +316,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -311,7 +335,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$MY_ENV_VAR/My Axolotlsay Documents/bin
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -273,7 +273,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -288,8 +290,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -315,14 +339,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -279,6 +279,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -294,11 +316,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -311,7 +335,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$HOME/.axolotlsay/bins
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -273,7 +273,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -288,8 +290,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -315,14 +339,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -279,6 +279,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -294,11 +316,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -311,7 +335,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$HOME/.axolotlsay
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -273,7 +273,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -288,8 +290,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -315,14 +339,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -279,6 +279,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -294,11 +316,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -311,7 +335,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -279,6 +279,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -294,11 +316,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -311,7 +335,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$HOME/My Axolotlsay Documents
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -273,7 +273,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -288,8 +290,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -315,14 +339,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -45,7 +45,7 @@ This script detects what platform you're on and fetches an appropriate archive f
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1
 then unpacks the binaries and installs them to \$HOME/My Axolotlsay Documents/bin
 
-It will then add that dir to PATH by adding the appropriate line to \$HOME/.profile
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
 USAGE:
     axolotlsay-installer.sh [OPTIONS]
@@ -273,7 +273,9 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
     fi
 }
 
@@ -288,8 +290,30 @@ add_install_dir_to_path() {
     local _install_dir_expr="$1"
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+
     if [ -n "${HOME:-}" ]; then
-        local _rcfile="$HOME/.profile"
+        local _target
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            local _rcfile="$HOME/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _target="$HOME/$_rcfile_relative"
+        fi
+
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
         # This apparently comes up a lot on freebsd. It's easy enough to always add
         # the more robust line to rcfiles, but when telling the user to apply the change
@@ -315,14 +339,14 @@ add_install_dir_to_path() {
         # (on error we want to create the file, which >> conveniently does)
         #
         # We search for both kinds of line here just to do the right thing in more cases.
-        if ! grep -F "$_robust_line" "$_rcfile" > /dev/null 2>/dev/null && \
-           ! grep -F "$_pretty_line" "$_rcfile" > /dev/null 2>/dev/null
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
         then
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_rcfile"
-                ensure echo "$_robust_line" >> "$_rcfile"
+                say_verbose "adding $_robust_line to $_target"
+                ensure echo "$_robust_line" >> "$_target"
                 say ""
                 say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
                 say ""

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -279,6 +279,28 @@ install() {
     fi
 }
 
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "$ZDOTDIR" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
 add_install_dir_to_path() {
     # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
     #
@@ -294,11 +316,13 @@ add_install_dir_to_path() {
 
     if [ -n "${HOME:-}" ]; then
         local _target
+        local _home
 
         # Find the first file in the array that exists and choose
         # that as our target to write to
         for _rcfile_relative in $_rcfiles; do
-            local _rcfile="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
 
             if [ -f "$_rcfile" ]; then
                 _target="$_rcfile"
@@ -311,7 +335,8 @@ add_install_dir_to_path() {
         if [ -z "${_target:-}" ]; then
             local _rcfile_relative
             _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
-            _target="$HOME/$_rcfile_relative"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
         fi
 
         # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.


### PR DESCRIPTION
~/.profile isn't sourced in many circumstances; we need to write this to a large number of locations to make sure it gets considered by bash and zsh under the largest number of circumstances.

Fixes #547.