### PR TITLE
fix: semver() over cargo()

### DIFF
--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -296,7 +296,7 @@ pub(crate) fn select_tag(
         .packages()
         .map(|(_, info)| Package {
             name: info.name.clone(),
-            version: info.version.clone().map(|v| v.cargo().clone()),
+            version: info.version.clone().map(|v| v.semver().clone()),
         })
         .collect();
 


### PR DESCRIPTION
This new call to cargo() was missed when rebasing the generic builds branch on top of main pre-merge.

Fixes `cargo dist build` in generic repos.