### PR TITLE
release: 0.5.0-prerelease.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.5.0-prerelease.1"
+version = "0.5.0-prerelease.2"
 dependencies = [
  "axoasset",
  "axocli",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.5.0-prerelease.1"
+version = "0.5.0-prerelease.2"
 dependencies = [
  "camino",
  "gazenot",

--- a/cargo-dist-schema/Cargo.toml
+++ b/cargo-dist-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-dist-schema"
 description = "Schema information for cargo-dist's dist-manifest.json"
-version = "0.5.0-prerelease.1"
+version = "0.5.0-prerelease.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-dist"
 description = "Shippable application packaging for Rust"
-version = "0.5.0-prerelease.1"
+version = "0.5.0-prerelease.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
@@ -31,7 +31,7 @@ axocli = { version = "0.1.0", optional = true }
 
 # Features used by the cli and library
 axotag = "0.1.0"
-cargo-dist-schema = { version = "=0.5.0-prerelease.1", path = "../cargo-dist-schema" }
+cargo-dist-schema = { version = "=0.5.0-prerelease.2", path = "../cargo-dist-schema" }
 
 axoasset = { version = "0.6.0", features = ["json-serde", "toml-serde", "toml-edit", "compression"] }
 axoproject = { version = "0.6.0", default-features = false, features = ["cargo-projects", "generic-projects"] }


### PR DESCRIPTION
Incorporates https://github.com/axodotdev/cargo-dist/pull/573.