### PR TITLE
chore: update gazenot to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "gazenot"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac47a492e7e0d8422cdb3256d578f5fca3d4277c2b69e7d2c33f2b331de64b6"
+checksum = "24cb31303e75862cce2e7e292eb369b4c8a94df2d80f5bbc4d17e944af9d2785"
 dependencies = [
  "axoasset",
  "camino",

--- a/cargo-dist-schema/Cargo.toml
+++ b/cargo-dist-schema/Cargo.toml
@@ -18,7 +18,7 @@ schemars = "0.8.16"
 semver = "1.0.14"
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1.0.87"
-gazenot = { version = "0.1.1", default-features = false }
+gazenot = { version = "0.1.2", default-features = false }
 
 [dev-dependencies]
 insta = "1.26.0"

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -35,7 +35,7 @@ cargo-dist-schema = { version = "=0.5.0-prerelease.2", path = "../cargo-dist-sch
 
 axoasset = { version = "0.6.0", features = ["json-serde", "toml-serde", "toml-edit", "compression"] }
 axoproject = { version = "0.6.0", default-features = false, features = ["cargo-projects", "generic-projects"] }
-gazenot = { version = "0.1.1" }
+gazenot = { version = "0.1.2" }
 
 comfy-table = "7.0.1"
 miette = { version = "5.6.0" }


### PR DESCRIPTION
makes uploads serial as a temporary fix to overloading connections