### PR TITLE
feat: add source tarballs

### DIFF
--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -299,6 +299,9 @@ pub enum ArtifactKind {
     /// A checksum of another artifact
     #[serde(rename = "checksum")]
     Checksum,
+    /// A tarball containing the source code
+    #[serde(rename = "source-tarball")]
+    SourceTarball,
     /// Unknown to this version of cargo-dist-schema
     ///
     /// This is a fallback for forward/backward-compat

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -166,6 +166,21 @@ expression: json_schema
           }
         },
         {
+          "description": "A tarball containing the source code",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "source-tarball"
+              ]
+            }
+          }
+        },
+        {
           "description": "Unknown to this version of cargo-dist-schema\n\nThis is a fallback for forward/backward-compat",
           "type": "object",
           "required": [

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -261,6 +261,11 @@ pub enum DistError {
         #[related]
         sources: Vec<AxoprojectError>,
     },
+
+    /// An error running `git archive`
+    #[error("We failed to generate a source tarball for your project")]
+    #[diagnostic(help("This is probably not your fault, please file an issue!"))]
+    GitArchiveError {},
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/src/manifest.rs
+++ b/cargo-dist/src/manifest.rs
@@ -269,6 +269,11 @@ fn manifest_artifact(
             description = None;
             kind = cargo_dist_schema::ArtifactKind::Checksum;
         }
+        ArtifactKind::SourceTarball(_) => {
+            install_hint = None;
+            description = None;
+            kind = cargo_dist_schema::ArtifactKind::SourceTarball;
+        }
     };
 
     let checksum = artifact.checksum.map(|idx| dist.artifact(idx).id.clone());

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -298,6 +298,8 @@ pub enum BuildStep {
     Zip(ZipDirStep),
     /// Generate some kind of installer
     GenerateInstaller(InstallerImpl),
+    /// Generates a source tarball
+    GenerateSourceTarball(SourceTarballStep),
     /// Checksum a file
     Checksum(ChecksumImpl),
     // FIXME: For macos universal builds we'll want
@@ -372,6 +374,18 @@ pub struct ChecksumImpl {
     pub src_path: Utf8PathBuf,
     /// and write it to here
     pub dest_path: Utf8PathBuf,
+}
+
+/// Create a source tarball
+#[derive(Debug, Clone)]
+pub struct SourceTarballStep {
+    /// the ref/tag/commit/branch/etc. to archive
+    pub committish: String,
+    /// A root directory to nest the archive's contents under
+    // Note: GitHub uses `appname-tag` for this
+    pub prefix: String,
+    /// target filename
+    pub target: Utf8PathBuf,
 }
 
 /// A kind of symbols (debuginfo)
@@ -458,6 +472,8 @@ pub enum ArtifactKind {
     Installer(InstallerImpl),
     /// A checksum
     Checksum(ChecksumImpl),
+    /// A source tarball
+    SourceTarball(SourceTarball),
 }
 
 /// An Archive containing binaries (aka ExecutableZip)
@@ -471,6 +487,18 @@ pub struct ExecutableZip {
 pub struct Symbols {
     /// The kind of symbols this is
     kind: SymbolKind,
+}
+
+/// A source tarball artifact
+#[derive(Clone, Debug)]
+pub struct SourceTarball {
+    /// the ref/tag/commit/branch/etc. to archive
+    pub committish: String,
+    /// A root directory to nest the archive's contents under
+    // Note: GitHub uses `appname-tag` for this
+    pub prefix: String,
+    /// target filename
+    pub target: Utf8PathBuf,
 }
 
 /// A logical release of an application that artifacts are grouped under
@@ -1023,6 +1051,38 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 self.add_artifact_checksum(variant_idx, zip_artifact_idx, checksum);
             }
         }
+    }
+
+    fn add_source_tarball(&mut self, tag: &String, to_release: ReleaseIdx) {
+        if !self.global_artifacts_enabled() {
+            return;
+        }
+
+        let release = self.release(to_release);
+        info!("adding source tarball to release {}", release.id);
+
+        let dist_dir = &self.inner.dist_dir;
+
+        let filename = "source.tar.gz".to_owned();
+        let target_path = dist_dir.join(&filename);
+        let prefix = format!("{}-{}/", release.app_name, release.version);
+
+        let artifact = Artifact {
+            id: filename,
+            target_triples: vec![],
+            file_path: target_path.clone(),
+            required_binaries: FastMap::new(),
+            archive: None,
+            kind: ArtifactKind::SourceTarball(SourceTarball {
+                committish: tag.to_owned(),
+                prefix,
+                target: target_path,
+            }),
+            checksum: None,
+            is_global: true,
+        };
+
+        self.add_global_artifact(to_release, artifact);
     }
 
     fn add_artifact_checksum(
@@ -1954,6 +2014,13 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 ArtifactKind::Checksum(checksum) => {
                     build_steps.push(BuildStep::Checksum(checksum.clone()));
                 }
+                ArtifactKind::SourceTarball(tarball) => {
+                    build_steps.push(BuildStep::GenerateSourceTarball(SourceTarballStep {
+                        committish: tarball.committish.to_owned(),
+                        prefix: tarball.prefix.to_owned(),
+                        target: tarball.target.to_owned(),
+                    }));
+                }
             }
 
             if let Some(archive) = &artifact.archive {
@@ -2028,6 +2095,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             }
             // Add executable zips to the Release
             self.add_executable_zip(release);
+
+            // Always add the source tarball
+            self.add_source_tarball(&announcing.tag, release);
 
             // Add installers to the Release
             // Prefer the CLI's choices (`cfg`) if they're non-empty

--- a/cargo-dist/tests/gallery/repo.rs
+++ b/cargo-dist/tests/gallery/repo.rs
@@ -147,7 +147,7 @@ where
             eprintln!("repo already cloned, updating it...");
             std::env::set_current_dir(repo_dir).into_diagnostic()?;
             git.output_checked(|c| c.arg("remote").arg("set-url").arg("origin").arg(repo_url))?;
-            git.output_checked(|c| c.arg("fetch").arg("origin").arg(commit_sha))?;
+            git.output_checked(|c| c.arg("fetch").arg("origin").arg(commit_sha).arg("--tags"))?;
             git.output_checked(|c| c.arg("reset").arg("--hard").arg("FETCH_HEAD"))?;
         } else {
             eprintln!("fetching {repo_url}");
@@ -155,7 +155,7 @@ where
             std::env::set_current_dir(repo_dir).into_diagnostic()?;
             git.output_checked(|c| c.arg("init"))?;
             git.output_checked(|c| c.arg("remote").arg("add").arg("origin").arg(repo_url))?;
-            git.output_checked(|c| c.arg("fetch").arg("origin").arg(commit_sha))?;
+            git.output_checked(|c| c.arg("fetch").arg("origin").arg(commit_sha).arg("--tags"))?;
             git.output_checked(|c| c.arg("reset").arg("--hard").arg("FETCH_HEAD"))?;
         }
 

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1041,6 +1041,7 @@ Install-Binary "$Args"
       "app_version": "0.2.0",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "akaikatana-repack-installer.sh",
         "akaikatana-repack-installer.ps1",
         "akaikatana-repack.rb",
@@ -1261,7 +1262,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1040,6 +1040,7 @@ Install-Binary "$Args"
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
       "artifacts": [
+        "source.tar.gz",
         "akaikatana-repack-installer.sh",
         "akaikatana-repack-installer.ps1",
         "akaikatana-repack.rb",
@@ -1257,6 +1258,10 @@ Install-Binary "$Args"
       ],
       "install_hint": "brew install mistydemeo/homebrew-formulae/akaikatana-repack",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -743,6 +743,7 @@ download_binary_and_run_installer "$@" || exit 1
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
       "artifacts": [
+        "source.tar.gz",
         "akaikatana-repack-installer.sh",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz.sha256",
@@ -940,6 +941,10 @@ download_binary_and_run_installer "$@" || exit 1
       "target_triples": [
         "x86_64-unknown-linux-musl"
       ]
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -744,6 +744,7 @@ download_binary_and_run_installer "$@" || exit 1
       "app_version": "0.2.0",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "akaikatana-repack-installer.sh",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz.sha256",
@@ -944,7 +945,12 @@ download_binary_and_run_installer "$@" || exit 1
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -1041,6 +1041,7 @@ Install-Binary "$Args"
       "app_version": "0.2.0",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "akaikatana-repack-installer.sh",
         "akaikatana-repack-installer.ps1",
         "akaikatana-repack.rb",
@@ -1261,7 +1262,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -1040,6 +1040,7 @@ Install-Binary "$Args"
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
       "artifacts": [
+        "source.tar.gz",
         "akaikatana-repack-installer.sh",
         "akaikatana-repack-installer.ps1",
         "akaikatana-repack.rb",
@@ -1257,6 +1258,10 @@ Install-Binary "$Args"
       ],
       "install_hint": "brew install mistydemeo/homebrew-formulae/akaikatana-repack",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1875,6 +1875,7 @@ maybeInstall(true).then(run);
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2193,7 +2194,12 @@ maybeInstall(true).then(run);
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1874,6 +1874,7 @@ maybeInstall(true).then(run);
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2189,6 +2190,10 @@ maybeInstall(true).then(run);
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1874,6 +1874,7 @@ maybeInstall(true).then(run);
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2189,7 +2190,12 @@ maybeInstall(true).then(run);
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1873,6 +1873,7 @@ maybeInstall(true).then(run);
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2185,6 +2186,10 @@ maybeInstall(true).then(run);
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1874,6 +1874,7 @@ maybeInstall(true).then(run);
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2181,6 +2182,10 @@ maybeInstall(true).then(run);
       ],
       "install_hint": "brew install axodotdev/homebrew-packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1875,6 +1875,7 @@ maybeInstall(true).then(run);
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2185,7 +2186,12 @@ maybeInstall(true).then(run);
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1875,6 +1875,7 @@ maybeInstall(true).then(run);
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2160,7 +2161,12 @@ maybeInstall(true).then(run);
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1874,6 +1874,7 @@ maybeInstall(true).then(run);
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2156,6 +2157,10 @@ maybeInstall(true).then(run);
       ],
       "install_hint": "brew install axodotdev/homebrew-packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1581,6 +1581,7 @@ maybeInstall(true).then(run);
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-npm-package.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1843,6 +1844,10 @@ maybeInstall(true).then(run);
       "target_triples": [
         "x86_64-unknown-linux-musl"
       ]
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1582,6 +1582,7 @@ maybeInstall(true).then(run);
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-npm-package.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1847,7 +1848,12 @@ maybeInstall(true).then(run);
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1582,6 +1582,7 @@ maybeInstall(true).then(run);
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-npm-package.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1801,7 +1802,12 @@ maybeInstall(true).then(run);
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1581,6 +1581,7 @@ maybeInstall(true).then(run);
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-npm-package.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1797,6 +1798,10 @@ maybeInstall(true).then(run);
       "target_triples": [
         "x86_64-unknown-linux-musl"
       ]
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1875,6 +1875,7 @@ maybeInstall(true).then(run);
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2160,7 +2161,12 @@ maybeInstall(true).then(run);
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1874,6 +1874,7 @@ maybeInstall(true).then(run);
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2156,6 +2157,10 @@ maybeInstall(true).then(run);
       ],
       "install_hint": "brew install axodotdev/homebrew-packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1019,6 +1019,7 @@ Install-Binary "$Args"
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1253,7 +1254,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1018,6 +1018,7 @@ Install-Binary "$Args"
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1249,6 +1250,10 @@ Install-Binary "$Args"
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1019,6 +1019,7 @@ Install-Binary "$Args"
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1253,7 +1254,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1018,6 +1018,7 @@ Install-Binary "$Args"
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
@@ -1249,6 +1250,10 @@ Install-Binary "$Args"
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1875,6 +1875,7 @@ maybeInstall(true).then(run);
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2160,7 +2161,12 @@ maybeInstall(true).then(run);
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1874,6 +1874,7 @@ maybeInstall(true).then(run);
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -2156,6 +2157,10 @@ maybeInstall(true).then(run);
       ],
       "install_hint": "brew install axodotdev/homebrew-packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1042,6 +1042,7 @@ Install-Binary "$Args"
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1259,6 +1260,10 @@ Install-Binary "$Args"
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1043,6 +1043,7 @@ Install-Binary "$Args"
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1263,7 +1264,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1023,6 +1023,7 @@ Install-Binary "$Args"
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1243,7 +1244,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1022,6 +1022,7 @@ Install-Binary "$Args"
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1239,6 +1240,10 @@ Install-Binary "$Args"
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1023,6 +1023,7 @@ Install-Binary "$Args"
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1243,7 +1244,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1022,6 +1022,7 @@ Install-Binary "$Args"
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1239,6 +1240,10 @@ Install-Binary "$Args"
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1023,6 +1023,7 @@ Install-Binary "$Args"
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1243,7 +1244,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1022,6 +1022,7 @@ Install-Binary "$Args"
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1239,6 +1240,10 @@ Install-Binary "$Args"
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1023,6 +1023,7 @@ Install-Binary "$Args"
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1243,7 +1244,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1022,6 +1022,7 @@ Install-Binary "$Args"
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1239,6 +1240,10 @@ Install-Binary "$Args"
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1023,6 +1023,7 @@ Install-Binary "$Args"
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1243,7 +1244,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1022,6 +1022,7 @@ Install-Binary "$Args"
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1239,6 +1240,10 @@ Install-Binary "$Args"
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1023,6 +1023,7 @@ Install-Binary "$Args"
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1243,7 +1244,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1022,6 +1022,7 @@ Install-Binary "$Args"
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1239,6 +1240,10 @@ Install-Binary "$Args"
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1023,6 +1023,7 @@ Install-Binary "$Args"
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1243,7 +1244,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1022,6 +1022,7 @@ Install-Binary "$Args"
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1239,6 +1240,10 @@ Install-Binary "$Args"
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1023,6 +1023,7 @@ Install-Binary "$Args"
       "app_version": "0.2.1",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1243,7 +1244,12 @@ Install-Binary "$Args"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1022,6 +1022,7 @@ Install-Binary "$Args"
       "app_name": "axolotlsay",
       "app_version": "0.2.1",
       "artifacts": [
+        "source.tar.gz",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
@@ -1239,6 +1240,10 @@ Install-Binary "$Args"
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -19,6 +19,7 @@ stdout:
       "app_version": "1.0.0-FAKEVERSION",
       "artifacts": [
         "source.tar.gz",
+        "source.tar.gz.sha256",
         "cargo-dist-installer.sh",
         "cargo-dist-installer.ps1",
         "cargo-dist.rb",
@@ -285,7 +286,12 @@ stdout:
     },
     "source.tar.gz": {
       "name": "source.tar.gz",
-      "kind": "source-tarball"
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -18,6 +18,7 @@ stdout:
       "app_name": "cargo-dist",
       "app_version": "1.0.0-FAKEVERSION",
       "artifacts": [
+        "source.tar.gz",
         "cargo-dist-installer.sh",
         "cargo-dist-installer.ps1",
         "cargo-dist.rb",
@@ -281,6 +282,10 @@ stdout:
       ],
       "install_hint": "brew install axodotdev/homebrew-tap/cargo-dist",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball"
     }
   },
   "publish_prereleases": false,


### PR DESCRIPTION
This adds a new global artifact kind: source tarballs. This ensures that a stable tarball gets added to releases, wherever those are hosted. They're generated using `git archive`, so they're semantically equivalent to GitHub's auto-generated tarballs (but not byte-for-byte identical).

Do we want to be able to turn this off, or always have it on?

~~The tests are currently failing because we don't actually have access to the appropriate git tags to run the archives. I should probably try to get us to skip the source for that.~~ Fixed by updating the tests to fetch tags.