### PR TITLE
feat: extra build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.snap.new
 /book/book/
 cargo-dist/wix
+/dist-manifest-schema.json
 
 # Oranda
 oranda-debug.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-dar
 # Publish jobs to run in CI
 pr-run-mode = "plan"
 
+[[workspace.metadata.dist.extra-artifacts]]
+artifacts = ["dist-manifest-schema.json"]
+build = ["cargo", "run", "--", "dist", "manifest-schema", "--output=dist-manifest-schema.json"]
+
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -302,6 +302,9 @@ pub enum ArtifactKind {
     /// A tarball containing the source code
     #[serde(rename = "source-tarball")]
     SourceTarball,
+    /// Some form of extra artifact produced by a sidecar build
+    #[serde(rename = "extra-artifact")]
+    ExtraArtifact,
     /// Unknown to this version of cargo-dist-schema
     ///
     /// This is a fallback for forward/backward-compat

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -181,6 +181,21 @@ expression: json_schema
           }
         },
         {
+          "description": "Some form of extra artifact produced by a sidecar build",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "extra-artifact"
+              ]
+            }
+          }
+        },
+        {
           "description": "Unknown to this version of cargo-dist-schema\n\nThis is a fallback for forward/backward-compat",
           "type": "object",
           "required": [

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -374,7 +374,11 @@ pub enum OutputFormat {
 }
 
 #[derive(Args, Clone, Debug)]
-pub struct ManifestSchemaArgs {}
+pub struct ManifestSchemaArgs {
+    /// Write the manifest schema to the named file instead of stdout
+    #[clap(long)]
+    pub output: Option<String>,
+}
 
 #[derive(Args, Clone, Debug)]
 pub struct HostArgs {

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -272,6 +272,10 @@ pub struct DistMetadata {
     /// Hosting provider
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hosting: Option<Vec<HostingStyle>>,
+
+    /// Any extra artifacts and their buildscripts
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_artifacts: Option<Vec<ExtraArtifact>>,
 }
 
 impl DistMetadata {
@@ -308,6 +312,7 @@ impl DistMetadata {
             ssldotcom_windows_sign: _,
             msvc_crt_static: _,
             hosting: _,
+            extra_artifacts: _,
         } = self;
         if let Some(include) = include {
             for include in include {
@@ -353,6 +358,7 @@ impl DistMetadata {
             ssldotcom_windows_sign,
             msvc_crt_static,
             hosting,
+            extra_artifacts,
         } = self;
 
         // Check for global settings on local packages
@@ -443,6 +449,9 @@ impl DistMetadata {
         }
         if publish_jobs.is_none() {
             *publish_jobs = workspace_config.publish_jobs.clone();
+        }
+        if extra_artifacts.is_none() {
+            *extra_artifacts = workspace_config.extra_artifacts.clone();
         }
 
         // This was historically implemented as extend, but I'm not convinced the
@@ -1032,6 +1041,16 @@ pub enum ProductionMode {
     Test,
     /// production mode
     Prod,
+}
+
+/// An extra artifact to upload alongside the release tarballs,
+/// and the build command which produces it.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ExtraArtifact {
+    /// The build command to invoke
+    pub build: Vec<String>,
+    /// The artifact(s) produced via this build script
+    pub artifacts: Vec<String>,
 }
 
 impl std::fmt::Display for ProductionMode {

--- a/cargo-dist/src/generic_build.rs
+++ b/cargo-dist/src/generic_build.rs
@@ -3,7 +3,7 @@
 use std::{
     env,
     io::{stderr, Write},
-    process::Command,
+    process::{Command, Output},
 };
 
 use camino::Utf8Path;
@@ -14,7 +14,8 @@ use crate::{
     copy_file,
     env::{calculate_cflags, calculate_ldflags, fetch_brew_env, parse_env, select_brew_env},
     errors::Result,
-    BinaryIdx, BuildStep, DistGraph, DistGraphBuilder, GenericBuildStep, SortedMap, TargetTriple,
+    BinaryIdx, BuildStep, DistGraph, DistGraphBuilder, ExtraBuildStep, GenericBuildStep, SortedMap,
+    TargetTriple,
 };
 
 impl<'a> DistGraphBuilder<'a> {
@@ -72,14 +73,12 @@ fn platform_appropriate_cxx(target: &str) -> &str {
     }
 }
 
-/// Build a generic target
-pub fn build_generic_target(dist_graph: &DistGraph, target: &GenericBuildStep) -> Result<()> {
-    let mut command_string = target.build_command.clone();
-    eprintln!(
-        "building generic target ({} via {})",
-        target.target_triple,
-        command_string.join(" ")
-    );
+fn run_build(
+    dist_graph: &DistGraph,
+    command_string: &[String],
+    target: Option<&str>,
+) -> Result<Output> {
+    let mut command_string = command_string.to_owned();
 
     let mut desired_extra_env = vec![];
     let mut cflags = None;
@@ -109,16 +108,16 @@ pub fn build_generic_target(dist_graph: &DistGraph, target: &GenericBuildStep) -
     // inject into the environment, apply them now.
     command.envs(desired_extra_env);
 
-    // Ensure we inform the build what architecture and platform
-    // it's building for.
-    command.env("CARGO_DIST_TARGET", &target.target_triple);
+    if let Some(target) = target {
+        // Ensure we inform the build what architecture and platform
+        // it's building for.
+        command.env("CARGO_DIST_TARGET", target);
 
-    let cc =
-        std::env::var("CC").unwrap_or(platform_appropriate_cc(&target.target_triple).to_owned());
-    command.env("CC", cc);
-    let cxx =
-        std::env::var("CXX").unwrap_or(platform_appropriate_cxx(&target.target_triple).to_owned());
-    command.env("CXX", cxx);
+        let cc = std::env::var("CC").unwrap_or(platform_appropriate_cc(target).to_owned());
+        command.env("CC", cc);
+        let cxx = std::env::var("CXX").unwrap_or(platform_appropriate_cxx(target).to_owned());
+        command.env("CXX", cxx);
+    }
 
     // Pass CFLAGS/LDFLAGS for C builds
     if let Some(cflags) = cflags {
@@ -133,10 +132,25 @@ pub fn build_generic_target(dist_graph: &DistGraph, target: &GenericBuildStep) -
     }
 
     info!("exec: {:?}", command);
-    let result = command
+    command
         .output()
         .into_diagnostic()
-        .wrap_err_with(|| format!("failed to exec generic build: {command:?}"))?;
+        .wrap_err_with(|| format!("failed to exec generic build: {command:?}"))
+}
+
+/// Build a generic target
+pub fn build_generic_target(dist_graph: &DistGraph, target: &GenericBuildStep) -> Result<()> {
+    eprintln!(
+        "building generic target ({} via {})",
+        target.target_triple,
+        target.build_command.join(" ")
+    );
+
+    let result = run_build(
+        dist_graph,
+        &target.build_command,
+        Some(&target.target_triple),
+    )?;
 
     if !result.status.success() {
         println!("Build exited non-zero: {}", result.status);
@@ -153,6 +167,40 @@ pub fn build_generic_target(dist_graph: &DistGraph, target: &GenericBuildStep) -
             for dest in &binary.copy_exe_to {
                 copy_file(binary_path, dest)?;
             }
+        } else {
+            return Err(miette!(
+                "failed to find bin {} -- did the build above have errors?",
+                binary_path
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Similar to the above, but with slightly different signatures since
+/// it's not based around axoproject-identified binaries
+pub fn run_extra_artifacts_build(dist_graph: &DistGraph, target: &ExtraBuildStep) -> Result<()> {
+    eprintln!(
+        "building extra artifacts target (via {})",
+        target.build_command.join(" ")
+    );
+
+    let result = run_build(dist_graph, &target.build_command, None)?;
+    let dest = dist_graph.dist_dir.to_owned();
+
+    if !result.status.success() {
+        println!("Build exited non-zero: {}", result.status);
+    }
+    eprintln!();
+    eprintln!("stdout:");
+    stderr().write_all(&result.stdout).into_diagnostic()?;
+
+    // Check that we got everything we expected, and copy into the distribution path
+    for artifact in &target.expected_artifacts {
+        let binary_path = Utf8Path::new(artifact);
+        if binary_path.exists() {
+            copy_file(binary_path, &dest.join(artifact))?;
         } else {
             return Err(miette!(
                 "failed to find bin {} -- did the build above have errors?",

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -251,6 +251,7 @@ fn get_new_dist_metadata(
             ssldotcom_windows_sign: None,
             msvc_crt_static: None,
             hosting: None,
+            extra_artifacts: None,
         }
     };
 
@@ -770,6 +771,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         ssldotcom_windows_sign,
         msvc_crt_static,
         hosting,
+        extra_artifacts: _,
     } = &meta;
 
     apply_optional_value(

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -25,7 +25,7 @@ use config::{
     ArtifactMode, ChecksumStyle, CompressionImpl, Config, DirtyMode, GenerateMode, ZipStyle,
 };
 use console::Term;
-use generic_build::build_generic_target;
+use generic_build::{build_generic_target, run_extra_artifacts_build};
 use semver::Version;
 use tracing::info;
 
@@ -138,6 +138,7 @@ fn run_build_step(
             prefix,
             target,
         }) => Ok(generate_source_tarball(committish, prefix, target)?),
+        BuildStep::Extra(target) => run_extra_artifacts_build(dist_graph, target),
     }
 }
 

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -4,6 +4,7 @@
 
 use std::io::Write;
 
+use axoasset::LocalAsset;
 use camino::Utf8PathBuf;
 // Import everything from the lib version of ourselves
 use cargo_dist::{linkage::Linkage, *};
@@ -492,10 +493,16 @@ fn print_help_markdown(out: &mut dyn Write) -> std::io::Result<()> {
 
 fn cmd_manifest_schema(
     _config: &Cli,
-    _args: &cli::ManifestSchemaArgs,
+    args: &cli::ManifestSchemaArgs,
 ) -> Result<(), miette::ErrReport> {
     let schema = cargo_dist_schema::DistManifest::json_schema();
     let json_schema = serde_json::to_string_pretty(&schema).expect("failed to stringify schema!?");
-    println!("{json_schema}");
+
+    if let Some(destination) = args.output.to_owned() {
+        let contents = json_schema + "\n";
+        LocalAsset::write_new(&contents, destination)?;
+    } else {
+        println!("{json_schema}");
+    }
     Ok(())
 }

--- a/cargo-dist/src/manifest.rs
+++ b/cargo-dist/src/manifest.rs
@@ -274,6 +274,11 @@ fn manifest_artifact(
             description = None;
             kind = cargo_dist_schema::ArtifactKind::SourceTarball;
         }
+        ArtifactKind::ExtraArtifact(_) => {
+            install_hint = None;
+            description = None;
+            kind = cargo_dist_schema::ArtifactKind::ExtraArtifact;
+        }
     };
 
     let checksum = artifact.checksum.map(|idx| dist.artifact(idx).id.clone());

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -20,6 +20,7 @@ stdout:
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
+        "dist-manifest-schema.json",
         "cargo-dist-installer.sh",
         "cargo-dist-installer.ps1",
         "cargo-dist.rb",
@@ -284,6 +285,10 @@ stdout:
       ],
       "install_hint": "brew install axodotdev/homebrew-tap/cargo-dist",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "dist-manifest-schema.json": {
+      "name": "dist-manifest-schema.json",
+      "kind": "extra-artifact"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",


### PR DESCRIPTION
This adds support for specifying arbitrary extra artifacts alongside the primary builds. These artifacts are currently expected to be architecture-independent and are uploaded as their own build artifacts rather than bundled into release tarballs. For example, we can use this to replace our current `append-release` code in to generate and upload the `dist-manifest-schema.json`.

I realized that most of our generic build code is very well-suited to this, so I split the existing generic builds into half. The code that runs the builds is now shared between this and the generic build path, while another section is separate for implementation detail reasons. There are two main distinctions between these and generic builds:

* Generic builds are oriented around *binaries*, which will eventually be collated into an artifact. Extra artifacts produce artifacts directly, and have no associated binaries.
* Generic builds (usually) build native code and have target triples; as a result, we get N copies of the generic build, one per desired triple. Extra artifacts do not have target triples, and we produce a single copy per release.

The syntax looks like this:

```toml
[[workspace.metadata.dist.extra-artifacts]]
artifacts = ["dist-manifest-schema.json"]
build = ["cargo", "dist", "manifest-schema", "--output=dist-manifest-schema.json"]
```

There can be arbitrary numbers of extra artifacts per build, so this is repeatable within a `Cargo.toml`/`dist.toml` as many times as needed.

Closes #349.