### PR TITLE
chore: remove stubbed init code

### DIFF
--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -967,14 +967,6 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         hosting.as_ref(),
     );
 
-    // NOTE: HashMap not supported by axoasset
-    // apply_optional_value(
-    //     table,
-    //     "github-custom-runners",
-    //     "# Custom GitHub runners to use for builds, mapped by triple target\n",
-    //     github_custom_runners.as_ref(),
-    // );
-
     // Finalize the table
     table
         .decor_mut()


### PR DESCRIPTION
After experimenting with some changes here, I think I've concluded we don't want this in `init`. Otherwise, our `toml_edit` code will reformat it into the less pretty syntax:

```toml
github-custom-runners = { aarch64-unknown-linux-gnu = "buildjet-16vcpu-ubuntu-2204-arm" }
```

instead of

```toml
[workspace.metadata.dist.github-custom-runners]
aarch64-unknown-linux-gnu = "buildjet-16vcpu-ubuntu-2204-arm"
```