### PR TITLE
Fix ldd broken pipe error

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -512,7 +512,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -495,7 +495,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -505,7 +505,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -495,7 +495,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -495,7 +495,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -495,7 +495,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -495,7 +495,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -495,7 +495,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -505,7 +505,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -505,7 +505,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -495,7 +495,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -495,7 +495,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -495,7 +495,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -495,7 +495,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -495,7 +495,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -478,7 +478,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -478,7 +478,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -478,7 +478,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -478,7 +478,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -478,7 +478,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -478,7 +478,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -478,7 +478,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -478,7 +478,7 @@ get_architecture() {
         else
             # Parsing version out from line 1 like:
             # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
-            _local_glibc="$(ldd --version | head -1 | awk -F' ' '{ print $NF }')"
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
 
             if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
                 _clibtype="gnu"


### PR DESCRIPTION
Fixes #624
Previously, there would be benign broken pipe error due to the interaction between `ldd` and `head`. Now that error is no more.
