### PR TITLE
fix: handle unset ZDOTDIR better

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -321,7 +321,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -304,7 +304,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -314,7 +314,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -304,7 +304,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -304,7 +304,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -304,7 +304,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -304,7 +304,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -304,7 +304,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -314,7 +314,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -314,7 +314,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -304,7 +304,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -304,7 +304,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -304,7 +304,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -304,7 +304,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -304,7 +304,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -287,7 +287,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -287,7 +287,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -287,7 +287,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -287,7 +287,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -287,7 +287,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -287,7 +287,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -287,7 +287,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -287,7 +287,7 @@ print_home_for_script() {
         # zsh has a special ZDOTDIR directory, which if set
         # should be considered instead of $HOME
         .zsh*)
-            if [ -n "$ZDOTDIR" ]; then
+            if [ -n "${ZDOTDIR:-}" ]; then
                 _home="$ZDOTDIR"
             else
                 _home="$HOME"


### PR DESCRIPTION
This avoids a message about `ZDOTDIR` being unset when checking it.