### PR TITLE
fix(installer): only print source once

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -308,8 +308,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -406,10 +416,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -291,8 +291,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -389,10 +399,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -301,8 +301,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -399,10 +409,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -291,8 +291,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -389,10 +399,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -291,8 +291,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -389,10 +399,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -291,8 +291,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -389,10 +399,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -291,8 +291,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -389,10 +399,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -291,8 +291,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -389,10 +399,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -301,8 +301,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -399,10 +409,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -301,8 +301,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -399,10 +409,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -291,8 +291,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -389,10 +399,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -291,8 +291,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -389,10 +399,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -291,8 +291,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -389,10 +399,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -291,8 +291,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -389,10 +399,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -291,8 +291,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -389,10 +399,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -274,8 +274,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -372,10 +382,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -274,8 +274,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -372,10 +382,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -274,8 +274,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -372,10 +382,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -274,8 +274,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -372,10 +382,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -274,8 +274,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -372,10 +382,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -274,8 +274,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -372,10 +382,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -274,8 +274,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -372,10 +382,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -274,8 +274,18 @@ install() {
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        exit1=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        exit2=$?
         add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        exit3=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr"
+        fi
     fi
 }
 
@@ -372,10 +382,7 @@ add_install_dir_to_path() {
             if [ -f "$_env_script_path" ]; then
                 say_verbose "adding $_robust_line to $_target"
                 ensure echo "$_robust_line" >> "$_target"
-                say ""
-                say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
-                say ""
-                say "    $_pretty_line"
+                return 1
             fi
         else
             say_verbose "$_install_dir already on PATH"


### PR DESCRIPTION
This fixes a UI regression from #555. After that PR, we now print the "source `.env`" message once *per rcfile we've edited*, rather than once overall. This updates it to print it only once, and only if at least one rcfile was edited.