### PR TITLE
feat: add package manager source to library

### DIFF
--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -664,6 +664,17 @@ expression: json_schema
         "path"
       ],
       "properties": {
+        "package_manager": {
+          "description": "Which package manager provided this library",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PackageManager"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "path": {
           "description": "The path to the library; on platforms without that information, it will be a basename instead",
           "type": "string"
@@ -722,6 +733,25 @@ expression: json_schema
           "uniqueItems": true
         }
       }
+    },
+    "PackageManager": {
+      "description": "Represents the package manager a library was installed by",
+      "oneOf": [
+        {
+          "description": "Homebrew (usually for Mac)",
+          "type": "string",
+          "enum": [
+            "Homebrew"
+          ]
+        },
+        {
+          "description": "Apt (Debian, Ubuntu, etc)",
+          "type": "string",
+          "enum": [
+            "Apt"
+          ]
+        }
+      ]
     },
     "PrRunMode": {
       "description": "Type of job to run on pull request",

--- a/cargo-dist/src/build/mod.rs
+++ b/cargo-dist/src/build/mod.rs
@@ -196,6 +196,7 @@ impl BuildExpectations {
             linkage.other.insert(cargo_dist_schema::Library {
                 path: "fakelib".to_owned(),
                 source: None,
+                package_manager: None,
             });
             linkage
         } else {

--- a/cargo-dist/src/linkage.rs
+++ b/cargo-dist/src/linkage.rs
@@ -8,7 +8,7 @@ use std::{
 use axoasset::SourceFile;
 use axoprocess::Cmd;
 use camino::Utf8PathBuf;
-use cargo_dist_schema::{AssetInfo, DistManifest, Library, Linkage};
+use cargo_dist_schema::{AssetInfo, DistManifest, Library, Linkage, PackageManager};
 use comfy_table::{presets::UTF8_FULL, Table};
 use goblin::Object;
 use mach_object::{LoadCommand, OFile};
@@ -226,11 +226,13 @@ pub fn library_from_homebrew(library: String) -> Library {
         Library {
             path: library,
             source: Some(package.to_owned()),
+            package_manager: Some(PackageManager::Homebrew),
         }
     } else {
         Library {
             path: library,
             source: None,
+            package_manager: None,
         }
     }
 }
@@ -242,6 +244,7 @@ pub fn library_from_apt(library: String) -> DistResult<Library> {
         return Ok(Library {
             path: library,
             source: None,
+            package_manager: None,
         });
     }
 
@@ -259,16 +262,23 @@ pub fn library_from_apt(library: String) -> DistResult<Library> {
             } else {
                 Some(package.to_owned())
             };
+            let package_manager = if source.is_some() {
+                Some(PackageManager::Apt)
+            } else {
+                None
+            };
 
             Ok(Library {
                 path: library,
                 source,
+                package_manager,
             })
         }
         // Couldn't find a package for this file
         Err(_) => Ok(Library {
             path: library,
             source: None,
+            package_manager: None,
         }),
     }
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3294,7 +3294,8 @@ run("axolotlsay");
       "linkage": {
         "other": [
           {
-            "path": "fakelib"
+            "path": "fakelib",
+            "package_manager": null
           }
         ]
       }
@@ -3309,7 +3310,8 @@ run("axolotlsay");
       "linkage": {
         "other": [
           {
-            "path": "fakelib"
+            "path": "fakelib",
+            "package_manager": null
           }
         ]
       }
@@ -3324,7 +3326,8 @@ run("axolotlsay");
       "linkage": {
         "other": [
           {
-            "path": "fakelib"
+            "path": "fakelib",
+            "package_manager": null
           }
         ]
       }
@@ -3339,7 +3342,8 @@ run("axolotlsay");
       "linkage": {
         "other": [
           {
-            "path": "fakelib"
+            "path": "fakelib",
+            "package_manager": null
           }
         ]
       }


### PR DESCRIPTION
This makes it easier to track which package manager a package comes from for non-Homebrew packages, which could be located in multiple places. I've also added a new method to get a flat list of package name strings from the linkage data.