### PR TITLE
feat(dockerimage): add a docker image installer

### DIFF
--- a/cargo-dist/src/backend/installer/docker.rs
+++ b/cargo-dist/src/backend/installer/docker.rs
@@ -1,0 +1,203 @@
+//! CI script generation
+//!
+//! In the future this may get split up into submodules.
+
+use std::process::Command;
+
+use axoasset::LocalAsset;
+use camino::Utf8PathBuf;
+use cargo_dist_schema::DistManifest;
+use serde::Serialize;
+
+use crate::{
+    backend::templates::{Templates, TEMPLATE_INSTALLER_DOCKER},
+    config::DependencyKind,
+    errors::{DistError, DistResult},
+    DistGraph, ReleaseIdx,
+};
+
+/// Info needed to build an msi
+#[derive(Debug, Clone)]
+pub struct DockerInstallerInfo {
+    /// Target triple this image is for
+    pub target: String,
+    /// Release this is for
+    pub release_idx: ReleaseIdx,
+    /// What to tag the image as
+    pub tag: String,
+    /// Binaries we'll be baking into the docker image
+    pub bins: Vec<String>,
+    /// Final file path of the docker image
+    pub file_path: Utf8PathBuf,
+    /// Dir stuff goes to
+    pub package_dir: Utf8PathBuf,
+    /// Additional dirs/files to include
+    pub includes: Vec<Utf8PathBuf>,
+}
+
+/// Info about running cargo-dist in Github CI
+#[derive(Debug, Serialize)]
+pub struct DockerfileInfo {
+    /// List of binaries this docker image should include
+    bins: Vec<Bin>,
+    /// Info about the runner image
+    runner: RunnerImage,
+}
+
+/// A binary
+#[derive(Debug, Serialize)]
+struct Bin {
+    /// Path to where the binary should be copied from, on the host system
+    source: String,
+    /// Name of the binary, as exposed to users of the image
+    name: String,
+}
+
+/// Info about the runner image
+#[derive(Debug, Serialize)]
+struct RunnerImage {
+    /// Base image (e.g. some debian distro)
+    image: String,
+    /// Apt deps to install
+    apt_deps: Vec<String>,
+    /// Additional files/dirs to copy into the image (e.g. examples)
+    includes: Vec<Utf8PathBuf>,
+}
+
+/// As of this rewriting this is the latest debian release
+const RUNNER_IMAGE: &str = "debian:bookworm-slim";
+/// What to call the temporary dockerfile we generate
+const DOCKERFILE_NAME: &str = "Dockerfile";
+
+impl DockerInstallerInfo {
+    /// Build the docker image
+    pub fn build(
+        &self,
+        templates: &Templates,
+        dist: &DistGraph,
+        manifest: &DistManifest,
+    ) -> DistResult<()> {
+        let info = self.compute_dockerfile(dist, manifest)?;
+        self.render_dockerfile(templates, &info)?;
+        self.build_and_export_image(dist)?;
+        Ok(())
+    }
+
+    /// Compute the apt runner deps
+    ///
+    /// We want this to be late-bound and to reference DistManifest
+    /// so linkage data can be incorporated.
+    fn apt_runner_deps(&self, dist: &DistGraph, _manifest: &DistManifest) -> Vec<String> {
+        // FIXME: incorporate linkage info to only include Explicit runtime deps
+        // and to also auto-include runtime deps they forgot to mention!
+        // (soft-blocked on doing a sysdeps refactor)
+        let release = dist.release(self.release_idx);
+        let packages: Vec<String> = release
+            .system_dependencies
+            .apt
+            .clone()
+            .into_iter()
+            .filter(|(_, package)| package.0.wanted_for_target(&self.target))
+            .filter(|(_, package)| package.0.stage_wanted(&DependencyKind::Run))
+            .map(|(name, spec)| {
+                if let Some(version) = spec.0.version {
+                    format!("{name}={version}")
+                } else {
+                    name
+                }
+            })
+            .collect();
+        packages
+    }
+
+    /// Compute the data for the dockerfile
+    ///
+    /// Split off from rendering in case it's useful for testing.
+    fn compute_dockerfile(
+        &self,
+        dist: &DistGraph,
+        manifest: &DistManifest,
+    ) -> DistResult<DockerfileInfo> {
+        let apt_deps = self.apt_runner_deps(dist, manifest);
+
+        let bins = self
+            .bins
+            .iter()
+            .map(|file_name| Bin {
+                source: format!("./{file_name}"),
+                name: file_name.clone(),
+            })
+            .collect();
+        let runner = RunnerImage {
+            image: RUNNER_IMAGE.to_owned(),
+            apt_deps,
+            includes: self.includes.clone(),
+        };
+        Ok(DockerfileInfo { bins, runner })
+    }
+
+    /// Render the dockerfile with the given data
+    fn render_dockerfile(&self, templates: &Templates, info: &DockerfileInfo) -> DistResult<()> {
+        let contents = templates.render_file_to_clean_string(TEMPLATE_INSTALLER_DOCKER, &info)?;
+        let dockerfile_path = self.package_dir.join(DOCKERFILE_NAME);
+        LocalAsset::write_new(&contents, dockerfile_path)?;
+        Ok(())
+    }
+
+    /// Build and export the docker image to a tarball with appropriate metadata,
+    /// assuming `render_dockerfile` has already run.
+    fn build_and_export_image(&self, dist: &DistGraph) -> DistResult<()> {
+        let Some(docker) = &dist.tools.docker else {
+            unreachable!("docker didn't exist, tasks.rs was supposed to catch that!");
+        };
+        // FIXME: in theory we can do "build" and "save" in one shot with
+        //
+        //    docker buildx build --output type=docker,dest=/path/to/output.tar
+        //
+        // which is what the Github Action seems to do, but locally (in WSL) i get:
+        //
+        // > ERROR: Docker exporter feature is currently not supported for docker driver.
+        // > Please switch to a different driver (eg. "docker buildx create --use")
+        //
+        // So for now just use `save` which Does work
+        {
+            let mut cmd = Command::new(&docker.cmd);
+            cmd.arg("build")
+                .arg(".")
+                .arg("-t")
+                .arg(&self.tag)
+                .current_dir(&self.package_dir);
+            let status = cmd.status().map_err(|cause| DistError::CommandFail {
+                command_summary: "export your docker image with 'docker build'".to_owned(),
+                cause,
+            })?;
+
+            if !status.success() {
+                return Err(DistError::CommandStatus {
+                    command_summary: "build your docker image with 'docker build'".to_owned(),
+                    status,
+                });
+            }
+        }
+        {
+            let mut cmd = Command::new(&docker.cmd);
+            cmd.arg("save")
+                .arg("--output")
+                .arg(&self.file_path)
+                .arg(&self.tag)
+                .current_dir(&self.package_dir);
+            let status = cmd.status().map_err(|cause| DistError::CommandFail {
+                command_summary: "export your docker image with 'docker save'".to_owned(),
+                cause,
+            })?;
+
+            if !status.success() {
+                return Err(DistError::CommandStatus {
+                    command_summary: "export your docker image with 'docker save'".to_owned(),
+                    status,
+                });
+            }
+        }
+        Ok(())
+    }
+}

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -10,10 +10,12 @@ use crate::{
     TargetTriple,
 };
 
+use self::docker::DockerInstallerInfo;
 use self::homebrew::HomebrewInstallerInfo;
 use self::msi::MsiInstallerInfo;
 use self::npm::NpmInstallerInfo;
 
+pub mod docker;
 pub mod homebrew;
 pub mod msi;
 pub mod npm;
@@ -34,6 +36,8 @@ pub enum InstallerImpl {
     Homebrew(HomebrewInstallerInfo),
     /// Windows msi installer
     Msi(MsiInstallerInfo),
+    /// Docker installer
+    Docker(DockerInstallerInfo),
 }
 
 /// Generic info about an installer

--- a/cargo-dist/src/backend/templates.rs
+++ b/cargo-dist/src/backend/templates.rs
@@ -15,10 +15,13 @@ pub type TemplateId = &'static str;
 pub const TEMPLATE_INSTALLER_PS1: TemplateId = "installer/installer.ps1";
 /// Template key for installer.sh
 pub const TEMPLATE_INSTALLER_SH: TemplateId = "installer/installer.sh";
+/// Template key for the dockerfile
+pub const TEMPLATE_INSTALLER_DOCKER: TemplateId = "installer/Dockerfile";
 /// Template key for Homebrew formula
 pub const TEMPLATE_INSTALLER_RB: TemplateId = "installer/homebrew.rb";
 /// Template key for the npm installer dir
 pub const TEMPLATE_INSTALLER_NPM: TemplateId = "installer/npm";
+
 /// Template key for the github ci.yml
 pub const TEMPLATE_CI_GITHUB: TemplateId = "ci/github_ci.yml";
 
@@ -310,6 +313,9 @@ mod test {
         let templates = Templates::new().unwrap();
 
         templates.get_template_file(TEMPLATE_INSTALLER_SH).unwrap();
+        templates
+            .get_template_file(TEMPLATE_INSTALLER_DOCKER)
+            .unwrap();
         templates.get_template_file(TEMPLATE_INSTALLER_RB).unwrap();
         templates.get_template_file(TEMPLATE_INSTALLER_PS1).unwrap();
         templates.get_template_dir(TEMPLATE_INSTALLER_NPM).unwrap();

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -342,6 +342,8 @@ pub enum InstallerStyle {
     Homebrew,
     /// Generates an msi for each windows platform
     Msi,
+    /// Generate a docker image for x86_64-unknown-linux-gnu
+    Docker,
 }
 
 impl InstallerStyle {
@@ -353,6 +355,7 @@ impl InstallerStyle {
             InstallerStyle::Npm => cargo_dist::config::InstallerStyle::Npm,
             InstallerStyle::Homebrew => cargo_dist::config::InstallerStyle::Homebrew,
             InstallerStyle::Msi => cargo_dist::config::InstallerStyle::Msi,
+            InstallerStyle::Docker => cargo_dist::config::InstallerStyle::Docker,
         }
     }
 }

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -602,6 +602,8 @@ pub enum InstallerStyle {
     Homebrew,
     /// Generate an msi installer that embeds the binary
     Msi,
+    /// Generate a docker image for x86_64-unknown-linux-gnu
+    Docker,
 }
 
 impl std::fmt::Display for InstallerStyle {
@@ -612,6 +614,7 @@ impl std::fmt::Display for InstallerStyle {
             InstallerStyle::Npm => "npm",
             InstallerStyle::Homebrew => "homebrew",
             InstallerStyle::Msi => "msi",
+            InstallerStyle::Docker => "docker",
         };
         string.fmt(f)
     }

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -6,6 +6,8 @@
 //!
 //! If we ever change this decision, this will be a lot more important!
 
+use std::process::ExitStatus;
+
 use axoproject::errors::AxoprojectError;
 use camino::Utf8PathBuf;
 use miette::Diagnostic;
@@ -266,6 +268,23 @@ pub enum DistError {
     #[error("We failed to generate a source tarball for your project")]
     #[diagnostic(help("This is probably not your fault, please file an issue!"))]
     GitArchiveError {},
+    /// Error running a random Command
+    #[error("We failed to {command_summary}")]
+    CommandFail {
+        /// user-friendly summary of what we were doing
+        command_summary: String,
+        /// Underlying error
+        #[source]
+        cause: std::io::Error,
+    },
+    /// Command returning a non-Ok status
+    #[error("We failed to {command_summary} ({status})")]
+    CommandStatus {
+        /// user-friendly summary of what we were doing
+        command_summary: String,
+        /// bad status
+        status: ExitStatus,
+    },
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/src/generic_build.rs
+++ b/cargo-dist/src/generic_build.rs
@@ -155,9 +155,11 @@ pub fn build_generic_target(dist_graph: &DistGraph, target: &GenericBuildStep) -
     if !result.status.success() {
         println!("Build exited non-zero: {}", result.status);
     }
-    eprintln!();
-    eprintln!("stdout:");
-    stderr().write_all(&result.stdout).into_diagnostic()?;
+    if !result.stdout.is_empty() {
+        eprintln!();
+        eprintln!("stdout:");
+        stderr().write_all(&result.stdout).into_diagnostic()?;
+    }
 
     // Check that we got everything we expected, and normalize to ArtifactIdx => Artifact Path
     for binary_idx in &target.expected_binaries {
@@ -192,9 +194,11 @@ pub fn run_extra_artifacts_build(dist_graph: &DistGraph, target: &ExtraBuildStep
     if !result.status.success() {
         println!("Build exited non-zero: {}", result.status);
     }
-    eprintln!();
-    eprintln!("stdout:");
-    stderr().write_all(&result.stdout).into_diagnostic()?;
+    if !result.stdout.is_empty() {
+        eprintln!();
+        eprintln!("stdout:");
+        stderr().write_all(&result.stdout).into_diagnostic()?;
+    }
 
     // Check that we got everything we expected, and copy into the distribution path
     for artifact in &target.expected_artifacts {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -539,6 +539,7 @@ fn get_new_dist_metadata(
                 InstallerStyle::Npm,
                 InstallerStyle::Homebrew,
                 InstallerStyle::Msi,
+                InstallerStyle::Docker,
             ]
         } else {
             eprintln!("{notice} no CI backends enabled, most installers have been hidden");
@@ -567,6 +568,7 @@ fn get_new_dist_metadata(
                 InstallerStyle::Npm => "npm",
                 InstallerStyle::Homebrew => "homebrew",
                 InstallerStyle::Msi => "msi",
+                InstallerStyle::Docker => "docker",
             });
         }
 

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -448,6 +448,7 @@ fn generate_installer(
             installer::homebrew::write_homebrew_formula(&dist.templates, dist, info, manifest)?
         }
         InstallerImpl::Msi(info) => info.build()?,
+        InstallerImpl::Docker(info) => info.build(&dist.templates, dist, manifest)?,
     }
     Ok(())
 }

--- a/cargo-dist/src/manifest.rs
+++ b/cargo-dist/src/manifest.rs
@@ -264,6 +264,11 @@ fn manifest_artifact(
             description = Some("install via msi".to_owned());
             kind = cargo_dist_schema::ArtifactKind::Installer;
         }
+        ArtifactKind::Installer(InstallerImpl::Docker(..)) => {
+            install_hint = None;
+            description = Some("try it out in docker".to_owned());
+            kind = cargo_dist_schema::ArtifactKind::Installer;
+        }
         ArtifactKind::Checksum(_) => {
             install_hint = None;
             description = None;

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -2205,7 +2205,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let checksum = release.checksum;
         let app_name = &release.app_name;
         let app_version = &release.version;
-        let tag = format!("{app_name}/{app_version}");
+        let tag = format!("{app_name}:{app_version}");
 
         // Make an msi for every windows platform
         for variant_idx in variants {

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -48,6 +48,7 @@ pub fn mock_tools() -> Tools {
         },
         rustup: None,
         brew: None,
+        docker: None,
     }
 }
 

--- a/cargo-dist/templates/installer/Dockerfile.j2
+++ b/cargo-dist/templates/installer/Dockerfile.j2
@@ -1,0 +1,13 @@
+FROM {{ runner.image }}
+{%- if runner.apt_deps %}
+RUN apt-get update && apt-get install -y {{ runner.apt_deps }} && rm -rf /var/lib/apt/lists/*
+{%- endif %}
+{%- for bin in bins %}
+COPY {{ bin.source }} /usr/local/bin/
+{%- endfor %}
+{%- for include in includes %}
+COPY {{ include }} /
+{%- endfor %}
+CMD [{%- for bin in bins %}"{{ bin.name }}"{{ ", " if not loop.last else "" }}{%- endfor %}]
+
+

--- a/cargo-dist/tests/snapshots/long-help.snap
+++ b/cargo-dist/tests/snapshots/long-help.snap
@@ -63,6 +63,7 @@ GLOBAL OPTIONS:
           - npm:        Generates an npm project that fetches the right build to your node_modules
           - homebrew:   Generates a Homebrew formula
           - msi:        Generates an msi for each windows platform
+          - docker:     Generate a docker image for x86_64-unknown-linux-gnu
 
   -c, --ci <CI>
           CI we want to support

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -65,6 +65,7 @@ Possible values:
 - npm:        Generates an npm project that fetches the right build to your node_modules
 - homebrew:   Generates a Homebrew formula
 - msi:        Generates an msi for each windows platform
+- docker:     Generate a docker image for x86_64-unknown-linux-gnu
 
 #### `-c, --ci <CI>`
 CI we want to support

--- a/cargo-dist/tests/snapshots/short-help.snap
+++ b/cargo-dist/tests/snapshots/short-help.snap
@@ -27,7 +27,7 @@ GLOBAL OPTIONS:
   -o, --output-format <OUTPUT_FORMAT>  The format of the output [default: human] [possible values: human, json]
       --no-local-paths                 Strip local paths from output (e.g. in the dist manifest json)
   -t, --target <TARGET>                Target triples we want to build
-  -i, --installer <INSTALLER>          Installers we want to build [possible values: shell, powershell, npm, homebrew, msi]
+  -i, --installer <INSTALLER>          Installers we want to build [possible values: shell, powershell, npm, homebrew, msi, docker]
   -c, --ci <CI>                        CI we want to support [possible values: github]
       --tag <TAG>                      The (git) tag to use for the Announcement that each invocation of cargo-dist is performing
       --allow-dirty                    Allow generated files like CI scripts to be out of date


### PR DESCRIPTION
This creates a Local (as in one-per-platform) docker installer (which only runs for x64 gnu linux) that builds a docker image that vendors the binaries, exporting to a tarball.

This does not currently setup docker buildx in CI (so might fail). This does not currently support publishing the docker image anywhere.