### PR TITLE
fix: check for git presence before calling

### DIFF
--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -266,6 +266,14 @@ pub enum DistError {
     #[error("We failed to generate a source tarball for your project")]
     #[diagnostic(help("This is probably not your fault, please file an issue!"))]
     GitArchiveError {},
+
+    /// A required tool is missing
+    #[error("{tool}, required to run this task, is missing")]
+    #[diagnostic(help("Ensure {tool} is installed"))]
+    ToolMissing {
+        /// the name of the missing tool
+        tool: String,
+    },
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -48,6 +48,7 @@ pub fn mock_tools() -> Tools {
         },
         rustup: None,
         brew: None,
+        git: None,
     }
 }
 


### PR DESCRIPTION
This follows up #647 by also ensuring we don't call `git` if it's not present on the system. If it's missing, we skip trying to generate a source tarball altogether.