### PR TITLE
chore(deps): update self_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c309e515543e67811222dbc9e3dd7e1056279b782e1dacffe4242b718734fb6"
+checksum = "58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba"
 
 [[package]]
 name = "semver"


### PR DESCRIPTION
`cargo publish` notified me that our version of self_cell was yanked.