### PR TITLE
feat(hosting): add --hosting cli flags to init for quick setup of custom hosting

### DIFF
--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -252,6 +252,13 @@ pub struct InitArgs {
     /// is currently intentionally undocumented to give us some flexibility to change it.
     #[clap(long)]
     pub with_json_config: Option<Utf8PathBuf>,
+    /// releases hosting backends we want to support
+    ///
+    /// If left unspecified we will use the value in [workspace.metadata.dist].
+    /// (If no such value exists we will use the one "native" to your CI provider)
+    /// `cargo dist init` will persist the values you pass to that location.
+    #[clap(long)]
+    pub hosting: Vec<HostingStyle>,
 }
 
 /// Which style(s) of configuration to generate
@@ -413,4 +420,23 @@ pub enum HostStyle {
     Release,
     /// Announce artifacts
     Announce,
+}
+
+impl HostingStyle {
+    /// Convert the application version of this enum to the library version
+    pub fn to_lib(self) -> cargo_dist::config::HostingStyle {
+        match self {
+            HostingStyle::Github => cargo_dist::config::HostingStyle::Github,
+            HostingStyle::Axodotdev => cargo_dist::config::HostingStyle::Axodotdev,
+        }
+    }
+}
+
+/// Hosting Providers
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum HostingStyle {
+    /// Host on Github Releases
+    Github,
+    /// Host on Axo Releases ("Abyss")
+    Axodotdev,
 }

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -8,8 +8,8 @@ use serde::Deserialize;
 
 use crate::{
     config::{
-        self, CiStyle, CompressionImpl, Config, DistMetadata, InstallerStyle, PublishStyle,
-        ZipStyle,
+        self, CiStyle, CompressionImpl, Config, DistMetadata, HostingStyle, InstallerStyle,
+        PublishStyle, ZipStyle,
     },
     do_generate,
     errors::{DistError, DistResult, Result},
@@ -25,6 +25,8 @@ pub struct InitArgs {
     pub no_generate: bool,
     /// A path to a json file containing values to set in workspace.metadata.dist
     pub with_json_config: Option<Utf8PathBuf>,
+    /// Hosts to enable
+    pub host: Vec<HostingStyle>,
 }
 
 /// Input for --with-json-config
@@ -275,6 +277,10 @@ fn get_new_dist_metadata(
     // Some indicators we'll use in a few places
     let check = console::style("✔".to_string()).for_stderr().green();
     let notice = console::style("⚠️".to_string()).for_stderr().yellow();
+
+    if !args.host.is_empty() {
+        meta.hosting = Some(args.host.clone());
+    }
 
     // Set cargo-dist-version
     let current_version: Version = std::env!("CARGO_PKG_VERSION").parse().unwrap();

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -278,6 +278,7 @@ fn cmd_init(cli: &Cli, args: &InitArgs) -> Result<(), miette::Report> {
         yes: args.yes,
         no_generate: args.no_generate,
         with_json_config: args.with_json_config.clone(),
+        host: args.hosting.iter().map(|host| host.to_lib()).collect(),
     };
     do_init(&config, &args)
 }

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -161,6 +161,15 @@ A path to a json file containing values to set in workspace.metadata.dist and pa
 
 This is the same toml => json format that `cargo metadata` produces when reporting `workspace.metadata.dist`. There is some additional hierarchy for specifying which values go to which packages, but this is currently intentionally undocumented to give us some flexibility to change it.
 
+#### `--hosting <HOSTING>`
+releases hosting backends we want to support
+
+If left unspecified we will use the value in [workspace.metadata.dist]. (If no such value exists we will use the one "native" to your CI provider) `cargo dist init` will persist the values you pass to that location.
+
+Possible values:
+- github:    Host on Github Releases
+- axodotdev: Host on Axo Releases ("Abyss")
+
 #### `-h, --help`
 Print help (see a summary with '-h')
 


### PR DESCRIPTION
With this you can just tell people to do `cargo dist init --hosting=axodotdev --hosting=github`