### PR TITLE
chore(ci): replace crates.io publish with custom job

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,38 +8,22 @@
 name: PublishRelease
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      tag:
-        description: 'Release Tag'
+      plan:
         required: true
         type: string
 
 jobs:
-  # This is a bit convoluted so that the other parts of this workflow remain
-  # the same even if the way the tag is defined is more complicated
-  download-tag:
-    runs-on: ubuntu-latest
-    outputs:
-        tag: ${{ steps.print-tag.outputs.tag }}
-    steps:
-      - id: print-tag
-        run: echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-
   # publish the current repo state to crates.io
   cargo-publish:
     runs-on: ubuntu-latest
-    needs: download-tag
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
-          ref: ${{needs.download-tag.outputs.tag}}
-          fetch-depth: 0
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
+          ref: ${{ inputs.plan.outputs.tag }}
+          submodules: recursive
       - run: cargo publish -p cargo-dist-schema --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,16 +261,27 @@ jobs:
           done
           git push
 
+  custom-publish-release:
+    needs:
+      - plan
+      - host
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    uses: ./.github/workflows/publish-release.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+
   # Create a Github Release while uploading all files to it
   announce:
     needs:
       - plan
       - host
       - publish-homebrew-formula
+      - custom-publish-release
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.custom-publish-release.result == 'skipped' || needs.custom-publish-release.result == 'success') }}
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ installers = ["shell", "powershell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
 tap = "axodotdev/homebrew-tap"
 # Publish jobs to run in CI
-publish-jobs = ["homebrew"]
+publish-jobs = ["homebrew", "./publish-release"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Publish jobs to run in CI


### PR DESCRIPTION
This switches us to using custom hooks in order to publish to crates.io as a part of the normal release process instead of as a manual job.