### PR TITLE
feat(ci): post-announce jobs

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -50,6 +50,8 @@ pub struct GithubCiInfo {
     pub publish_jobs: Vec<String>,
     /// user-specified publish jobs
     pub user_publish_jobs: Vec<String>,
+    /// post-announce jobs
+    pub post_announce_jobs: Vec<String>,
     /// whether to create the release or assume an existing one
     pub create_release: bool,
     /// \[unstable\] whether to add ssl.com windows binary signing
@@ -119,6 +121,7 @@ impl GithubCiInfo {
         let host_jobs = dist.host_jobs.clone();
         let publish_jobs = dist.publish_jobs.iter().map(|j| j.to_string()).collect();
         let user_publish_jobs = dist.user_publish_jobs.clone();
+        let post_announce_jobs = dist.post_announce_jobs.clone();
 
         // Figure out what Local Artifact tasks we need
         let local_runs = if dist.merge_tasks {
@@ -155,6 +158,7 @@ impl GithubCiInfo {
             host_jobs,
             publish_jobs,
             user_publish_jobs,
+            post_announce_jobs,
             artifacts_matrix: GithubMatrix { include: tasks },
             pr_run_mode,
             global_task,

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -276,6 +276,13 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publish_jobs: Option<Vec<PublishStyle>>,
 
+    /// Post-announce jobs to run in CI
+    ///
+    /// This allows custom jobs to be configured to run after the announce job
+    // runs in its entirety.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_announce_jobs: Option<Vec<JobStyle>>,
+
     /// Whether to publish prereleases to package managers
     ///
     /// (defaults to false)
@@ -341,6 +348,7 @@ impl DistMetadata {
             global_artifacts_jobs: _,
             host_jobs: _,
             publish_jobs: _,
+            post_announce_jobs: _,
             publish_prereleases: _,
             create_release: _,
             pr_run_mode: _,
@@ -392,6 +400,7 @@ impl DistMetadata {
             global_artifacts_jobs,
             host_jobs,
             publish_jobs,
+            post_announce_jobs,
             publish_prereleases,
             create_release,
             pr_run_mode,
@@ -459,6 +468,9 @@ impl DistMetadata {
         }
         if publish_jobs.is_some() {
             warn!("package.metadata.dist.publish-jobs is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
+        }
+        if post_announce_jobs.is_some() {
+            warn!("package.metadata.dist.post-announce-jobs is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
         }
 
         // Merge non-global settings

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -250,6 +250,7 @@ fn get_new_dist_metadata(
             global_artifacts_jobs: None,
             host_jobs: None,
             publish_jobs: None,
+            post_announce_jobs: None,
             publish_prereleases: None,
             create_release: None,
             pr_run_mode: None,
@@ -779,6 +780,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         global_artifacts_jobs,
         host_jobs,
         publish_jobs,
+        post_announce_jobs,
         publish_prereleases,
         create_release,
         pr_run_mode,
@@ -965,6 +967,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "publish-jobs",
         "# Publish jobs to run in CI\n",
         publish_jobs.as_ref(),
+    );
+
+    apply_string_list(
+        table,
+        "post-announce-jobs",
+        "# Post-announce jobs to run in CI\n",
+        post_announce_jobs.as_ref(),
     );
 
     apply_optional_value(

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -199,6 +199,8 @@ pub struct DistGraph {
     pub publish_jobs: Vec<PublishStyle>,
     /// Extra user-specified publish jobs to run
     pub user_publish_jobs: Vec<String>,
+    /// List of post-announce jobs to run
+    pub post_announce_jobs: Vec<String>,
     /// A GitHub repo to publish the Homebrew formula to
     pub tap: Option<String>,
     /// Whether msvc targets should statically link the crt
@@ -745,6 +747,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             host_jobs: _,
             // Only the final value merged into a package_config matters
             publish_jobs: _,
+            // Only the final value merged into a package_config matters
+            post_announce_jobs: _,
             publish_prereleases,
             features,
             default_features,
@@ -864,6 +868,21 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             })
             .collect();
 
+        let post_announce_jobs = workspace_metadata
+            .post_announce_jobs
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|s| {
+                let string = s.to_string();
+                if let Some(stripped) = string.strip_prefix("./") {
+                    stripped.to_owned()
+                } else {
+                    string
+                }
+            })
+            .collect();
+
         let templates = Templates::new()?;
         let publish_jobs: Vec<PublishStyle>;
         let user_publish_jobs: Vec<PublishStyle>;
@@ -928,6 +947,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 host_jobs,
                 publish_jobs,
                 user_publish_jobs,
+                post_announce_jobs,
                 allow_dirty,
                 msvc_crt_static,
                 hosting,

--- a/cargo-dist/templates/ci/github_ci.yml.j2
+++ b/cargo-dist/templates/ci/github_ci.yml.j2
@@ -546,3 +546,15 @@ jobs:
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
     {{%- endif %}}
+
+{{%- for job in post_announce_jobs %}}
+
+  custom-{{{ job|safe }}}:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/{{{ job|safe }}}.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+{{%- endfor %}}


### PR DESCRIPTION
These jobs will be run after the "announce" step is run, ensuring that the GitHub release has been created already.