### PR TITLE
docs(ci): document custom jobs

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -17,6 +17,7 @@
   - [symbols](./artifacts/symbols.md)
 - [CI](./ci/index.md)
   - [github](./ci/github.md)
+  - [Customizing](./ci/customizing.md)
 - [Workspaces](./workspaces/index.md)
   - [A Simple Application](./workspaces/simple-guide.md)
   - [More Complex Workspaces](./workspaces/workspace-guide.md)

--- a/book/src/ci/customizing.md
+++ b/book/src/ci/customizing.md
@@ -1,0 +1,92 @@
+# Customizing CI
+
+<!-- toc -->
+
+cargo-dist's generated CI configuration can be extended in several ways: it can be configured to install extra packages before the build begins, and it's possible to add extra jobs to run at specific lifecycle moments.
+
+In the past, you may have customized cargo-dist's generated CI configuration and used the `allow-dirty = ["ci"]` configuration option. With these new customization options, you may well not need to directly hand-edit cargo-dist's config any longer; we encourate migrating to these new tools.
+
+
+## Install extra packages
+
+> since 0.4.0
+
+Sometimes, you may need extra packages from the system package manager to be installed before in the builder before cargo-dist begins building your software. Cargo-dist can do this for you by adding the `dependencies` setting to your `Cargo.toml`. When set, the packages you request will be fetched and installed in the step before `build`. Additionally, on macOS, the `cargo build` process will be wrapped in `brew bundle exec` to ensure that your dependencies can be found no matter where Homebrew placed them.
+
+Sometimes, you may want to make sure your users also have these dependencies available when they install your software. If you use a package manager-based installer, cargo-dist has the ability to specify these dependencies. By default, cargo-dist will examine your program to try to detect which dependencies it thinks will be necessary. At the moment, [Homebrew][homebrew] is the only supported package manager installer. You can also specify these dependencies manually.
+
+For more information, see the [configuration syntax][config-dependencies].
+
+
+## Custom jobs
+
+> since 0.3.0 (publish-jobs) and 0.7.0 (other steps)
+
+cargo-dist's CI can be configured to call additional jobs on top of the ones it has builtin. Currently, we support adding extra jobs to the the following list of steps:
+
+* [`plan-jobs`][config-plan] (the beginning of the build process)
+* [`build-local-artifacts-jobs`][config-build-local]
+* [`build-global-artifacts-jobs`][config-build-global]
+* [`host-jobs`][config-host-jobs] (pre-publish)
+* [`publish-jobs`][config-publish-jobs]
+* [`post-announce-jobs`][config-post-announce] (after the release is created)
+
+Custom jobs have access to the plan, produced via the "plan" step. This is a JSON document containing information about the project, planned steps, and its outputs. It's the same format contained as the "dist-manifest.json" that will be included with your release. You can use this in your custom jobs to obtain information about what will be built. For more details on the format of this file, see the [schema reference][schema].
+
+To add a custom job, you need to follow two steps:
+
+1. Define the new job as a reusable workflow using the standard method defined by your CI system. For GitHub actions, see the documentation on [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow).
+2. Add the name of your new workflow file to the appropriate array in your `Cargo.toml`'s cargo-dist config, prefixed with a `./`. For example, if your job name is `.github/workflows/my-publish.yml`, you would write it like this:
+
+```toml
+publish-jobs = ["./my-publish"]
+```
+
+Here's an example reusable workflow written using GitHub Actions. It won't do any real publishing, just echo text to the CI output. First, create a file named `.github/workflows/publish-greeter.yml` with these contents:
+
+```yaml
+name: Greeter
+
+on:
+  # Defining workflow_call means that this workflow can be called from
+  # your main workflow job
+  workflow_call:
+    # cargo-dist exposes the plan from the plan step, as a JSON string,
+    # to your job if it needs it
+    inputs:
+      plan:
+        required: true
+        type: string
+
+jobs:
+  greeter:
+    runs-on: ubuntu-latest
+    # This is optional; it exposes the plan to your job as an environment variable
+    env:
+      PLAN: ${{ inputs.plan }}
+    steps:
+      - name: Step 1
+        run: |
+          echo "Hello!"
+          echo "Plan is: ${PLAN}"
+```
+
+Then, add the following to your `publish-jobs` array:
+
+```toml
+publish-jobs = ["./publish-greeter"]
+```
+
+Running `cargo-dist init` for your tool will update your GitHub Actions configuration to make use of the new reusable workflow during the publish step.
+
+[config-dependencies]: ../reference/config.md#dependencies
+[config-plan]: ../reference/config.md#plan-jobs
+[config-build-local]: ../reference/config.md#build-local-artifacts-jobs
+[config-build-global]: ../reference/config.md#build-global-artifacts-jobs
+[host-jobs]: ../reference/config.md#host-jobs
+[publish-jobs]: ../reference/config.md#publish-jobs
+[post-announce-jobs]: ../reference/config.md#post-announce-jobs
+
+[schema]: ../reference/schema.md
+
+[homebrew]: ../installers/homebrew.md

--- a/book/src/ci/github.md
+++ b/book/src/ci/github.md
@@ -65,68 +65,6 @@ If you set `create-release = false` in your cargo-dist config, cargo-dist will a
 
 
 
-### Custom jobs
-
-> since 0.3.0
-
-cargo-dist's CI can be configured to call additional jobs on top of the ones it has builtin. Currently, we support adding extra jobs to the publish step; in the future, we'll allow extending all of the lifecycle steps of the CI workflow. To add one, you need to follow two steps:
-
-1. Define the new job as a reusable workflow using the standard method defined by your CI system. For GitHub actions, see the documentation on [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow).
-2. Add the name of your new workflow file to the `publish-jobs` array in your `Cargo.toml`'s cargo-dist config, prefixed with a `./`. For example, if your job name is `.github/workflows/my-publish.yml`, you would write it like this:
-
-```toml
-publish-jobs = ["./my-publish"]
-```
-
-Here's an example reusable workflow written using GitHub Actions. It won't do any real publishing, just echo text to the CI output. First, create a file named `.github/workflows/publish-greeter.yml` with these contents:
-
-```yaml
-name: Greeter
-
-on:
-  # Defining workflow_call means that this workflow can be called from
-  # your main workflow job
-  workflow_call:
-    # cargo-dist exposes the plan from the plan step, as a JSON string,
-    # to your job if it needs it
-    inputs:
-      plan:
-        required: true
-        type: string
-
-jobs:
-  greeter:
-    runs-on: ubuntu-latest
-    # This is optional; it exposes the plan to your job as an environment variable
-    env:
-      PLAN: ${{ inputs.plan }}
-    steps:
-      - name: Step 1
-        run: |
-          echo "Hello!"
-          echo "Plan is: ${PLAN}"
-```
-
-Then, add the following to your `publish-jobs` array:
-
-```toml
-publish-jobs = ["./publish-greeter"]
-```
-
-Running `cargo-dist init` for your tool will update your GitHub Actions configuration to make use of the new reusable workflow during the publish step.
-
-
-
-### Install extra packages
-
-> since 0.4.0
-
-Sometimes, you may need extra packages from the system package manager to be installed before in the builder before cargo-dist begins building your software. Cargo-dist can do this for you by adding the `dependencies` setting to your `Cargo.toml`. When set, the packages you request will be fetched and installed in the step before `build`. Additionally, on macOS, the `cargo build` process will be wrapped in `brew bundle exec` to ensure that your dependencies can be found no matter where Homebrew placed them.
-
-Sometimes, you may want to make sure your users also have these dependencies available when they install your software. If you use a package manager-based installer, cargo-dist has the ability to specify these dependencies. By default, cargo-dist will examine your program to try to detect which dependencies it thinks will be necessary. At the moment, [Homebrew][homebrew] is the only supported package manager installer. You can also specify these dependencies manually.
-
-For more information, see the [configuration syntax][config-dependencies].
-
 #### Limitations
 
 * Currently, the only supported package managers are Apt (Linux), Chocolatey (Windows) and Homebrew (macOS).
@@ -216,9 +154,7 @@ The Windows report is currently unable to provide information about the sources 
 [config-merge-tasks]: ../reference/config.md#merge-tasks
 [config-allow-dirty]: ../reference/config.md#allow-dirty
 [config-pr-run-mode]: ../reference/config.md#pr-run-mode
-[config-dependencies]: ../reference/config.md#dependencies
 
 [artifact-url]: ../reference/artifact-url.md#github
 [quickstart]: ../way-too-quickstart.md
 [testing]: ../way-too-quickstart.md#test-it-out
-[homebrew]: ../installers/homebrew.md

--- a/book/src/ci/index.md
+++ b/book/src/ci/index.md
@@ -2,13 +2,27 @@
 
 All of the [distribute functionality][distribute] of cargo-dist depends on some kind of CI integration to provide things like [file hosting][artifact-url], secret keys, and the ability to spin up multiple machines.
 
-A CI backend can be enabled with [the ci config][config-ci]
+A CI backend can be enabled with [the ci config][config-ci]. cargo-dist's core CI job can be [customized][ci-customization] using several extra features.
 
 
 
 ## Supported CI Providers
 
 * [github][]: use GitHub Actions and uploads to GitHub Releases
+
+
+
+
+## A quick tour of the CI process
+
+The CI process is divided into several stages which happen in order. Understanding these steps will help you follow the release process and, if necessary, debug failures.
+
+1. plan: cargo-dist calculates which builds to run, and which platforms to build for, and enumerates the files that builds are expected to produce. The output of this step is saved and shared between steps and is also included in the final release as `dist-manifest.json`.
+2. build-local-artifacts: cargo-dist builds native binaries and produces tarballs.
+3. build-global-artifacts: cargo-dist builds platform-independent artifacts such as installers.
+4. host: cargo-dist decides whether to proceed with publishing a release and uploading artifacts.
+5. publish: Artifacts are uploaded and, if used, the Homebrew formula is released.
+6. announce: The release is created with its final non-draft contents.
 
 
 
@@ -23,7 +37,7 @@ The following CI providers have been requested, and we're open to supporting the
 
 
 
-
+[ci-customization]: ../ci/customizing.md
 [config-ci]: ../reference/config.md#ci
 
 [github]: ./github.md

--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -94,6 +94,24 @@ Example: `auto-includes = false`
 Allows you to specify whether cargo-dist should auto-include README, (UN)LICENSE, and CHANGELOG/RELEASES files in [archives][]. Defaults to true.
 
 
+### build-global-artifacts-jobs
+
+> since 0.7.0
+
+Example: `build-global-artifacts-jobs = ["./my-job"]`
+
+This setting determines which custom jobs to run during the "build global artifacts" phase, during which installers are built.
+
+
+### build-local-artifacts-jobs
+
+> since 0.7.0
+
+Example: `build-local-artifacts-jobs = ["./my-job"]`
+
+This setting determines which custom jobs to run during the "build local artifacts" phase, during which binaries are built.
+
+
 ### cargo-dist-version
 
 > since 0.0.3
@@ -277,6 +295,15 @@ If you use this you *probably* want to set it on `[package.metadata.dist]` and
 not `[workspace.metadata.dist]`. See ["inferring precise-builds"](#inferring-precise-builds) for details.
 
 
+### host-jobs
+
+> since 0.7.0
+
+Example: `host-jobs = ["./my-job"]`
+
+This setting determines which custom jobs to run during the "host" phase, during which cargo-dist decides whether to proceed with publishing the release.
+
+
 ### hosting
 
 > since 0.5.0
@@ -388,6 +415,24 @@ Specifies that [npm installers][] should be published under the given [scope][].
 If no scope is specified the package will be global.
 
 
+### plan-jobs
+
+> since 0.7.0
+
+Example: `plan-jobs = ["./my-job"]`
+
+This setting determines which custom jobs to run during the "plan" phase, which happens at the very start of the build.
+
+
+### post-announce-jobs
+
+> since 0.7.0
+
+Example: `post-announce-jobs = ["./my-job"]`
+
+This setting determines which custom jobs to run after the "announce" phase. "Announce" is the final phase during which cargo-dist schedules any jobs, so any custom jobs specified here are guaranteed to run after everything else.
+
+
 ### precise-builds
 
 > since 0.1.0
@@ -449,6 +494,15 @@ This setting determines to what extent we run your Release CI on pull-requests:
 * "skip": don't check the release process in PRs
 * "plan": run 'cargo dist plan' on PRs (recommended, also the default)
 * "upload": build and upload an artifacts.zip to the PR (expensive)
+
+
+### publish-jobs
+
+> since 0.2.0
+
+Example: `publish-jobs = ["homebrew"]`
+
+This setting determines which publish jobs to run. It includes one builtin job (`homebrew`) and, since 0.3.0, the ability to specify custom jobs.
 
 
 ### publish-prereleases


### PR DESCRIPTION
This adds the new custom jobs to our existing documentation, with explanations of where each job runs.