### PR TITLE
chore(toolchain): update to 1.75

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.74"
+channel = "1.75"
 components = ["rustc", "cargo", "rust-std", "clippy", "rustfmt"]


### PR DESCRIPTION
Released 2023-12-28.

We can probably eventually remove this file; we need it for now because our minimum Rust is 1.74 and CI picked something older without hinting.