### PR TITLE
feat(installers): add install receipt

### DIFF
--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 
 use crate::{
     config::{JinjaInstallPathStrategy, ZipStyle},
-    TargetTriple,
+    InstallReceipt, TargetTriple,
 };
 
 use self::homebrew::HomebrewInstallerInfo;
@@ -55,6 +55,8 @@ pub struct InstallerInfo {
     pub hint: String,
     /// Where to install binaries
     pub install_path: JinjaInstallPathStrategy,
+    /// Install receipt to write, if any
+    pub receipt: Option<InstallReceipt>,
 }
 
 /// A fake fragment of an ExecutableZip artifact for installers

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -56,6 +56,7 @@ use camino::Utf8PathBuf;
 use cargo_dist_schema::DistManifest;
 use miette::{miette, Context, IntoDiagnostic};
 use semver::Version;
+use serde::Serialize;
 use tracing::{info, warn};
 
 use crate::announce::{self, AnnouncementTag};
@@ -1662,6 +1663,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 artifacts,
                 hint,
                 desc,
+                receipt: InstallReceipt::from_metadata(&self.inner, release),
             })),
             is_global: true,
         };
@@ -1912,6 +1914,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     artifacts,
                     hint,
                     desc,
+                    receipt: None,
                 },
             })),
             is_global: true,
@@ -1990,6 +1993,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 artifacts,
                 hint,
                 desc,
+                receipt: InstallReceipt::from_metadata(&self.inner, release),
             })),
             is_global: true,
         };
@@ -2171,6 +2175,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     artifacts,
                     hint,
                     desc,
+                    receipt: None,
                 },
             })),
             is_global: true,
@@ -2770,4 +2775,102 @@ fn find_tool(name: &str, test_flag: &str) -> Option<Tool> {
         cmd: name.to_owned(),
         version: version.to_owned(),
     })
+}
+
+/// Represents the source for the canonical form of this app's releases
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReleaseSourceType {
+    /// GitHub Releases
+    GitHub,
+    /// Axo releases
+    Axo,
+}
+
+/// Where to look up releases for this app
+#[derive(Clone, Debug, Serialize)]
+pub struct ReleaseSource {
+    /// Which type of remote resource to look up
+    pub release_type: ReleaseSourceType,
+    /// The owner, from the owner/name format
+    pub owner: String,
+    /// The name, from the owner/name format
+    pub name: String,
+    /// The app's name
+    pub app_name: String,
+}
+
+/// The software which installed this receipt
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProviderSource {
+    /// cargo-dist
+    CargoDist,
+}
+
+/// Information about the source of this receipt
+#[derive(Clone, Debug, Serialize)]
+pub struct Provider {
+    /// The software this receipt was installed via
+    pub source: ProviderSource,
+    /// The version of the above software
+    pub version: String,
+}
+
+/// Struct representing an install receipt
+#[derive(Clone, Debug, Serialize)]
+pub struct InstallReceipt {
+    /// The location on disk where this app was installed
+    pub install_prefix: Utf8PathBuf,
+    /// A list of all binaries installed by this app
+    pub binaries: Vec<String>,
+    /// Information about where to request information on new releases
+    pub source: ReleaseSource,
+    /// The version that was installed
+    pub version: String,
+    /// The software which installed this receipt
+    pub provider: Provider,
+}
+
+impl InstallReceipt {
+    /// Produces an install receipt for the given DistGraph.
+    pub fn from_metadata(manifest: &DistGraph, release: &Release) -> Option<InstallReceipt> {
+        let hosting = if let Some(hosting) = &manifest.hosting {
+            hosting
+        } else {
+            return None;
+        };
+        let source_type = if hosting.hosts.contains(&HostingStyle::Axodotdev) {
+            ReleaseSourceType::Axo
+        } else {
+            ReleaseSourceType::GitHub
+        };
+
+        let install_prefix = match &release.install_path {
+            // The actual value of $CARGO_HOME isn't known until inside the
+            // install script, so we write out a temporary value that the
+            // install script will replace with the real one later.
+            InstallPathStrategy::CargoHome => "AXO_CARGO_HOME".to_owned(),
+            InstallPathStrategy::HomeSubdir { subdir } => format!("$HOME/{}", subdir),
+            InstallPathStrategy::EnvSubdir { env_key, subdir } => {
+                format!("${}/{}", env_key, subdir)
+            }
+        };
+
+        Some(InstallReceipt {
+            install_prefix: Utf8PathBuf::from(install_prefix),
+            binaries: vec!["CARGO_DIST_BINS".to_owned()],
+            version: release.version.to_string(),
+            source: ReleaseSource {
+                release_type: source_type,
+                owner: hosting.owner.to_owned(),
+                name: hosting.project.to_owned(),
+                app_name: release.app_name.to_owned(),
+            },
+            provider: Provider {
+                source: ProviderSource::CargoDist,
+                version: env!("CARGO_PKG_VERSION").to_owned(),
+            },
+        })
+    }
 }

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -47,6 +47,11 @@ param (
 $app_name = '{{ app_name }}'
 $app_version = '{{ app_version }}'
 
+$receipt = @"
+{{ receipt | tojson }}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\{{ app_name }}"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -175,13 +180,18 @@ function Invoke-Installer($bin_paths) {
 {% if install_path.kind == "CargoHome" %}
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 {% elif install_path.kind == "HomeSubdir" %}
   # Install to this subdir of the user's home dir
   $dest_dir = if (($base_dir = $HOME)) {
@@ -208,6 +218,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/{{ app_name }}-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -22,6 +22,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-{{ base_url }}}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{{ receipt | tojson }}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/{{ app_name }}"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -139,11 +144,15 @@ download_binary_and_run_installer() {
             _artifact_name="{{ artifact.id }}"
             _zip_ext="{{ artifact.zip_style }}"
             _bins="{% for bin in artifact.binaries %}{{ bin }}{{ " " if not loop.last else "" }}{% endfor %}"
+            _bins_js_array='{% for bin in artifact.binaries %}"{{ bin }}"{{ "," if not loop.last else ""}}{% endfor %}'
             ;;{% endfor %}
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -185,8 +194,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -240,6 +260,7 @@ install() {
 {% if install_path.kind == "CargoHome" %}
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -258,6 +279,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -265,6 +287,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 {% elif install_path.kind == "HomeSubdir" %}
     # Install to this subdir of the user's home dir
     # In this case we want to be late-bound, as $HOME is reliable/nice.

--- a/cargo-dist/tests/gallery/dist.rs
+++ b/cargo-dist/tests/gallery/dist.rs
@@ -642,6 +642,7 @@ pub fn snapshot_settings_with_gallery_filter() -> insta::Settings {
         r"cargo-dist/releases/download/v\d+\.\d+\.\d+(\-prerelease\d*)?(\.\d+)?/",
         "cargo-dist/releases/download/vSOME_VERSION/",
     );
+    settings.add_filter(r#""version":"[a-zA-Z\.0-9]*""#, r#""version":"CENSORED""#);
     settings
 }
 

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/a
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="akaikatana-repack-aarch64-apple-darwin.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
+            _bins_js_array='"akextract","akmetadata","akrepack"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="akaikatana-repack-x86_64-apple-darwin.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
+            _bins_js_array='"akextract","akmetadata","akrepack"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
+            _bins_js_array='"akextract","akmetadata","akrepack"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -862,6 +888,11 @@ param (
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -986,13 +1017,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1003,6 +1039,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/akaikatana-repack-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/a
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,31 +141,39 @@ download_binary_and_run_installer() {
             _artifact_name="akaikatana-repack-aarch64-apple-darwin.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
+            _bins_js_array='"akextract","akmetadata","akrepack"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="akaikatana-repack-x86_64-apple-darwin.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
+            _bins_js_array='"akextract","akmetadata","akrepack"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
+            _bins_js_array='"akextract","akmetadata","akrepack"'
             ;;
         "x86_64-unknown-linux-musl-dynamic")
             _artifact_name="akaikatana-repack-x86_64-unknown-linux-musl.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
+            _bins_js_array='"akextract","akmetadata","akrepack"'
             ;;
         "x86_64-unknown-linux-musl-static")
             _artifact_name="akaikatana-repack-x86_64-unknown-linux-musl.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
+            _bins_js_array='"akextract","akmetadata","akrepack"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -202,8 +215,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -257,6 +281,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -275,6 +300,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -282,6 +308,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/a
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="akaikatana-repack-aarch64-apple-darwin.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
+            _bins_js_array='"akextract","akmetadata","akrepack"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="akaikatana-repack-x86_64-apple-darwin.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
+            _bins_js_array='"akextract","akmetadata","akrepack"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz"
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
+            _bins_js_array='"akextract","akmetadata","akrepack"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -862,6 +888,11 @@ param (
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -986,13 +1017,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1003,6 +1039,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/akaikatana-repack-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://fake.axo.dev/faker/axol
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -863,6 +889,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -987,13 +1018,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1004,6 +1040,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://fake.axo.dev/faker/axol
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -863,6 +889,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -987,13 +1018,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1004,6 +1040,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -863,6 +889,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -987,13 +1018,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1004,6 +1040,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -863,6 +889,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -987,13 +1018,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1004,6 +1040,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,31 +141,39 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-musl-dynamic")
             _artifact_name="axolotlsay-x86_64-unknown-linux-musl.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-musl-static")
             _artifact_name="axolotlsay-x86_64-unknown-linux-musl.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -202,8 +215,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -257,6 +281,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -275,6 +300,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -282,6 +308,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,31 +141,39 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-musl.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-musl-dynamic")
             _artifact_name="axolotlsay-x86_64-unknown-linux-musl.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-musl-static")
             _artifact_name="axolotlsay-x86_64-unknown-linux-musl.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -202,8 +215,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -257,6 +281,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -275,6 +300,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -282,6 +308,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -863,6 +889,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -987,13 +1018,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1004,6 +1040,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -817,6 +843,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -941,13 +972,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -958,6 +994,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -817,6 +843,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -941,13 +972,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -958,6 +994,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -863,6 +889,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -987,13 +1018,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1004,6 +1040,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -863,6 +889,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -987,13 +1018,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1004,6 +1040,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -863,6 +889,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -987,13 +1018,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1004,6 +1040,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -863,6 +889,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -987,13 +1018,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1004,6 +1040,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -863,6 +889,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -987,13 +1018,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1004,6 +1040,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -247,6 +269,7 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
+        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
@@ -265,6 +288,7 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
+        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -272,6 +296,8 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_home,")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -863,6 +889,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"AXO_CARGO_HOME","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -987,13 +1018,18 @@ function Invoke-Installer($bin_paths) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
-  $dest_dir = if (($base_dir = $env:CARGO_HOME)) {
-    Join-Path $base_dir "bin"
+  $root = if (($base_dir = $env:CARGO_HOME)) {
+    $base_dir
   } elseif (($base_dir = $HOME)) {
-    Join-Path $base_dir ".cargo\bin"
+    Join-Path $base_dir ".cargo"
   } else {
     throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $root.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
@@ -1004,6 +1040,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$MY_ENV_VAR/","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -846,6 +868,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$MY_ENV_VAR/","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -984,6 +1011,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$MY_ENV_VAR/bin","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -846,6 +868,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$MY_ENV_VAR/bin","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -984,6 +1011,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$MY_ENV_VAR/My Axolotlsay Documents","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -846,6 +868,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$MY_ENV_VAR/My Axolotlsay Documents","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -984,6 +1011,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$MY_ENV_VAR/My Axolotlsay Documents/bin","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -846,6 +868,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$MY_ENV_VAR/My Axolotlsay Documents/bin","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -984,6 +1011,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$HOME/.axolotlsay/bins","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -846,6 +868,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$HOME/.axolotlsay/bins","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -984,6 +1011,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$HOME/.axolotlsay","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -846,6 +868,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$HOME/.axolotlsay","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -984,6 +1011,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$HOME/My Axolotlsay Documents","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -846,6 +868,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$HOME/My Axolotlsay Documents","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -984,6 +1011,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -27,6 +27,11 @@ ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/ax
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$HOME/My Axolotlsay Documents/bin","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
 # glibc provided by our Ubuntu 20.04 runners;
 # in the future, we should actually record which glibc was on the runner,
@@ -136,21 +141,27 @@ download_binary_and_run_installer() {
             _artifact_name="axolotlsay-aarch64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-apple-darwin")
             _artifact_name="axolotlsay-x86_64-apple-darwin.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         "x86_64-unknown-linux-gnu")
             _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
             ;;
         *)
             err "there isn't a package for $_arch"
             ;;
     esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s,'"CARGO_DIST_BINS"',"$_bins_js_array",)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -192,8 +203,19 @@ download_binary_and_run_installer() {
 
     install "$_dir" "$_bins" "$@"
     local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
 
     ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
 
     return "$_retval"
 }
@@ -846,6 +868,11 @@ param (
 $app_name = 'axolotlsay'
 $app_version = '0.2.1'
 
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"install_prefix":"$HOME/My Axolotlsay Documents/bin","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -984,6 +1011,16 @@ function Invoke-Installer($bin_paths) {
     Remove-Item "$bin_path" -Recurse -Force
     Write-Information "  $installed_file"
   }
+
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+  $info = $platforms[$arch]
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  Out-File -FilePath $receipt_home/axolotlsay-receipt.json -InputObject $receipt -Encoding utf8
 
   Write-Information "Everything's installed!"
   if (-not $NoModifyPath) {


### PR DESCRIPTION
This adds install receipts, letting us track information about where a program was installed from and what its current version is. We'll use that information eventually in the updater, #650; getting the data in place now will help us be prepared for it in the future.

This is still a draft since it's got a few issues I want to fix up on Monday:

- [x] The list of binaries is wrong; I'm using the wrong source.
- [x] The install prefix isn't filled out yet, and probably has to be filled out in shell instead of in cargo-dist.
- [x] Powershell isn't done yet.