### PR TITLE
fix: improve glibc bounds to npm installer

### DIFF
--- a/cargo-dist/templates/installer/npm/binary.js.j2
+++ b/cargo-dist/templates/installer/npm/binary.js.j2
@@ -14,7 +14,7 @@ const name = {{ inner.app_name }};
 const artifact_download_url = {{ inner.base_url }};
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   {%- for artifact in inner.artifacts %}

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1410,7 +1410,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1410,7 +1410,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1410,7 +1410,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1410,7 +1410,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1092,7 +1092,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1092,7 +1092,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1410,7 +1410,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1410,7 +1410,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1410,7 +1410,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1410,7 +1410,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1410,7 +1410,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1410,7 +1410,7 @@ const name = "axolotlsay";
 const artifact_download_url = "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1";
 
 const builder_glibc_major_version = 2;
-const builder_glibc_minor_version = 35;
+const builder_glibc_minor_version = 31;
 
 const supportedPlatforms = {
   "aarch64-apple-darwin": {


### PR DESCRIPTION
we did this for shell but forgot about npm