### PR TITLE
fix: more literally disable host --check

### DIFF
--- a/cargo-dist/templates/ci/github_ci.yml.j2
+++ b/cargo-dist/templates/ci/github_ci.yml.j2
@@ -113,10 +113,11 @@ jobs:
       - id: plan
         run: |
           cargo dist
-          {{%- if dispatch_releases %}} ${{ inputs.tag && (inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag) || format('host --steps=create', inputs.tag))
-          {{%- else %}} ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)
+          {{%- if dispatch_releases %}} ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag))
+          {{%- else %}} ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name))
           {{%- endif %}}
-          {{{- " || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json" | safe }}}
+          {{%- if "axodotdev" in hosting_providers %}} || (env.AXO_RELEASES_TOKEN && 'host --steps=check') {{%- endif %}}
+          {{{- " || 'plan' }} --output-format=json > dist-manifest.json" | safe }}}
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -135,6 +135,149 @@ path-guid = "BFD25009-65A4-4D1E-97F1-0030465D90D6"
 }
 
 #[test]
+fn axolotlsay_dispatch() -> Result<(), miette::Report> {
+    let test_name = _function_name!();
+    AXOLOTLSAY.run_test(|ctx| {
+        let dist_version = ctx.tools.cargo_dist.version().unwrap();
+        ctx.patch_cargo_toml(format!(r#"
+[workspace.metadata.dist]
+cargo-dist-version = "{dist_version}"
+installers = []
+targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
+ci = ["github"]
+dispatch-releases = true
+"#
+        ))?;
+
+        // Run generate to make sure stuff is up to date before running other commands
+        let ci_result = ctx.cargo_dist_generate(test_name)?;
+        let ci_snap = ci_result.check_all()?;
+        //rr Do usual build+plan checks
+        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
+        let main_snap = main_result.check_all(ctx, ".cargo/bin/")?;
+        // snapshot all
+        main_snap.join(ci_snap).snap();
+        Ok(())
+    })
+}
+
+#[test]
+fn axolotlsay_dispatch_abyss() -> Result<(), miette::Report> {
+    let test_name = _function_name!();
+    AXOLOTLSAY.run_test(|ctx| {
+        let dist_version = ctx.tools.cargo_dist.version().unwrap();
+        ctx.patch_cargo_toml(format!(r#"
+[workspace.metadata.dist]
+cargo-dist-version = "{dist_version}"
+installers = []
+targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
+ci = ["github"]
+hosting = ["axodotdev", "github"]
+dispatch-releases = true
+"#
+        ))?;
+
+        // Run generate to make sure stuff is up to date before running other commands
+        let ci_result = ctx.cargo_dist_generate(test_name)?;
+        let ci_snap = ci_result.check_all()?;
+        // Do usual build+plan checks
+        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
+        // !!! this hosting doesn't exist, do not ruin my computer with installers!!!
+        let main_snap = main_result.check_all_no_ruin(ctx, ".cargo/bin/")?;
+        // snapshot all
+        main_snap.join(ci_snap).snap();
+        Ok(())
+    })
+}
+
+#[test]
+fn axolotlsay_dispatch_abyss_only() -> Result<(), miette::Report> {
+    let test_name = _function_name!();
+    AXOLOTLSAY.run_test(|ctx| {
+        let dist_version = ctx.tools.cargo_dist.version().unwrap();
+        ctx.patch_cargo_toml(format!(r#"
+[workspace.metadata.dist]
+cargo-dist-version = "{dist_version}"
+installers = []
+targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
+ci = ["github"]
+hosting = ["axodotdev"]
+dispatch-releases = true
+"#
+        ))?;
+
+        // Run generate to make sure stuff is up to date before running other commands
+        let ci_result = ctx.cargo_dist_generate(test_name)?;
+        let ci_snap = ci_result.check_all()?;
+        // Do usual build+plan checks
+        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
+        // !!! this hosting doesn't exist, do not ruin my computer with installers!!!
+        let main_snap = main_result.check_all_no_ruin(ctx, ".cargo/bin/")?;
+        // snapshot all
+        main_snap.join(ci_snap).snap();
+        Ok(())
+    })
+}
+
+#[test]
+fn axolotlsay_no_locals() -> Result<(), miette::Report> {
+    let test_name = _function_name!();
+    AXOLOTLSAY.run_test(|ctx| {
+        let dist_version = ctx.tools.cargo_dist.version().unwrap();
+        ctx.patch_cargo_toml(format!(r#"
+[workspace.metadata.dist]
+cargo-dist-version = "{dist_version}"
+installers = []
+targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
+ci = ["github"]
+build-local-artifacts = false
+"#
+        ))?;
+
+        // Run generate to make sure stuff is up to date before running other commands
+        let ci_result = ctx.cargo_dist_generate(test_name)?;
+        let ci_snap = ci_result.check_all()?;
+        // Do usual build+plan checks
+        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
+        // !!! this hosting doesn't exist, do not ruin my computer with installers!!!
+        let main_snap = main_result.check_all_no_ruin(ctx, ".cargo/bin/")?;
+        // snapshot all
+        main_snap.join(ci_snap).snap();
+        Ok(())
+    })
+}
+
+#[test]
+fn axolotlsay_no_locals_but_custom() -> Result<(), miette::Report> {
+    let test_name = _function_name!();
+    AXOLOTLSAY.run_test(|ctx| {
+        let dist_version = ctx.tools.cargo_dist.version().unwrap();
+        ctx.patch_cargo_toml(format!(r#"
+[workspace.metadata.dist]
+cargo-dist-version = "{dist_version}"
+installers = []
+targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
+ci = ["github"]
+build-local-artifacts = false
+local-artifacts-jobs = ["./local-artifacts"]
+
+"#
+        ))?;
+
+        // Run generate to make sure stuff is up to date before running other commands
+        let ci_result = ctx.cargo_dist_generate(test_name)?;
+        let ci_snap = ci_result.check_all()?;
+        // Do usual build+plan checks
+        let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
+        // !!! this hosting doesn't exist, do not ruin my computer with installers!!!
+        let main_snap = main_result.check_all_no_ruin(ctx, ".cargo/bin/")?;
+        // snapshot all
+        main_snap.join(ci_snap).snap();
+        Ok(())
+    })
+}
+
+#[test]
 fn axolotlsay_no_homebrew_publish() -> Result<(), miette::Report> {
     let test_name = _function_name!();
     AXOLOTLSAY.run_test(|ctx| {

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1483,7 +1483,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1132,7 +1132,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -1483,7 +1483,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -2415,7 +2415,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || (env.AXO_RELEASES_TOKEN && 'host --steps=check') || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -2407,7 +2407,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || (env.AXO_RELEASES_TOKEN && 'host --steps=check') || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2405,7 +2405,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -10,7 +10,7 @@ expression: self.payload
   "announcement_is_prerelease": false,
   "announcement_title": "Version 0.2.1",
   "announcement_changelog": "```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```",
-  "announcement_github_body": "## Release Notes\n\n```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Download axolotlsay 0.2.1\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-gnu.tar.xz) | ARM64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n| [axolotlsay-aarch64-unknown-linux-musl.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-musl.tar.xz) | ARM64 MUSL Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-musl.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-musl.tar.xz) | x64 MUSL Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256) |\n\n",
+  "announcement_github_body": "## Release Notes\n\n```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Download axolotlsay 0.2.1\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-apple-darwin.tar.xz) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-apple-darwin.tar.xz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.zip](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-pc-windows-msvc.zip) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-pc-windows-msvc.zip.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n\n",
   "system_info": {
     "cargo_version_line": "CENSORED"
   },
@@ -21,14 +21,14 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
-        "axolotlsay-aarch64-unknown-linux-gnu.tar.xz",
-        "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256",
-        "axolotlsay-aarch64-unknown-linux-musl.tar.xz",
-        "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256",
+        "axolotlsay-aarch64-apple-darwin.tar.xz",
+        "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-apple-darwin.tar.xz",
+        "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-pc-windows-msvc.zip",
+        "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
         "axolotlsay-x86_64-unknown-linux-gnu.tar.xz",
-        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256",
-        "axolotlsay-x86_64-unknown-linux-musl.tar.xz",
-        "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256"
+        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256"
       ],
       "hosting": {
         "github": {
@@ -38,11 +38,11 @@ expression: self.payload
     }
   ],
   "artifacts": {
-    "axolotlsay-aarch64-unknown-linux-gnu.tar.xz": {
-      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz",
+    "axolotlsay-aarch64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz",
       "kind": "executable-zip",
       "target_triples": [
-        "aarch64-unknown-linux-gnu"
+        "aarch64-apple-darwin"
       ],
       "assets": [
         {
@@ -71,20 +71,20 @@ expression: self.payload
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256"
+      "checksum": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256"
     },
-    "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256": {
-      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256",
+    "axolotlsay-aarch64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "aarch64-unknown-linux-gnu"
+        "aarch64-apple-darwin"
       ]
     },
-    "axolotlsay-aarch64-unknown-linux-musl.tar.xz": {
-      "name": "axolotlsay-aarch64-unknown-linux-musl.tar.xz",
+    "axolotlsay-x86_64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz",
       "kind": "executable-zip",
       "target_triples": [
-        "aarch64-unknown-linux-musl"
+        "x86_64-apple-darwin"
       ],
       "assets": [
         {
@@ -113,13 +113,55 @@ expression: self.payload
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256"
+      "checksum": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256"
     },
-    "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256": {
-      "name": "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256",
+    "axolotlsay-x86_64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "aarch64-unknown-linux-musl"
+        "x86_64-apple-darwin"
+      ]
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "name": "axolotlsay",
+          "path": "axolotlsay.exe",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256"
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip.sha256": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
       ]
     },
     "axolotlsay-x86_64-unknown-linux-gnu.tar.xz": {
@@ -164,48 +206,6 @@ expression: self.payload
         "x86_64-unknown-linux-gnu"
       ]
     },
-    "axolotlsay-x86_64-unknown-linux-musl.tar.xz": {
-      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.xz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "x86_64-unknown-linux-musl"
-      ],
-      "assets": [
-        {
-          "name": "CHANGELOG.md",
-          "path": "CHANGELOG.md",
-          "kind": "changelog"
-        },
-        {
-          "name": "LICENSE-APACHE",
-          "path": "LICENSE-APACHE",
-          "kind": "license"
-        },
-        {
-          "name": "LICENSE-MIT",
-          "path": "LICENSE-MIT",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "name": "axolotlsay",
-          "path": "axolotlsay",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256"
-    },
-    "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256": {
-      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "x86_64-unknown-linux-musl"
-      ]
-    },
     "source.tar.gz": {
       "name": "source.tar.gz",
       "kind": "source-tarball",
@@ -223,37 +223,35 @@ expression: self.payload
         "include": [
           {
             "targets": [
-              "aarch64-unknown-linux-gnu"
+              "aarch64-apple-darwin"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu"
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
             "targets": [
-              "aarch64-unknown-linux-musl"
+              "x86_64-apple-darwin"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
+          },
+          {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
+            "runner": "windows-2019",
+            "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
             "targets": [
               "x86_64-unknown-linux-gnu"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204",
+            "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
-          },
-          {
-            "targets": [
-              "x86_64-unknown-linux-musl"
-            ],
-            "runner": "buildjet-8vcpu-ubuntu-2204",
-            "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
           }
         ]
       },
@@ -282,7 +280,7 @@ name: Release
 permissions:
   contents: write
 
-# This task will run whenever you push a git tag that looks like a version
+# This task will run whenever you workflow_dispatch with a tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
 # Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
@@ -304,9 +302,13 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  push:
-    tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release Tag
+        required: true
+        default: dry-run
+        type: string
   pull_request:
 
 jobs:
@@ -315,9 +317,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
-      publishing: ${{ !github.event.pull_request }}
+      tag: ${{ (inputs.tag != 'dry-run' && inputs.tag) || '' }}
+      tag-flag: ${{ inputs.tag && inputs.tag != 'dry-run' && format('--tag={0}', inputs.tag) || '' }}
+      publishing: ${{ inputs.tag && inputs.tag != 'dry-run' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -336,7 +338,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -352,7 +354,7 @@ jobs:
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan
-    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
+    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') || inputs.tag == 'dry-run' }}
     strategy:
       fail-fast: false
       # Target platforms/runners are computed by cargo-dist in create-release.

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -10,7 +10,7 @@ expression: self.payload
   "announcement_is_prerelease": false,
   "announcement_title": "Version 0.2.1",
   "announcement_changelog": "```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```",
-  "announcement_github_body": "## Release Notes\n\n```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Download axolotlsay 0.2.1\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-gnu.tar.xz) | ARM64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n| [axolotlsay-aarch64-unknown-linux-musl.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-musl.tar.xz) | ARM64 MUSL Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-musl.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-musl.tar.xz) | x64 MUSL Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256) |\n\n",
+  "announcement_github_body": "## Release Notes\n\n```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Download axolotlsay 0.2.1\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.xz](https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-aarch64-apple-darwin.tar.xz) | Apple Silicon macOS | [checksum](https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-aarch64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.xz](https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-x86_64-apple-darwin.tar.xz) | Intel macOS | [checksum](https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-x86_64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.zip](https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-x86_64-pc-windows-msvc.zip) | x64 Windows | [checksum](https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-x86_64-pc-windows-msvc.zip.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.xz](https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n\n",
   "system_info": {
     "cargo_version_line": "CENSORED"
   },
@@ -21,28 +21,36 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
-        "axolotlsay-aarch64-unknown-linux-gnu.tar.xz",
-        "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256",
-        "axolotlsay-aarch64-unknown-linux-musl.tar.xz",
-        "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256",
+        "axolotlsay-aarch64-apple-darwin.tar.xz",
+        "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-apple-darwin.tar.xz",
+        "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-pc-windows-msvc.zip",
+        "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
         "axolotlsay-x86_64-unknown-linux-gnu.tar.xz",
-        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256",
-        "axolotlsay-x86_64-unknown-linux-musl.tar.xz",
-        "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256"
+        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256"
       ],
       "hosting": {
         "github": {
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1"
+        },
+        "axodotdev": {
+          "package": "axolotlsay",
+          "public_id": "fake-id-do-not-upload",
+          "set_download_url": "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload",
+          "upload_url": null,
+          "release_url": null,
+          "announce_url": null
         }
       }
     }
   ],
   "artifacts": {
-    "axolotlsay-aarch64-unknown-linux-gnu.tar.xz": {
-      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz",
+    "axolotlsay-aarch64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz",
       "kind": "executable-zip",
       "target_triples": [
-        "aarch64-unknown-linux-gnu"
+        "aarch64-apple-darwin"
       ],
       "assets": [
         {
@@ -71,20 +79,20 @@ expression: self.payload
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256"
+      "checksum": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256"
     },
-    "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256": {
-      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256",
+    "axolotlsay-aarch64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "aarch64-unknown-linux-gnu"
+        "aarch64-apple-darwin"
       ]
     },
-    "axolotlsay-aarch64-unknown-linux-musl.tar.xz": {
-      "name": "axolotlsay-aarch64-unknown-linux-musl.tar.xz",
+    "axolotlsay-x86_64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz",
       "kind": "executable-zip",
       "target_triples": [
-        "aarch64-unknown-linux-musl"
+        "x86_64-apple-darwin"
       ],
       "assets": [
         {
@@ -113,13 +121,55 @@ expression: self.payload
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256"
+      "checksum": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256"
     },
-    "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256": {
-      "name": "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256",
+    "axolotlsay-x86_64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "aarch64-unknown-linux-musl"
+        "x86_64-apple-darwin"
+      ]
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "name": "axolotlsay",
+          "path": "axolotlsay.exe",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256"
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip.sha256": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
       ]
     },
     "axolotlsay-x86_64-unknown-linux-gnu.tar.xz": {
@@ -164,48 +214,6 @@ expression: self.payload
         "x86_64-unknown-linux-gnu"
       ]
     },
-    "axolotlsay-x86_64-unknown-linux-musl.tar.xz": {
-      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.xz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "x86_64-unknown-linux-musl"
-      ],
-      "assets": [
-        {
-          "name": "CHANGELOG.md",
-          "path": "CHANGELOG.md",
-          "kind": "changelog"
-        },
-        {
-          "name": "LICENSE-APACHE",
-          "path": "LICENSE-APACHE",
-          "kind": "license"
-        },
-        {
-          "name": "LICENSE-MIT",
-          "path": "LICENSE-MIT",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "name": "axolotlsay",
-          "path": "axolotlsay",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256"
-    },
-    "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256": {
-      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "x86_64-unknown-linux-musl"
-      ]
-    },
     "source.tar.gz": {
       "name": "source.tar.gz",
       "kind": "source-tarball",
@@ -223,37 +231,35 @@ expression: self.payload
         "include": [
           {
             "targets": [
-              "aarch64-unknown-linux-gnu"
+              "aarch64-apple-darwin"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu"
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
             "targets": [
-              "aarch64-unknown-linux-musl"
+              "x86_64-apple-darwin"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
+          },
+          {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
+            "runner": "windows-2019",
+            "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
             "targets": [
               "x86_64-unknown-linux-gnu"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204",
+            "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
-          },
-          {
-            "targets": [
-              "x86_64-unknown-linux-musl"
-            ],
-            "runner": "buildjet-8vcpu-ubuntu-2204",
-            "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
           }
         ]
       },
@@ -272,6 +278,7 @@ expression: self.payload
 # * checks for a Git Tag that looks like a release
 # * builds artifacts with cargo-dist (archives, installers, hashes)
 # * uploads those artifacts to temporary workflow zip
+# * on success, uploads the artifacts to Axo Releases and makes an Announcement
 # * on success, uploads the artifacts to a Github Release
 #
 # Note that the Github Release will be created with a generated
@@ -282,7 +289,7 @@ name: Release
 permissions:
   contents: write
 
-# This task will run whenever you push a git tag that looks like a version
+# This task will run whenever you workflow_dispatch with a tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
 # Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
@@ -304,9 +311,13 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  push:
-    tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release Tag
+        required: true
+        default: dry-run
+        type: string
   pull_request:
 
 jobs:
@@ -315,11 +326,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
-      publishing: ${{ !github.event.pull_request }}
+      tag: ${{ (inputs.tag != 'dry-run' && inputs.tag) || '' }}
+      tag-flag: ${{ inputs.tag && inputs.tag != 'dry-run' && format('--tag={0}', inputs.tag) || '' }}
+      publishing: ${{ inputs.tag && inputs.tag != 'dry-run' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -336,7 +348,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag)) || (env.AXO_RELEASES_TOKEN && 'host --steps=check') || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -352,7 +364,7 @@ jobs:
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan
-    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
+    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') || inputs.tag == 'dry-run' }}
     strategy:
       fail-fast: false
       # Target platforms/runners are computed by cargo-dist in create-release.
@@ -452,7 +464,16 @@ jobs:
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
-  # Determines if we should publish/announce
+  # Uploads the artifacts to Axo Releases and tentatively creates Releases for them.
+  # This makes perma URLs like /v1.0.0/ live for subsequent publish steps to use, but
+  # leaves them "disconnected" from the release history (for the purposes of
+  # "list the releases" or "give me the latest releases").
+  #
+  # If all the subsequent "publish" steps succeed, the "announce" job will "connect"
+  # the releases and concepts like "latest" will be updated. Otherwise you're hopefully
+  # in a decent position to roll back the release without anyone noticing it!
+  # This is imperfect with things like "publish to crates.io" being irreversible, but
+  # at worst you're in a better position to yank the version with minimum disruption.
   host:
     needs:
       - plan
@@ -462,6 +483,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     runs-on: "ubuntu-20.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
@@ -477,6 +499,7 @@ jobs:
         with:
           name: artifacts
           path: target/distrib/
+      # Upload files to Axo Releases and create the Releases
       # This is a harmless no-op for Github Releases, hosting for that happens in "announce"
       - id: host
         shell: bash
@@ -491,6 +514,7 @@ jobs:
           name: artifacts
           path: dist-manifest.json
 
+  # Create an Announcement for all the Axo Releases, updating the "latest" release
   # Create a Github Release while uploading all files to it
   announce:
     needs:
@@ -503,10 +527,21 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install cargo-dist
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+      - name: Fetch Axo Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+          path: target/distrib/
+      - name: Announce Axo Releases
+        run: |
+          cargo dist host --steps=announce ${{ needs.plan.outputs.tag-flag }}
       - name: "Download Github Artifacts"
         uses: actions/download-artifact@v3
         with:

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -10,7 +10,6 @@ expression: self.payload
   "announcement_is_prerelease": false,
   "announcement_title": "Version 0.2.1",
   "announcement_changelog": "```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```",
-  "announcement_github_body": "## Release Notes\n\n```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Download axolotlsay 0.2.1\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-gnu.tar.xz) | ARM64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n| [axolotlsay-aarch64-unknown-linux-musl.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-musl.tar.xz) | ARM64 MUSL Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-musl.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-musl.tar.xz) | x64 MUSL Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256) |\n\n",
   "system_info": {
     "cargo_version_line": "CENSORED"
   },
@@ -21,28 +20,33 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
-        "axolotlsay-aarch64-unknown-linux-gnu.tar.xz",
-        "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256",
-        "axolotlsay-aarch64-unknown-linux-musl.tar.xz",
-        "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256",
+        "axolotlsay-aarch64-apple-darwin.tar.xz",
+        "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-apple-darwin.tar.xz",
+        "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-pc-windows-msvc.zip",
+        "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
         "axolotlsay-x86_64-unknown-linux-gnu.tar.xz",
-        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256",
-        "axolotlsay-x86_64-unknown-linux-musl.tar.xz",
-        "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256"
+        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256"
       ],
       "hosting": {
-        "github": {
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1"
+        "axodotdev": {
+          "package": "axolotlsay",
+          "public_id": "fake-id-do-not-upload",
+          "set_download_url": "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload",
+          "upload_url": null,
+          "release_url": null,
+          "announce_url": null
         }
       }
     }
   ],
   "artifacts": {
-    "axolotlsay-aarch64-unknown-linux-gnu.tar.xz": {
-      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz",
+    "axolotlsay-aarch64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz",
       "kind": "executable-zip",
       "target_triples": [
-        "aarch64-unknown-linux-gnu"
+        "aarch64-apple-darwin"
       ],
       "assets": [
         {
@@ -71,20 +75,20 @@ expression: self.payload
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256"
+      "checksum": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256"
     },
-    "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256": {
-      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256",
+    "axolotlsay-aarch64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "aarch64-unknown-linux-gnu"
+        "aarch64-apple-darwin"
       ]
     },
-    "axolotlsay-aarch64-unknown-linux-musl.tar.xz": {
-      "name": "axolotlsay-aarch64-unknown-linux-musl.tar.xz",
+    "axolotlsay-x86_64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz",
       "kind": "executable-zip",
       "target_triples": [
-        "aarch64-unknown-linux-musl"
+        "x86_64-apple-darwin"
       ],
       "assets": [
         {
@@ -113,13 +117,55 @@ expression: self.payload
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256"
+      "checksum": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256"
     },
-    "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256": {
-      "name": "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256",
+    "axolotlsay-x86_64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "aarch64-unknown-linux-musl"
+        "x86_64-apple-darwin"
+      ]
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "name": "axolotlsay",
+          "path": "axolotlsay.exe",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256"
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip.sha256": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
       ]
     },
     "axolotlsay-x86_64-unknown-linux-gnu.tar.xz": {
@@ -164,48 +210,6 @@ expression: self.payload
         "x86_64-unknown-linux-gnu"
       ]
     },
-    "axolotlsay-x86_64-unknown-linux-musl.tar.xz": {
-      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.xz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "x86_64-unknown-linux-musl"
-      ],
-      "assets": [
-        {
-          "name": "CHANGELOG.md",
-          "path": "CHANGELOG.md",
-          "kind": "changelog"
-        },
-        {
-          "name": "LICENSE-APACHE",
-          "path": "LICENSE-APACHE",
-          "kind": "license"
-        },
-        {
-          "name": "LICENSE-MIT",
-          "path": "LICENSE-MIT",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "name": "axolotlsay",
-          "path": "axolotlsay",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256"
-    },
-    "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256": {
-      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "x86_64-unknown-linux-musl"
-      ]
-    },
     "source.tar.gz": {
       "name": "source.tar.gz",
       "kind": "source-tarball",
@@ -223,37 +227,35 @@ expression: self.payload
         "include": [
           {
             "targets": [
-              "aarch64-unknown-linux-gnu"
+              "aarch64-apple-darwin"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu"
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
             "targets": [
-              "aarch64-unknown-linux-musl"
+              "x86_64-apple-darwin"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
+          },
+          {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
+            "runner": "windows-2019",
+            "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
             "targets": [
               "x86_64-unknown-linux-gnu"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204",
+            "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
-          },
-          {
-            "targets": [
-              "x86_64-unknown-linux-musl"
-            ],
-            "runner": "buildjet-8vcpu-ubuntu-2204",
-            "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
           }
         ]
       },
@@ -272,17 +274,14 @@ expression: self.payload
 # * checks for a Git Tag that looks like a release
 # * builds artifacts with cargo-dist (archives, installers, hashes)
 # * uploads those artifacts to temporary workflow zip
-# * on success, uploads the artifacts to a Github Release
-#
-# Note that the Github Release will be created with a generated
-# title/body based on your changelogs.
+# * on success, uploads the artifacts to Axo Releases and makes an Announcement
 
 name: Release
 
 permissions:
   contents: write
 
-# This task will run whenever you push a git tag that looks like a version
+# This task will run whenever you workflow_dispatch with a tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
 # Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
@@ -304,9 +303,13 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  push:
-    tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release Tag
+        required: true
+        default: dry-run
+        type: string
   pull_request:
 
 jobs:
@@ -315,11 +318,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
-      publishing: ${{ !github.event.pull_request }}
+      tag: ${{ (inputs.tag != 'dry-run' && inputs.tag) || '' }}
+      tag-flag: ${{ inputs.tag && inputs.tag != 'dry-run' && format('--tag={0}', inputs.tag) || '' }}
+      publishing: ${{ inputs.tag && inputs.tag != 'dry-run' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -336,7 +340,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag)) || (env.AXO_RELEASES_TOKEN && 'host --steps=check') || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -352,7 +356,7 @@ jobs:
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan
-    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
+    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') || inputs.tag == 'dry-run' }}
     strategy:
       fail-fast: false
       # Target platforms/runners are computed by cargo-dist in create-release.
@@ -452,7 +456,16 @@ jobs:
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
-  # Determines if we should publish/announce
+  # Uploads the artifacts to Axo Releases and tentatively creates Releases for them.
+  # This makes perma URLs like /v1.0.0/ live for subsequent publish steps to use, but
+  # leaves them "disconnected" from the release history (for the purposes of
+  # "list the releases" or "give me the latest releases").
+  #
+  # If all the subsequent "publish" steps succeed, the "announce" job will "connect"
+  # the releases and concepts like "latest" will be updated. Otherwise you're hopefully
+  # in a decent position to roll back the release without anyone noticing it!
+  # This is imperfect with things like "publish to crates.io" being irreversible, but
+  # at worst you're in a better position to yank the version with minimum disruption.
   host:
     needs:
       - plan
@@ -462,6 +475,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     runs-on: "ubuntu-20.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
@@ -477,7 +491,7 @@ jobs:
         with:
           name: artifacts
           path: target/distrib/
-      # This is a harmless no-op for Github Releases, hosting for that happens in "announce"
+      # Upload files to Axo Releases and create the Releases
       - id: host
         shell: bash
         run: |
@@ -491,7 +505,7 @@ jobs:
           name: artifacts
           path: dist-manifest.json
 
-  # Create a Github Release while uploading all files to it
+  # Create an Announcement for all the Axo Releases, updating the "latest" release
   announce:
     needs:
       - plan
@@ -503,26 +517,20 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: "Download Github Artifacts"
+      - name: Install cargo-dist
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+      - name: Fetch Axo Artifacts
         uses: actions/download-artifact@v3
         with:
           name: artifacts
-          path: artifacts
-      - name: Cleanup
+          path: target/distrib/
+      - name: Announce Axo Releases
         run: |
-          # Remove the granular manifests
-          rm -f artifacts/*-dist-manifest.json
-      - name: Create Github Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ needs.plan.outputs.tag }}
-          name: ${{ fromJson(needs.host.outputs.val).announcement_title }}
-          body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
-          prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
-          artifacts: "artifacts/*"
+          cargo dist host --steps=announce ${{ needs.plan.outputs.tag-flag }}
 
 

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2380,7 +2380,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2033,7 +2033,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1979,7 +1979,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -2380,7 +2380,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -10,7 +10,7 @@ expression: self.payload
   "announcement_is_prerelease": false,
   "announcement_title": "Version 0.2.1",
   "announcement_changelog": "```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```",
-  "announcement_github_body": "## Release Notes\n\n```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Download axolotlsay 0.2.1\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-gnu.tar.xz) | ARM64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n| [axolotlsay-aarch64-unknown-linux-musl.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-musl.tar.xz) | ARM64 MUSL Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-musl.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-musl.tar.xz) | x64 MUSL Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256) |\n\n",
+  "announcement_github_body": "## Release Notes\n\n```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Download axolotlsay 0.2.1\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-apple-darwin.tar.xz) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-apple-darwin.tar.xz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.zip](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-pc-windows-msvc.zip) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-pc-windows-msvc.zip.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n\n",
   "system_info": {
     "cargo_version_line": "CENSORED"
   },
@@ -21,14 +21,14 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
-        "axolotlsay-aarch64-unknown-linux-gnu.tar.xz",
-        "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256",
-        "axolotlsay-aarch64-unknown-linux-musl.tar.xz",
-        "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256",
+        "axolotlsay-aarch64-apple-darwin.tar.xz",
+        "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-apple-darwin.tar.xz",
+        "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-pc-windows-msvc.zip",
+        "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
         "axolotlsay-x86_64-unknown-linux-gnu.tar.xz",
-        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256",
-        "axolotlsay-x86_64-unknown-linux-musl.tar.xz",
-        "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256"
+        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256"
       ],
       "hosting": {
         "github": {
@@ -38,11 +38,11 @@ expression: self.payload
     }
   ],
   "artifacts": {
-    "axolotlsay-aarch64-unknown-linux-gnu.tar.xz": {
-      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz",
+    "axolotlsay-aarch64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz",
       "kind": "executable-zip",
       "target_triples": [
-        "aarch64-unknown-linux-gnu"
+        "aarch64-apple-darwin"
       ],
       "assets": [
         {
@@ -71,20 +71,20 @@ expression: self.payload
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256"
+      "checksum": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256"
     },
-    "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256": {
-      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256",
+    "axolotlsay-aarch64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "aarch64-unknown-linux-gnu"
+        "aarch64-apple-darwin"
       ]
     },
-    "axolotlsay-aarch64-unknown-linux-musl.tar.xz": {
-      "name": "axolotlsay-aarch64-unknown-linux-musl.tar.xz",
+    "axolotlsay-x86_64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz",
       "kind": "executable-zip",
       "target_triples": [
-        "aarch64-unknown-linux-musl"
+        "x86_64-apple-darwin"
       ],
       "assets": [
         {
@@ -113,13 +113,55 @@ expression: self.payload
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256"
+      "checksum": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256"
     },
-    "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256": {
-      "name": "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256",
+    "axolotlsay-x86_64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "aarch64-unknown-linux-musl"
+        "x86_64-apple-darwin"
+      ]
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "name": "axolotlsay",
+          "path": "axolotlsay.exe",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256"
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip.sha256": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
       ]
     },
     "axolotlsay-x86_64-unknown-linux-gnu.tar.xz": {
@@ -164,48 +206,6 @@ expression: self.payload
         "x86_64-unknown-linux-gnu"
       ]
     },
-    "axolotlsay-x86_64-unknown-linux-musl.tar.xz": {
-      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.xz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "x86_64-unknown-linux-musl"
-      ],
-      "assets": [
-        {
-          "name": "CHANGELOG.md",
-          "path": "CHANGELOG.md",
-          "kind": "changelog"
-        },
-        {
-          "name": "LICENSE-APACHE",
-          "path": "LICENSE-APACHE",
-          "kind": "license"
-        },
-        {
-          "name": "LICENSE-MIT",
-          "path": "LICENSE-MIT",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "name": "axolotlsay",
-          "path": "axolotlsay",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256"
-    },
-    "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256": {
-      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "x86_64-unknown-linux-musl"
-      ]
-    },
     "source.tar.gz": {
       "name": "source.tar.gz",
       "kind": "source-tarball",
@@ -223,37 +223,35 @@ expression: self.payload
         "include": [
           {
             "targets": [
-              "aarch64-unknown-linux-gnu"
+              "aarch64-apple-darwin"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu"
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
             "targets": [
-              "aarch64-unknown-linux-musl"
+              "x86_64-apple-darwin"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
+          },
+          {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
+            "runner": "windows-2019",
+            "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
             "targets": [
               "x86_64-unknown-linux-gnu"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204",
+            "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
-          },
-          {
-            "targets": [
-              "x86_64-unknown-linux-musl"
-            ],
-            "runner": "buildjet-8vcpu-ubuntu-2204",
-            "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
           }
         ]
       },
@@ -346,77 +344,10 @@ jobs:
           name: artifacts
           path: dist-manifest.json
 
-  # Build and packages all the platform-specific things
-  build-local-artifacts:
-    name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
-    # Let the initial task tell us to not run (currently very blunt)
-    needs:
-      - plan
-    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
-    strategy:
-      fail-fast: false
-      # Target platforms/runners are computed by cargo-dist in create-release.
-      # Each member of the matrix has the following arguments:
-      #
-      # - runner: the github runner
-      # - dist-args: cli flags to pass to cargo dist
-      # - install-dist: expression to run to install cargo-dist on the runner
-      #
-      # Typically there will be:
-      # - 1 "global" task that builds universal installers
-      # - N "local" tasks that build each platform's binaries and platform-specific installers
-      matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
-    runs-on: ${{ matrix.runner }}
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: swatinem/rust-cache@v2
-      - name: Install cargo-dist
-        run: ${{ matrix.install_dist }}
-      # Get the dist-manifest
-      - name: Fetch local artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifacts
-          path: target/distrib/
-      - name: Install dependencies
-        run: |
-          ${{ matrix.packages_install }}
-      - name: Build artifacts
-        run: |
-          # Actually do builds and make zips and whatnot
-          cargo dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
-          echo "cargo dist ran successfully"
-      - id: cargo-dist
-        name: Post-build
-        # We force bash here just because github makes it really hard to get values up
-        # to "real" actions without writing to env-vars, and writing to env-vars has
-        # inconsistent syntax between shell and powershell.
-        shell: bash
-        run: |
-          # Parse out what we just built and upload it to scratch storage
-          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-
-          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
-      - name: "Upload artifacts"
-        uses: actions/upload-artifact@v3
-        with:
-          name: artifacts
-          path: |
-            ${{ steps.cargo-dist.outputs.paths }}
-            ${{ env.BUILD_MANIFEST_NAME }}
-
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:
     needs:
       - plan
-      - build-local-artifacts
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -456,10 +387,9 @@ jobs:
   host:
     needs:
       - plan
-      - build-local-artifacts
       - build-global-artifacts
     # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-20.04"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -10,7 +10,7 @@ expression: self.payload
   "announcement_is_prerelease": false,
   "announcement_title": "Version 0.2.1",
   "announcement_changelog": "```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```",
-  "announcement_github_body": "## Release Notes\n\n```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Download axolotlsay 0.2.1\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-gnu.tar.xz) | ARM64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n| [axolotlsay-aarch64-unknown-linux-musl.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-musl.tar.xz) | ARM64 MUSL Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-musl.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-musl.tar.xz) | x64 MUSL Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256) |\n\n",
+  "announcement_github_body": "## Release Notes\n\n```text\n         +--------------------------------------+\n         | now with linux static musl binary!!! |\n         +--------------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Download axolotlsay 0.2.1\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-apple-darwin.tar.xz) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-aarch64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-apple-darwin.tar.xz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.zip](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-pc-windows-msvc.zip) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-pc-windows-msvc.zip.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.1/axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n\n",
   "system_info": {
     "cargo_version_line": "CENSORED"
   },
@@ -21,14 +21,14 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
-        "axolotlsay-aarch64-unknown-linux-gnu.tar.xz",
-        "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256",
-        "axolotlsay-aarch64-unknown-linux-musl.tar.xz",
-        "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256",
+        "axolotlsay-aarch64-apple-darwin.tar.xz",
+        "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-apple-darwin.tar.xz",
+        "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-pc-windows-msvc.zip",
+        "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
         "axolotlsay-x86_64-unknown-linux-gnu.tar.xz",
-        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256",
-        "axolotlsay-x86_64-unknown-linux-musl.tar.xz",
-        "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256"
+        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256"
       ],
       "hosting": {
         "github": {
@@ -38,11 +38,11 @@ expression: self.payload
     }
   ],
   "artifacts": {
-    "axolotlsay-aarch64-unknown-linux-gnu.tar.xz": {
-      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz",
+    "axolotlsay-aarch64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz",
       "kind": "executable-zip",
       "target_triples": [
-        "aarch64-unknown-linux-gnu"
+        "aarch64-apple-darwin"
       ],
       "assets": [
         {
@@ -71,20 +71,20 @@ expression: self.payload
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256"
+      "checksum": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256"
     },
-    "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256": {
-      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256",
+    "axolotlsay-aarch64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "aarch64-unknown-linux-gnu"
+        "aarch64-apple-darwin"
       ]
     },
-    "axolotlsay-aarch64-unknown-linux-musl.tar.xz": {
-      "name": "axolotlsay-aarch64-unknown-linux-musl.tar.xz",
+    "axolotlsay-x86_64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz",
       "kind": "executable-zip",
       "target_triples": [
-        "aarch64-unknown-linux-musl"
+        "x86_64-apple-darwin"
       ],
       "assets": [
         {
@@ -113,13 +113,55 @@ expression: self.payload
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256"
+      "checksum": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256"
     },
-    "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256": {
-      "name": "axolotlsay-aarch64-unknown-linux-musl.tar.xz.sha256",
+    "axolotlsay-x86_64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "aarch64-unknown-linux-musl"
+        "x86_64-apple-darwin"
+      ]
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "name": "axolotlsay",
+          "path": "axolotlsay.exe",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256"
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip.sha256": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
       ]
     },
     "axolotlsay-x86_64-unknown-linux-gnu.tar.xz": {
@@ -164,48 +206,6 @@ expression: self.payload
         "x86_64-unknown-linux-gnu"
       ]
     },
-    "axolotlsay-x86_64-unknown-linux-musl.tar.xz": {
-      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.xz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "x86_64-unknown-linux-musl"
-      ],
-      "assets": [
-        {
-          "name": "CHANGELOG.md",
-          "path": "CHANGELOG.md",
-          "kind": "changelog"
-        },
-        {
-          "name": "LICENSE-APACHE",
-          "path": "LICENSE-APACHE",
-          "kind": "license"
-        },
-        {
-          "name": "LICENSE-MIT",
-          "path": "LICENSE-MIT",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "name": "axolotlsay",
-          "path": "axolotlsay",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256"
-    },
-    "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256": {
-      "name": "axolotlsay-x86_64-unknown-linux-musl.tar.xz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "x86_64-unknown-linux-musl"
-      ]
-    },
     "source.tar.gz": {
       "name": "source.tar.gz",
       "kind": "source-tarball",
@@ -223,37 +223,35 @@ expression: self.payload
         "include": [
           {
             "targets": [
-              "aarch64-unknown-linux-gnu"
+              "aarch64-apple-darwin"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu"
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },
           {
             "targets": [
-              "aarch64-unknown-linux-musl"
+              "x86_64-apple-darwin"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "runner": "macos-11",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin"
+          },
+          {
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
+            "runner": "windows-2019",
+            "install_dist": "irm  https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex",
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc"
           },
           {
             "targets": [
               "x86_64-unknown-linux-gnu"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204",
+            "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu"
-          },
-          {
-            "targets": [
-              "x86_64-unknown-linux-musl"
-            ],
-            "runner": "buildjet-8vcpu-ubuntu-2204",
-            "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
           }
         ]
       },
@@ -346,77 +344,20 @@ jobs:
           name: artifacts
           path: dist-manifest.json
 
-  # Build and packages all the platform-specific things
-  build-local-artifacts:
-    name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
-    # Let the initial task tell us to not run (currently very blunt)
+  custom-local-artifacts:
     needs:
       - plan
-    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
-    strategy:
-      fail-fast: false
-      # Target platforms/runners are computed by cargo-dist in create-release.
-      # Each member of the matrix has the following arguments:
-      #
-      # - runner: the github runner
-      # - dist-args: cli flags to pass to cargo dist
-      # - install-dist: expression to run to install cargo-dist on the runner
-      #
-      # Typically there will be:
-      # - 1 "global" task that builds universal installers
-      # - N "local" tasks that build each platform's binaries and platform-specific installers
-      matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
-    runs-on: ${{ matrix.runner }}
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: swatinem/rust-cache@v2
-      - name: Install cargo-dist
-        run: ${{ matrix.install_dist }}
-      # Get the dist-manifest
-      - name: Fetch local artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: artifacts
-          path: target/distrib/
-      - name: Install dependencies
-        run: |
-          ${{ matrix.packages_install }}
-      - name: Build artifacts
-        run: |
-          # Actually do builds and make zips and whatnot
-          cargo dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
-          echo "cargo dist ran successfully"
-      - id: cargo-dist
-        name: Post-build
-        # We force bash here just because github makes it really hard to get values up
-        # to "real" actions without writing to env-vars, and writing to env-vars has
-        # inconsistent syntax between shell and powershell.
-        shell: bash
-        run: |
-          # Parse out what we just built and upload it to scratch storage
-          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-
-          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
-      - name: "Upload artifacts"
-        uses: actions/upload-artifact@v3
-        with:
-          name: artifacts
-          path: |
-            ${{ steps.cargo-dist.outputs.paths }}
-            ${{ env.BUILD_MANIFEST_NAME }}
+    if: ${{ needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' }}
+    uses: ./.github/workflows/local-artifacts.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
 
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:
     needs:
       - plan
-      - build-local-artifacts
+      - custom-local-artifacts
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -456,10 +397,9 @@ jobs:
   host:
     needs:
       - plan
-      - build-local-artifacts
       - build-global-artifacts
     # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-20.04"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1450,7 +1450,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1450,7 +1450,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -2380,7 +2380,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -2380,7 +2380,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -2380,7 +2380,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -2380,7 +2380,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -2380,7 +2380,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ !github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name) || (github.event.pull_request.head.repo.fork && 'plan' || 'host --steps=check') }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
           echo "cargo dist ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
We were using 'is from a fork' as a proxy for 'should have the secret' but evidently dependabot can make branches on your repo and trigger PR CI that doesn't have secrets. This regresses our ability to do validation that you've set things up right but it's more reliable.