### PR TITLE
feat(lies): add --artifacts=lies

### DIFF
--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -218,6 +218,8 @@ pub enum ArtifactMode {
     Host,
     /// Build all the artifacts; useful for `cargo dist manifest`
     All,
+    /// Fake all the artifacts; useful for testing/mocking/staging
+    Lies,
 }
 
 impl ArtifactMode {
@@ -228,6 +230,7 @@ impl ArtifactMode {
             ArtifactMode::Global => cargo_dist::config::ArtifactMode::Global,
             ArtifactMode::Host => cargo_dist::config::ArtifactMode::Host,
             ArtifactMode::All => cargo_dist::config::ArtifactMode::All,
+            ArtifactMode::Lies => cargo_dist::config::ArtifactMode::Lies,
         }
     }
 }

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -584,7 +584,7 @@ pub struct Config {
 }
 
 /// How we should select the artifacts to build
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ArtifactMode {
     /// Build target-specific artifacts like archives, symbols, msi installers
     Local,
@@ -594,6 +594,8 @@ pub enum ArtifactMode {
     Host,
     /// Build all the artifacts; only really appropriate for `cargo-dist manifest`
     All,
+    /// Fake all the artifacts; useful for testing/mocking/staging
+    Lies,
 }
 
 /// The style of CI we should generate

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -215,6 +215,8 @@ pub struct DistGraph {
     pub extra_artifacts: Vec<ExtraArtifact>,
     /// Custom GitHub runners, mapped by triple target
     pub github_custom_runners: HashMap<String, String>,
+    /// LIES ALL LIES
+    pub local_builds_are_lies: bool,
 }
 
 /// Info about artifacts should be hosted
@@ -780,6 +782,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let build_local_artifacts = build_local_artifacts.unwrap_or(true);
         let dispatch_releases = dispatch_releases.unwrap_or(false);
         let msvc_crt_static = msvc_crt_static.unwrap_or(true);
+        let local_builds_are_lies = artifact_mode == ArtifactMode::Lies;
         let ssldotcom_windows_sign = ssldotcom_windows_sign.clone();
 
         let mut packages_with_mismatched_features = vec![];
@@ -941,6 +944,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 desired_cargo_dist_version,
                 desired_rust_toolchain,
                 tools,
+                local_builds_are_lies,
                 templates,
                 ci_style: vec![],
                 local_build_steps: vec![],
@@ -2567,6 +2571,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             ArtifactMode::Global => false,
             ArtifactMode::Host => true,
             ArtifactMode::All => true,
+            ArtifactMode::Lies => true,
         }
     }
     pub(crate) fn global_artifacts_enabled(&self) -> bool {
@@ -2575,6 +2580,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             ArtifactMode::Global => true,
             ArtifactMode::Host => true,
             ArtifactMode::All => true,
+            ArtifactMode::Lies => true,
         }
     }
 }

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1260,7 +1260,10 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             .stderr(std::process::Stdio::piped())
             .check(false)
             .status();
-        let is_git_repo = if let Ok(status) = status {
+        // We'll be stubbing the actual generation in this case
+        let is_git_repo = if self.inner.local_builds_are_lies {
+            true
+        } else if let Ok(status) = status {
             status.success()
         } else {
             false
@@ -1273,7 +1276,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             .stderr(std::process::Stdio::piped())
             .check(false)
             .status();
-        let has_head = if let Ok(status) = status {
+        let has_head = if self.inner.local_builds_are_lies {
+            true
+        } else if let Ok(status) = status {
             status.success()
         } else {
             false

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -82,7 +82,7 @@ fn test_manifest() {
     let output = Command::new(BIN)
         .arg("dist")
         .arg("manifest")
-        .arg("--artifacts=all")
+        .arg("--artifacts=lies")
         .arg("--no-local-paths")
         .arg("--allow-dirty")
         .arg("--output-format=json")

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -123,6 +123,7 @@ Possible values:
 - global: Build unique artifacts like curl-sh installers and npm packages
 - host:   Fuzzily build "as much as possible" for the host system
 - all:    Build all the artifacts; useful for `cargo dist manifest`
+- lies:   Fake all the artifacts; useful for testing/mocking/staging
 
 #### `-p, --print <PRINT>`
 What extra information to print, if anything. Currently supported:
@@ -265,6 +266,7 @@ Possible values:
 - global: Build unique artifacts like curl-sh installers and npm packages
 - host:   Fuzzily build "as much as possible" for the host system
 - all:    Build all the artifacts; useful for `cargo dist manifest`
+- lies:   Fake all the artifacts; useful for testing/mocking/staging
 
 #### `-p, --print <PRINT>`
 What extra information to print, if anything. Currently supported:


### PR DESCRIPTION
`--artifacts=lies` is equivalent to `--artifacts=all` except instead of being "something doomed to fail with `cargo dist build`" it just lies through its teeth and fakes the builds to generate all the files needed to upload.

This would let us have a staging upload workflow you can run on anyone's machine:

```
STAGE_INTO_THE_ABYSS=1
AXO_RELEASES_STAGING_TOKEN="...."
cargo dist host --steps=create
cargo dist build --artifacts=lies
cargo dist host --steps=upload --steps=release --steps=announce
```