### PR TITLE
feat(github): introduce Apple Silicon runner

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -264,8 +264,10 @@ fn distribute_targets_to_runners_split<'a>(
 type GithubRunner = String;
 /// The Github Runner to use for Linux
 const GITHUB_LINUX_RUNNER: &str = "ubuntu-20.04";
-/// The Github Runner to use for macos
-const GITHUB_MACOS_RUNNER: &str = "macos-11";
+/// The Github Runner to use for Intel macos
+const GITHUB_MACOS_INTEL_RUNNER: &str = "macos-11";
+/// The Github Runner to use for Apple Silicon macos
+const GITHUB_MACOS_ARM64_RUNNER: &str = "macos-14";
 /// The Github Runner to use for windows
 const GITHUB_WINDOWS_RUNNER: &str = "windows-2019";
 
@@ -283,8 +285,10 @@ fn github_runner_for_target(
     // recent. This helps with portability!
     if target.contains("linux") {
         Some(GITHUB_LINUX_RUNNER.to_owned())
-    } else if target.contains("apple") {
-        Some(GITHUB_MACOS_RUNNER.to_owned())
+    } else if target.contains("x86_64-apple") {
+        Some(GITHUB_MACOS_INTEL_RUNNER.to_owned())
+    } else if target.contains("aarch64-apple") {
+        Some(GITHUB_MACOS_ARM64_RUNNER.to_owned())
     } else if target.contains("windows") {
         Some(GITHUB_WINDOWS_RUNNER.to_owned())
     } else {

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1372,7 +1372,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1020,7 +1020,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -1372,7 +1372,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -2304,7 +2304,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -2300,7 +2300,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2296,7 +2296,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -225,7 +225,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -233,7 +233,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -229,7 +229,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2271,7 +2271,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1923,7 +1923,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1877,7 +1877,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -2271,7 +2271,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -225,7 +225,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -225,7 +225,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1341,7 +1341,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1341,7 +1341,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -2271,7 +2271,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -2271,7 +2271,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -2271,7 +2271,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -2271,7 +2271,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -2271,7 +2271,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1374,7 +1374,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1354,7 +1354,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1354,7 +1354,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1354,7 +1354,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1354,7 +1354,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1354,7 +1354,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1354,7 +1354,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1354,7 +1354,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1354,7 +1354,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -402,7 +402,7 @@ stdout:
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-11",
+            "runner": "macos-14",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },


### PR DESCRIPTION
The new macOS 14 runner runs specifically on Apple Silicon, while the macos-11 through macos-13 runners are Intel only.

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/