### PR TITLE
feat(github): swap back to macos-12 for arm64

### DIFF
--- a/book/src/ci/customizing.md
+++ b/book/src/ci/customizing.md
@@ -87,7 +87,7 @@ By default, cargo-dist uses the following runners:
 
 * Linux (x86_64): `ubuntu-20.04`
 * macOS (x86_64): `macos-12`
-* macOS (Apple Silicon): `macos-14`
+* macOS (Apple Silicon): `macos-12`
 * Windows (x86_64): `windows-2019`
 
 It's possible to configure alternate runners for these jobs, or runners for targets not natively supported by GitHub actions. To do this, use the [`github-custom-runners`](config-github-custom-runners) configuration setting in `Cargo.toml`. Here's an example which adds support for Linux (aarch64) using runners from [Buildjet](https://buildjet.com/for-github-actions):
@@ -98,7 +98,12 @@ aarch64-unknown-linux-gnu = "buildjet-8vcpu-ubuntu-2204-arm"
 aarch64-unknown-linux-musl = "buildjet-8vcpu-ubuntu-2204-arm"
 ```
 
-In addition to adding support for new targets, some users may find it useful to use this feature to fine-tune their builds for supported targets. For example, some projects may wish to build on a newer Ubuntu runner or alternate Linux distros, or may wish to opt into cross-compiling for Apple Silicon from an Intel-based runner.
+In addition to adding support for new targets, some users may find it useful to use this feature to fine-tune their builds for supported targets. For example, some projects may wish to build on a newer Ubuntu runner or alternate Linux distros, or may wish to opt into building for Apple Silicon from a native runner by using the `macos-14` runner. Here's an example which uses `macos-14` for native Apple Silicon builds:
+
+```toml
+[workspace.metadata.dist.github-custom-runners]
+aarch64-apple-darwin = "macos-14"
+```
 
 [config-dependencies]: ../reference/config.md#dependencies
 [config-plan]: ../reference/config.md#plan-jobs

--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -267,7 +267,7 @@ const GITHUB_LINUX_RUNNER: &str = "ubuntu-20.04";
 /// The Github Runner to use for Intel macos
 const GITHUB_MACOS_INTEL_RUNNER: &str = "macos-12";
 /// The Github Runner to use for Apple Silicon macos
-const GITHUB_MACOS_ARM64_RUNNER: &str = "macos-14";
+const GITHUB_MACOS_ARM64_RUNNER: &str = "macos-12";
 /// The Github Runner to use for windows
 const GITHUB_WINDOWS_RUNNER: &str = "windows-2019";
 

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1418,7 +1418,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1048,7 +1048,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -1418,7 +1418,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -2350,7 +2350,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -2346,7 +2346,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2342,7 +2342,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -225,7 +225,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -233,7 +233,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -229,7 +229,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2317,7 +2317,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1951,7 +1951,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1905,7 +1905,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -2317,7 +2317,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -225,7 +225,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -225,7 +225,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1387,7 +1387,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1387,7 +1387,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -2317,7 +2317,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -2317,7 +2317,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -2317,7 +2317,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -2317,7 +2317,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -2317,7 +2317,7 @@ maybeInstall(true).then(run);
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1420,7 +1420,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1391,7 +1391,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1391,7 +1391,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1391,7 +1391,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1391,7 +1391,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1391,7 +1391,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1391,7 +1391,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1391,7 +1391,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1391,7 +1391,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -402,7 +402,7 @@ stdout:
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-14",
+            "runner": "macos-12",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin"
           },


### PR DESCRIPTION
For consistency with Intel and older OS support, this may be a better choice for the time being. We'll reconsider this in the future. In the meantime, provide some more information in the docs about how to opt into macos-14.