### PR TITLE
ci: test on macos-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       # Test the cross-product of these platforms+toolchains
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
         rust: [stable]
     steps:
       # Setup tools


### PR DESCRIPTION
This should be much faster than `macos-latest`, which is currently `macos-12`.