### PR TITLE
release: 0.9.0-prerelease.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.9.0-prerelease.2"
+version = "0.9.0-prerelease.3"
 dependencies = [
  "axoasset",
  "axocli",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.9.0-prerelease.2"
+version = "0.9.0-prerelease.3"
 dependencies = [
  "camino",
  "gazenot",

--- a/cargo-dist-schema/Cargo.toml
+++ b/cargo-dist-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-dist-schema"
 description = "Schema information for cargo-dist's dist-manifest.json"
-version = "0.9.0-prerelease.2"
+version = "0.9.0-prerelease.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-dist"
 description = "Shippable application packaging for Rust"
-version = "0.9.0-prerelease.2"
+version = "0.9.0-prerelease.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
@@ -34,7 +34,7 @@ axocli = { version = "0.1.1", optional = true }
 
 # Features used by the cli and library
 axotag = "0.1.0"
-cargo-dist-schema = { version = "=0.9.0-prerelease.2", path = "../cargo-dist-schema" }
+cargo-dist-schema = { version = "=0.9.0-prerelease.3", path = "../cargo-dist-schema" }
 
 axoasset = { version = "0.6.1", features = ["json-serde", "toml-serde", "toml-edit", "compression"] }
 axoprocess = { version = "0.1.0" }


### PR DESCRIPTION
Cutting a new prerelease following the latest batch of default runner changes to ensure our own release is made using these and not the prior choice.