### PR TITLE
wip: platform refactor

### DIFF
--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -6,8 +6,8 @@ use camino::Utf8PathBuf;
 use serde::Serialize;
 
 use crate::{
-    config::{JinjaInstallPathStrategy, ZipStyle},
-    TargetTriple,
+    config::ZipStyle,
+    TargetTriple, ReleaseIdx,
 };
 
 use self::homebrew::HomebrewInstallerInfo;
@@ -41,20 +41,15 @@ pub enum InstallerImpl {
 pub struct InstallerInfo {
     /// The path to generate the installer at
     pub dest_path: Utf8PathBuf,
-    /// App name to use (display only)
-    pub app_name: String,
-    /// App version to use (display only)
-    pub app_version: String,
     /// URL of the directory where artifacts can be fetched from
     pub base_url: String,
-    /// Artifacts this installer can fetch
-    pub artifacts: Vec<ExecutableZipFragment>,
     /// Description of the installer (a good heading)
     pub desc: String,
     /// Hint for how to run the installer
     pub hint: String,
-    /// Where to install binaries
-    pub install_path: JinjaInstallPathStrategy,
+    /// The release this is installing
+    #[serde(skip)]
+    pub release: ReleaseIdx,
 }
 
 /// A fake fragment of an ExecutableZip artifact for installers

--- a/cargo-dist/src/backend/installer/shell.rs
+++ b/cargo-dist/src/backend/installer/shell.rs
@@ -13,6 +13,7 @@ pub(crate) fn write_install_sh_script(
     templates: &Templates,
     info: &InstallerInfo,
 ) -> DistResult<()> {
+
     let script = templates.render_file_to_clean_string(TEMPLATE_INSTALLER_SH, info)?;
     LocalAsset::write_new(&script, &info.dest_path)?;
     Ok(())

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -45,6 +45,7 @@ pub mod host;
 mod init;
 pub mod linkage;
 pub mod manifest;
+pub mod platform;
 pub mod tasks;
 #[cfg(test)]
 mod tests;

--- a/cargo-dist/src/platform.rs
+++ b/cargo-dist/src/platform.rs
@@ -1,172 +1,261 @@
 #![allow(missing_docs)]
 
+use axoproject::platforms::{
+    TARGET_ARM64_MAC, TARGET_ARM64_WINDOWS, TARGET_X64_MAC, TARGET_X64_WINDOWS, TARGET_X86_MAC,
+    TARGET_X86_WINDOWS,
+};
 use cargo_dist_schema::ArtifactId;
 
-use crate::{ArtifactIdx, TargetTriple, SortedMap, DistGraph, Release, DistGraphBuilder, ReleaseIdx, backend::installer::ExecutableZipFragment};
+use crate::{config::ZipStyle, DistGraphBuilder, ReleaseIdx, SortedMap, TargetTriple};
 
-const X64_MUSL_STATIC: &str = "x86_64-unknown-linux-musl-static";
-const X64_MUSL_DYNAMIC: &str = "x86_64-unknown-linux-musl-dynamic";
+/// Suffixes of TargetTriples that refer to statically linked linux libcs.
+///
+/// On Linux it's preferred to dynamically link libc *but* because the One True ABI
+/// is actually the Linux kernel syscall interface, you *can* theoretically statically
+/// link libc. This comes with various tradeoffs but the big selling point is that the
+/// Linux kernel is a much more slowly moving target, so you can build a binary
+/// that's portable across way more systems by statically linking libc. As such,
+/// for any archive claiming to provide a static libc linux build, we can mark this
+/// archive as providing support for any linux distro (for that architecture)
+///
+/// Currently rust takes "linux-musl" to mean "statically linked musl"a
+/// in the future it will mean "dynamically linked musl":
+///
+/// https://github.com/rust-lang/compiler-team/issues/422
+///
+/// We prefer "musl-static" and "musl-dynamic" aliases to disambiguate this situation,
+/// but support bare musl with the current semantics:
+///
+/// FIXME: when rustc makes the change, move "linux-musl" from STATIC_LIBCS to REPLACEABLE_LIBCS!
+/// (this may involve detecting the current rust toolchain).
+const LINUX_STATIC_LIBCS: &[&str] = &["linux-musl-static", "linux-musl"];
+/// Dynamically linked linux libcs that static libcs can replace
+const LINUX_STATIC_REPLACEABLE_LIBCS: &[&str] = &["linux-gnu", "linux-musl-dynamic"];
+/// A fake TargetTriple for apple's universal2 format (staples x64 and arm64 together)
+const TARGET_MACOS_UNIVERSAL2: &str = "universal2-apple-darwin";
 
+/// The quality of support an archive provides for a given platform
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SupportQuality {
+    /// The archive natively supports this platform, there's no beating it
     HostNative,
+    /// The archive natively supports this platform, but it's a Universal binary that contains
+    /// multiple platforms stapled together, so if there are also more precise archives, prefer those.
+    BulkyNative,
+    /// The archive is still technically native to this platform, but it's in some sense
+    /// imperfect. This can happen for things like "running a 32-bit binary on 64-bit" or
+    /// "using a statically linked linux libc". This solution is acceptable, but a HostNative
+    /// (or BulkyNative) solution should always be preferred.
     ImperfectNative,
+    /// The archive is only running by the grace of pretty heavyweight emulation like Rosetta2.
+    /// This should be treated as a last resort, but hey, it works!
     Emulated,
+    /// The layers of emulation are out of control.
+    Hellmulated,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeCondition {
     MinGlibcVersion { major: u64, series: u64 },
-    MinMuslVersion  { major: u64, series: u64 },
+    MinMuslVersion { major: u64, series: u64 },
     Rosetta2,
 }
 
-pub struct InitialPlatformSupport {
+#[derive(Debug, Clone, Default)]
+pub struct PlatformSupport {
+    pub archives: Vec<FetchableArchive>,
     pub platforms: SortedMap<TargetTriple, Vec<PlatformEntry>>,
 }
 
+#[derive(Debug, Clone)]
 pub struct FetchableArchive {
     pub id: ArtifactId,
+    pub native_runtime_conditions: Vec<RuntimeCondition>,
+    pub target_triples: Vec<TargetTriple>,
     pub sha256sum: Option<String>,
     pub binaries: Vec<String>,
+    pub zip_style: ZipStyle,
 }
 
+pub type FetchableArchiveIdx = usize;
+
+#[derive(Debug, Clone)]
 pub struct PlatformEntry {
     pub quality: SupportQuality,
+    pub runtime_conditions: Vec<RuntimeCondition>,
+    pub archive_idx: FetchableArchiveIdx,
 }
 
-struct FinalPlatformSupport {
-    platforms: SortedMap<TargetTriple, Vec<FullPlatformEntry>>,
-}
-
-struct FullPlatformEntry {
-}
-
-impl InitialPlatformSupport {
-    fn new(dist: &DistGraphBuilder, release_idx: ReleaseIdx) -> InitialPlatformSupport {
-        let platforms = SortedMap::new();
+impl PlatformSupport {
+    pub(crate) fn new(dist: &DistGraphBuilder, release_idx: ReleaseIdx) -> PlatformSupport {
+        let mut platforms = SortedMap::<TargetTriple, Vec<PlatformEntry>>::new();
         let release = dist.release(release_idx);
+        let mut archives = vec![];
+
+        // Gather up all the fetchable archives
         for &variant_idx in &release.variants {
-            let variant = dist.variant(variant_idx);
             // Compute the artifact zip this variant *would* make *if* it were built
             // FIXME: this is a kind of hacky workaround for the fact that we don't have a good
             // way to add artifacts to the graph and then say "ok but don't build it".
-            let (artifact, binaries) = dist.make_executable_zip_for_variant(release_idx, variant_idx);
-            let archive = ExecutableZipFragment {
+            let (artifact, binaries) =
+                dist.make_executable_zip_for_variant(release_idx, variant_idx);
+            let archive = FetchableArchive {
                 id: artifact.id,
                 target_triples: artifact.target_triples,
                 binaries: binaries
-                .into_iter()
-                .map(|(_, dest_path)| dest_path.file_name().unwrap().to_owned())
-                .collect(),
+                    .into_iter()
+                    .map(|(_, dest_path)| dest_path.file_name().unwrap().to_owned())
+                    .collect(),
                 zip_style: artifact.archive.as_ref().unwrap().zip_style,
+                sha256sum: None,
+                native_runtime_conditions: vec![],
             };
+            archives.push(archive);
         }
 
-        InitialPlatformSupport {
+        // Compute what platforms each archive Really supports
+        for (archive_idx, archive) in archives.iter().enumerate() {
+            let supports = supports(archive_idx, archive);
+            for (target, support) in supports {
+                platforms.entry(target).or_default().push(support);
+            }
+        }
+
+        // Now sort the platform-support so the best options come first
+        for (_platform, support) in &mut platforms {
+            support.sort_by(|a, b| {
+                // Sort by SupportQuality, tie break by artifact name (for stability)
+                a.quality.cmp(&b.quality).then_with(|| {
+                    let archive_a = &archives[a.archive_idx];
+                    let archive_b = &archives[b.archive_idx];
+                    archive_a.id.cmp(&archive_b.id)
+                })
+            });
+        }
+
+        PlatformSupport {
+            archives,
             platforms,
         }
     }
 }
 
+fn supports(
+    archive_idx: FetchableArchiveIdx,
+    archive: &FetchableArchive,
+) -> Vec<(TargetTriple, PlatformEntry)> {
+    let mut res = Vec::new();
+    for target in &archive.target_triples {
+        // First, add the target itself as a HostNative entry
+        res.push((
+            target.clone(),
+            PlatformEntry {
+                quality: SupportQuality::HostNative,
+                runtime_conditions: archive.native_runtime_conditions.clone(),
+                archive_idx,
+            },
+        ));
 
-/*
-fn supports(platform: &str, conditions: &[RuntimeCondition]) -> Vec<&'static str, PlatformSupport> {
-    let mut res = vec![(platform, conditions.to_owned(), ];
-    if platform == X64_MUSL_STATIC {
-        res.extend([
-            (X64_MUSL_DYNAMIC, conditions.to_owned(),
-        ]);
-    } else if platform == X64_MUSL_DYNAMIC {
-        res.extend([X64_MUSL_DYNAMIC]);
+        // If this is a static linux libc, say it can support any linux at ImperfectNative quality
+        for &static_libc in LINUX_STATIC_LIBCS {
+            if let Some(system) = target.strip_suffix(static_libc) {
+                for &libc in LINUX_STATIC_REPLACEABLE_LIBCS {
+                    res.push((
+                        format!("{system}{libc}"),
+                        PlatformEntry {
+                            quality: SupportQuality::ImperfectNative,
+                            runtime_conditions: archive.native_runtime_conditions.clone(),
+                            archive_idx,
+                        },
+                    ));
+                }
+                break;
+            }
+        }
+
+        // universal2 macos binaries are totally native for both arches, but bulkier than
+        // necessary if we have builds for the individual platforms too.
+        if target == TARGET_MACOS_UNIVERSAL2 {
+            res.push((
+                TARGET_X64_MAC.to_owned(),
+                PlatformEntry {
+                    quality: SupportQuality::BulkyNative,
+                    runtime_conditions: archive.native_runtime_conditions.clone(),
+                    archive_idx,
+                },
+            ));
+            res.push((
+                TARGET_ARM64_MAC.to_owned(),
+                PlatformEntry {
+                    quality: SupportQuality::BulkyNative,
+                    runtime_conditions: archive.native_runtime_conditions.clone(),
+                    archive_idx,
+                },
+            ));
+        }
+
+        // x86_32 macos binaries ran fine on x86_64, but it's Imperfect compared to actual x86_64 binaries
+        // ...UP UNTIL macOS Catalina (macOS 10.15, October 2019)!
+        //
+        // FIXME: add some condition for "check the macos version" if we care about this!
+        if target == TARGET_X86_MAC {
+            res.push((
+                TARGET_X64_MAC.to_owned(),
+                PlatformEntry {
+                    quality: SupportQuality::ImperfectNative,
+                    runtime_conditions: archive.native_runtime_conditions.clone(),
+                    archive_idx,
+                },
+            ));
+        }
+
+        // If this is x64 macos, say it can support arm64 macos using Rosetta2
+        // Note that Rosetta2 is not *actually* installed by default on Apple Silicon,
+        // and the auto-installer for it only applies to GUI apps, not CLI apps, so ideally
+        // any installer that uses this fallback should check if Rosetta2 is installed!
+        if target == TARGET_X64_MAC {
+            let runtime_conditions = archive
+                .native_runtime_conditions
+                .iter()
+                .cloned()
+                .chain(Some(RuntimeCondition::Rosetta2))
+                .collect();
+            res.push((
+                TARGET_ARM64_MAC.to_owned(),
+                PlatformEntry {
+                    quality: SupportQuality::Emulated,
+                    runtime_conditions,
+                    archive_idx,
+                },
+            ));
+        }
+
+        // x86_32 windows binaries run fine on x86_64, but it's Imperfect compared to actual x86_64 binaries
+        if target == TARGET_X86_WINDOWS {
+            res.push((
+                TARGET_X64_WINDOWS.to_owned(),
+                PlatformEntry {
+                    quality: SupportQuality::ImperfectNative,
+                    runtime_conditions: archive.native_runtime_conditions.clone(),
+                    archive_idx,
+                },
+            ));
+        }
+
+        // Windows' equivalent to Rosetta2 (CHPE) is in fact installed-by-default so no need to detect!
+        //
+        // FIXME: ideally if both 32-bit and 64-bit binaries exist, the 64-bit should presumably be preferred?
+        // do we want a "SupportQuality::Hellmulated" for i686-on-arm64?
+        if target == TARGET_X64_WINDOWS || target == TARGET_X86_WINDOWS {
+            res.push((
+                TARGET_ARM64_WINDOWS.to_owned(),
+                PlatformEntry {
+                    quality: SupportQuality::Emulated,
+                    runtime_conditions: archive.native_runtime_conditions.clone(),
+                    archive_idx,
+                },
+            ));
+        }
     }
+    res
 }
-
-fn add_support(platform: &'static str, conditions: impl IntoIterator<RuntimeCondition>, )
-
- */
-
-/*
-
-const X64_MACOS: &str = "x86_64-apple-darwin";
-const ARM64_MACOS: &str = "aarch64-apple-darwin";
-const X64_GNU: &str = "x86_64-unknown-linux-gnu";
-const X64_MUSL: &str = "x86_64-unknown-linux-musl";
-
-let mut has_x64_apple = false;
-let mut has_arm_apple = false;
-let mut has_gnu_linux = false;
-let mut has_static_musl_linux = false;
-// Currently always false, someday this build will exist
-let has_dynamic_musl_linux = false;
-for &variant_idx in &release.variants {
-    let variant = self.variant(variant_idx);
-    let target = &variant.target;
-    if target == X64_MACOS {
-        has_x64_apple = true;
-    }
-    if target == ARM64_MACOS {
-        has_arm_apple = true;
-    }
-    if target == X64_GNU {
-        has_gnu_linux = true;
-    }
-    if target == X64_MUSL {
-        has_static_musl_linux = true;
-    }
-}
-let do_rosetta_fallback = has_x64_apple && !has_arm_apple;
-let do_gnu_to_musl_fallback = !has_gnu_linux && has_static_musl_linux;
-let do_musl_to_musl_fallback = has_static_musl_linux && !has_dynamic_musl_linux;
-
-// Gather up the bundles the installer supports
-let mut artifacts = vec![];
-let mut target_triples = SortedSet::new();
-for &variant_idx in &release.variants {
-    let variant = self.variant(variant_idx);
-    let target = &variant.target;
-    if target.contains("windows") {
-        continue;
-    }
-    // Compute the artifact zip this variant *would* make *if* it were built
-    // FIXME: this is a kind of hacky workaround for the fact that we don't have a good
-    // way to add artifacts to the graph and then say "ok but don't build it".
-    let (artifact, binaries) =
-        self.make_executable_zip_for_variant(to_release, variant_idx);
-    target_triples.insert(target.clone());
-    let mut fragment = ExecutableZipFragment {
-        id: artifact.id,
-        target_triples: artifact.target_triples,
-        zip_style: artifact.archive.as_ref().unwrap().zip_style,
-        binaries: binaries
-            .into_iter()
-            .map(|(_, dest_path)| dest_path.file_name().unwrap().to_owned())
-            .collect(),
-    };
-    if do_rosetta_fallback && target == X64_MACOS {
-        // Copy the info but respecify it to be arm64 macos
-        let mut arm_fragment = fragment.clone();
-        arm_fragment.target_triples = vec![ARM64_MACOS.to_owned()];
-        artifacts.push(arm_fragment);
-    }
-    if target == X64_MUSL {
-        // musl-static is actually kind of a fake triple we've invented
-        // to let us specify which is which; we want to ensure it exists
-        // for the installer to act on
-        fragment.target_triples = vec![X64_MUSL_STATIC.to_owned()];
-    }
-    if do_gnu_to_musl_fallback && target == X64_MUSL {
-        // Copy the info but lie that it's actually glibc
-        let mut musl_fragment = fragment.clone();
-        musl_fragment.target_triples = vec![X64_GNU.to_owned()];
-        artifacts.push(musl_fragment);
-    }
-    if do_musl_to_musl_fallback && target == X64_MUSL {
-        // Copy the info but lie that it's actually dynamic musl
-        let mut musl_fragment = fragment.clone();
-        musl_fragment.target_triples = vec![X64_MUSL_DYNAMIC.to_owned()];
-        artifacts.push(musl_fragment);
-    }
-
-    artifacts.push(fragment);
-}
-
-*/

--- a/cargo-dist/src/platform.rs
+++ b/cargo-dist/src/platform.rs
@@ -1,0 +1,172 @@
+#![allow(missing_docs)]
+
+use cargo_dist_schema::ArtifactId;
+
+use crate::{ArtifactIdx, TargetTriple, SortedMap, DistGraph, Release, DistGraphBuilder, ReleaseIdx, backend::installer::ExecutableZipFragment};
+
+const X64_MUSL_STATIC: &str = "x86_64-unknown-linux-musl-static";
+const X64_MUSL_DYNAMIC: &str = "x86_64-unknown-linux-musl-dynamic";
+
+pub enum SupportQuality {
+    HostNative,
+    ImperfectNative,
+    Emulated,
+}
+
+pub enum RuntimeCondition {
+    MinGlibcVersion { major: u64, series: u64 },
+    MinMuslVersion  { major: u64, series: u64 },
+    Rosetta2,
+}
+
+pub struct InitialPlatformSupport {
+    pub platforms: SortedMap<TargetTriple, Vec<PlatformEntry>>,
+}
+
+pub struct FetchableArchive {
+    pub id: ArtifactId,
+    pub sha256sum: Option<String>,
+    pub binaries: Vec<String>,
+}
+
+pub struct PlatformEntry {
+    pub quality: SupportQuality,
+}
+
+struct FinalPlatformSupport {
+    platforms: SortedMap<TargetTriple, Vec<FullPlatformEntry>>,
+}
+
+struct FullPlatformEntry {
+}
+
+impl InitialPlatformSupport {
+    fn new(dist: &DistGraphBuilder, release_idx: ReleaseIdx) -> InitialPlatformSupport {
+        let platforms = SortedMap::new();
+        let release = dist.release(release_idx);
+        for &variant_idx in &release.variants {
+            let variant = dist.variant(variant_idx);
+            // Compute the artifact zip this variant *would* make *if* it were built
+            // FIXME: this is a kind of hacky workaround for the fact that we don't have a good
+            // way to add artifacts to the graph and then say "ok but don't build it".
+            let (artifact, binaries) = dist.make_executable_zip_for_variant(release_idx, variant_idx);
+            let archive = ExecutableZipFragment {
+                id: artifact.id,
+                target_triples: artifact.target_triples,
+                binaries: binaries
+                .into_iter()
+                .map(|(_, dest_path)| dest_path.file_name().unwrap().to_owned())
+                .collect(),
+                zip_style: artifact.archive.as_ref().unwrap().zip_style,
+            };
+        }
+
+        InitialPlatformSupport {
+            platforms,
+        }
+    }
+}
+
+
+/*
+fn supports(platform: &str, conditions: &[RuntimeCondition]) -> Vec<&'static str, PlatformSupport> {
+    let mut res = vec![(platform, conditions.to_owned(), ];
+    if platform == X64_MUSL_STATIC {
+        res.extend([
+            (X64_MUSL_DYNAMIC, conditions.to_owned(),
+        ]);
+    } else if platform == X64_MUSL_DYNAMIC {
+        res.extend([X64_MUSL_DYNAMIC]);
+    }
+}
+
+fn add_support(platform: &'static str, conditions: impl IntoIterator<RuntimeCondition>, )
+
+ */
+
+/*
+
+const X64_MACOS: &str = "x86_64-apple-darwin";
+const ARM64_MACOS: &str = "aarch64-apple-darwin";
+const X64_GNU: &str = "x86_64-unknown-linux-gnu";
+const X64_MUSL: &str = "x86_64-unknown-linux-musl";
+
+let mut has_x64_apple = false;
+let mut has_arm_apple = false;
+let mut has_gnu_linux = false;
+let mut has_static_musl_linux = false;
+// Currently always false, someday this build will exist
+let has_dynamic_musl_linux = false;
+for &variant_idx in &release.variants {
+    let variant = self.variant(variant_idx);
+    let target = &variant.target;
+    if target == X64_MACOS {
+        has_x64_apple = true;
+    }
+    if target == ARM64_MACOS {
+        has_arm_apple = true;
+    }
+    if target == X64_GNU {
+        has_gnu_linux = true;
+    }
+    if target == X64_MUSL {
+        has_static_musl_linux = true;
+    }
+}
+let do_rosetta_fallback = has_x64_apple && !has_arm_apple;
+let do_gnu_to_musl_fallback = !has_gnu_linux && has_static_musl_linux;
+let do_musl_to_musl_fallback = has_static_musl_linux && !has_dynamic_musl_linux;
+
+// Gather up the bundles the installer supports
+let mut artifacts = vec![];
+let mut target_triples = SortedSet::new();
+for &variant_idx in &release.variants {
+    let variant = self.variant(variant_idx);
+    let target = &variant.target;
+    if target.contains("windows") {
+        continue;
+    }
+    // Compute the artifact zip this variant *would* make *if* it were built
+    // FIXME: this is a kind of hacky workaround for the fact that we don't have a good
+    // way to add artifacts to the graph and then say "ok but don't build it".
+    let (artifact, binaries) =
+        self.make_executable_zip_for_variant(to_release, variant_idx);
+    target_triples.insert(target.clone());
+    let mut fragment = ExecutableZipFragment {
+        id: artifact.id,
+        target_triples: artifact.target_triples,
+        zip_style: artifact.archive.as_ref().unwrap().zip_style,
+        binaries: binaries
+            .into_iter()
+            .map(|(_, dest_path)| dest_path.file_name().unwrap().to_owned())
+            .collect(),
+    };
+    if do_rosetta_fallback && target == X64_MACOS {
+        // Copy the info but respecify it to be arm64 macos
+        let mut arm_fragment = fragment.clone();
+        arm_fragment.target_triples = vec![ARM64_MACOS.to_owned()];
+        artifacts.push(arm_fragment);
+    }
+    if target == X64_MUSL {
+        // musl-static is actually kind of a fake triple we've invented
+        // to let us specify which is which; we want to ensure it exists
+        // for the installer to act on
+        fragment.target_triples = vec![X64_MUSL_STATIC.to_owned()];
+    }
+    if do_gnu_to_musl_fallback && target == X64_MUSL {
+        // Copy the info but lie that it's actually glibc
+        let mut musl_fragment = fragment.clone();
+        musl_fragment.target_triples = vec![X64_GNU.to_owned()];
+        artifacts.push(musl_fragment);
+    }
+    if do_musl_to_musl_fallback && target == X64_MUSL {
+        // Copy the info but lie that it's actually dynamic musl
+        let mut musl_fragment = fragment.clone();
+        musl_fragment.target_triples = vec![X64_MUSL_DYNAMIC.to_owned()];
+        artifacts.push(musl_fragment);
+    }
+
+    artifacts.push(fragment);
+}
+
+*/

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1347,7 +1347,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
     /// Make an executable zip for a variant, but don't yet integrate it into the graph
     ///
     /// This is useful for installers which want to know about *potential* executable zips
-    fn make_executable_zip_for_variant(
+    pub(crate) fn make_executable_zip_for_variant(
         &self,
         release_idx: ReleaseIdx,
         variant_idx: ReleaseVariantIdx,


### PR DESCRIPTION
This started as the Big Linkage Refactor but ended up being the Big Platform Fallback Refactor. The meat here is platform.rs.

I got way in over my head when I started adding RuntimeCondition and SupportQuality to try to centralize stuff like "the glibc version has to be this".

Optimistically I think the point this refactor was at was "ok all the data is threaded, now I just need to completely rework the logic for installer.sh.js, installer.ps1.j2, installer.rb, and npm, which, was Too Much to do at once.