### PR TITLE
Remove rust-toolchain.yml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ publish-jobs = ["homebrew", "./publish-crates"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Publish jobs to run in CI
-pr-run-mode = "plan"
+pr-run-mode = "upload"
 # Where to host releases
 hosting = ["axodotdev", "github"]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.75"
-components = ["rustc", "cargo", "rust-std", "clippy", "rustfmt"]


### PR DESCRIPTION
Seeing if we can safely remove this now that it's been a bit.