### PR TITLE
fix: installer.sh doesn't require `which`

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -81,7 +81,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -1387,5 +1386,3 @@ jobs:
           body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
-
-

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -2946,5 +2945,3 @@ jobs:
     </Product>
 
 </Wix>
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -2918,5 +2917,3 @@ jobs:
     </Product>
 
 </Wix>
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -2282,5 +2281,3 @@ jobs:
           body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -2228,5 +2227,3 @@ jobs:
           body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -2657,5 +2656,3 @@ jobs:
           body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -2014,5 +2013,3 @@ jobs:
     </Product>
 
 </Wix>
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -2014,5 +2013,3 @@ jobs:
     </Product>
 
 </Wix>
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -1492,5 +1491,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -1463,5 +1462,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -1463,5 +1462,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -1463,5 +1462,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -1463,5 +1462,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -1463,5 +1462,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -1463,5 +1462,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -1463,5 +1462,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -78,7 +78,6 @@ download_binary_and_run_installer() {
     need_cmd mkdir
     need_cmd rm
     need_cmd tar
-    need_cmd which
     need_cmd grep
     need_cmd cat
 
@@ -1463,5 +1462,3 @@ try {
   },
   "linkage": []
 }
-
-


### PR DESCRIPTION
Going back to the earliest commits, this was always present in the requirements but `which` was never actually used even in the earliest commit. Presumably it was already removed before the first commit that introduced the installers.

Fixes #828.