### PR TITLE
Enable fallback to x64 in Invoke-Installer

### DIFF
--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -82,7 +82,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched $platforms "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -193,7 +193,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 {% if install_path.kind == "CargoHome" %}
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -256,7 +258,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     $platforms_json = ConvertTo-Json $platforms
     throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
   }
-  
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -193,9 +193,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 {% if install_path.kind == "CargoHome" %}
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -82,7 +82,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer $fetched $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -193,7 +193,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer($bin_paths, $platforms) {
 {% if install_path.kind == "CargoHome" %}
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -244,6 +244,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+  
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1060,9 +1060,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -949,7 +949,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1060,7 +1060,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1095,6 +1097,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -1060,9 +1060,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -949,7 +949,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1060,7 +1060,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1095,6 +1097,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -965,7 +965,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1076,7 +1076,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1111,6 +1113,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1076,9 +1076,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1015,9 +1015,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -904,7 +904,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1015,7 +1015,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1050,6 +1052,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1015,9 +1015,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -904,7 +904,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1015,7 +1015,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1050,6 +1052,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1077,9 +1077,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -966,7 +966,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1077,7 +1077,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1112,6 +1114,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1061,9 +1061,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -950,7 +950,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1061,7 +1061,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # first try CARGO_HOME, then fallback to HOME
   # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
@@ -1096,6 +1098,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1042,9 +1042,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's MY_ENV_VAR dir
   $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -931,7 +931,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1042,7 +1042,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # Install to this subdir of the user's MY_ENV_VAR dir
   $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
@@ -1072,6 +1074,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1042,9 +1042,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's MY_ENV_VAR dir
   $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -931,7 +931,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1042,7 +1042,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # Install to this subdir of the user's MY_ENV_VAR dir
   $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
@@ -1072,6 +1074,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1042,9 +1042,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's MY_ENV_VAR dir
   $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -931,7 +931,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1042,7 +1042,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # Install to this subdir of the user's MY_ENV_VAR dir
   $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
@@ -1072,6 +1074,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1042,9 +1042,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's MY_ENV_VAR dir
   $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -931,7 +931,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1042,7 +1042,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # Install to this subdir of the user's MY_ENV_VAR dir
   $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
@@ -1072,6 +1074,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1042,9 +1042,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's home dir
   $dest_dir = if (($base_dir = $HOME)) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -931,7 +931,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1042,7 +1042,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # Install to this subdir of the user's home dir
   $dest_dir = if (($base_dir = $HOME)) {
@@ -1072,6 +1074,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1042,9 +1042,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's home dir
   $dest_dir = if (($base_dir = $HOME)) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -931,7 +931,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1042,7 +1042,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # Install to this subdir of the user's home dir
   $dest_dir = if (($base_dir = $HOME)) {
@@ -1072,6 +1074,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1042,9 +1042,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's home dir
   $dest_dir = if (($base_dir = $HOME)) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -931,7 +931,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1042,7 +1042,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # Install to this subdir of the user's home dir
   $dest_dir = if (($base_dir = $HOME)) {
@@ -1072,6 +1074,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1042,9 +1042,7 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer {
-Param($bin_paths)
-Param($platforms)
+function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's home dir
   $dest_dir = if (($base_dir = $HOME)) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -931,7 +931,7 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer $fetched "$install_args"
+  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
 }
 
 function Get-TargetTriple() {
@@ -1042,7 +1042,9 @@ function Download($download_url, $platforms) {
   return $bin_paths
 }
 
-function Invoke-Installer($bin_paths) {
+function Invoke-Installer {
+Param($bin_paths)
+Param($platforms)
 
   # Install to this subdir of the user's home dir
   $dest_dir = if (($base_dir = $HOME)) {
@@ -1072,6 +1074,19 @@ function Invoke-Installer($bin_paths) {
 
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # X64 is well-supported, including in emulation on ARM64
+    Write-Verbose "$arch is not available, falling back to X64"
+    $arch = "x86_64-pc-windows-msvc"
+  }
+
+  if (-not $platforms.ContainsKey($arch)) {
+    # should not be possible, as currently we always produce X64 binaries.
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
   $info = $platforms[$arch]
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)


### PR DESCRIPTION
Fixes #834.

Right now, if `platforms` doesn't contain an entry for ARM64, `Download` falls back to x64, but `Invoke-Install` is missing matching fallback behavior, leading to failure.