### PR TITLE
feat: allow overriding install path

### DIFF
--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -206,9 +206,6 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
-
-  # The replace call here ensures proper escaping is inlined into the receipt
-  $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
 {% elif install_path.kind == "HomeSubdir" %}
   # Install to this subdir of the user's home dir
   $dest_dir = if (($base_dir = $HOME)) {
@@ -226,6 +223,15 @@ function Invoke-Installer($bin_paths) {
 {% else %}
   {{ error("unimplemented install_path format: " ~ install_path.kind) }}
 {% endif %}
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
+
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -318,8 +318,6 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
-    # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 {% elif install_path.kind == "HomeSubdir" %}
     # Install to this subdir of the user's home dir
     # In this case we want to be late-bound, as $HOME is reliable/nice.
@@ -345,6 +343,19 @@ install() {
 {% else %}
     {{ error("unimplemented install_path format: " ~ install_path.kind) }}
 {% endif %}
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
+
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
 

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1063,6 +1074,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -335,6 +335,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1387,5 +1398,3 @@ jobs:
           body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
-
-

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1063,6 +1074,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -335,6 +335,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1079,6 +1090,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1064,6 +1075,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
@@ -2946,5 +2963,3 @@ jobs:
     </Product>
 
 </Wix>
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1064,6 +1075,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
@@ -2918,5 +2935,3 @@ jobs:
     </Product>
 
 </Wix>
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1064,6 +1075,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1064,6 +1075,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -335,6 +335,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -2282,5 +2293,3 @@ jobs:
           body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -335,6 +335,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -2228,5 +2239,3 @@ jobs:
           body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1064,6 +1075,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
@@ -2657,5 +2674,3 @@ jobs:
           body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1018,6 +1029,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
@@ -2014,5 +2031,3 @@ jobs:
     </Product>
 
 </Wix>
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1018,6 +1029,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
@@ -2014,5 +2031,3 @@ jobs:
     </Product>
 
 </Wix>
-
-

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -335,6 +335,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1080,6 +1091,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1064,6 +1075,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1064,6 +1075,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1064,6 +1075,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1064,6 +1075,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1064,6 +1075,12 @@ function Invoke-Installer($bin_paths) {
   }
 
   $dest_dir = Join-Path $root "bin"
+
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -323,6 +323,17 @@ install() {
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
+
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
 
@@ -1065,6 +1076,12 @@ function Invoke-Installer($bin_paths) {
 
   $dest_dir = Join-Path $root "bin"
 
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
+
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
 
@@ -1492,5 +1509,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -305,6 +305,19 @@ install() {
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
 
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
+
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
 
@@ -1039,6 +1052,15 @@ function Invoke-Installer($bin_paths) {
     throw "ERROR: could not find your MY_ENV_VAR dir to install binaries to"
   }
 
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
+
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
@@ -1463,5 +1485,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -305,6 +305,19 @@ install() {
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
 
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
+
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
 
@@ -1039,6 +1052,15 @@ function Invoke-Installer($bin_paths) {
     throw "ERROR: could not find your MY_ENV_VAR dir to install binaries to"
   }
 
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
+
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
@@ -1463,5 +1485,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -305,6 +305,19 @@ install() {
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
 
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
+
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
 
@@ -1039,6 +1052,15 @@ function Invoke-Installer($bin_paths) {
     throw "ERROR: could not find your MY_ENV_VAR dir to install binaries to"
   }
 
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
+
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
@@ -1463,5 +1485,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -305,6 +305,19 @@ install() {
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
 
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
+
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
 
@@ -1039,6 +1052,15 @@ function Invoke-Installer($bin_paths) {
     throw "ERROR: could not find your MY_ENV_VAR dir to install binaries to"
   }
 
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
+
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
@@ -1463,5 +1485,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -305,6 +305,19 @@ install() {
         err "could not find your HOME dir to install binaries to"
     fi
 
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
+
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
 
@@ -1039,6 +1052,15 @@ function Invoke-Installer($bin_paths) {
     throw "ERROR: could not find your HOME dir to install binaries to"
   }
 
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
+
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
@@ -1463,5 +1485,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -305,6 +305,19 @@ install() {
         err "could not find your HOME dir to install binaries to"
     fi
 
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
+
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
 
@@ -1039,6 +1052,15 @@ function Invoke-Installer($bin_paths) {
     throw "ERROR: could not find your HOME dir to install binaries to"
   }
 
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
+
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
@@ -1463,5 +1485,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -305,6 +305,19 @@ install() {
         err "could not find your HOME dir to install binaries to"
     fi
 
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
+
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
 
@@ -1039,6 +1052,15 @@ function Invoke-Installer($bin_paths) {
     throw "ERROR: could not find your HOME dir to install binaries to"
   }
 
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
+
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
@@ -1463,5 +1485,3 @@ try {
   },
   "linkage": []
 }
-
-

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -305,6 +305,19 @@ install() {
         err "could not find your HOME dir to install binaries to"
     fi
 
+    # ...ignoring all of the above, if the user asked us to completely override
+    # those choices and use a specified directory, then pick that now
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$_install_dir"
+        _env_script_path_expr="$_env_script_path"
+    fi
+
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_CARGO_HOME,$_install_dir,")
+
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
 
@@ -1039,6 +1052,15 @@ function Invoke-Installer($bin_paths) {
     throw "ERROR: could not find your HOME dir to install binaries to"
   }
 
+  # ...ignoring all of the above, if the user asked us to completely override
+  # those choices and use a specified directory, then pick that now
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+  }
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_CARGO_HOME', $dest_dir.replace("\", "\\"))
+
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
@@ -1463,5 +1485,3 @@ try {
   },
   "linkage": []
 }
-
-


### PR DESCRIPTION
This provides a way to override any configuration on the installer and install to a location specified by a new environment variable. It provides a more predictable way to insist that it gets installed to a specific place, regardless of how the installer was built.

Possible fix for axodotdev/axoupdater#32, where we'd like to be able to install a new version to exactly the same path as the previous version.