### PR TITLE
chore: new rust

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75"
+channel = "1.77"
 components = ["rustc", "cargo", "rust-std", "clippy", "rustfmt"]


### PR DESCRIPTION
At some point we may be able to remove `rust-toolchain.toml`; this was here because we needed a feature in a new Rust that the actions runners weren't using by default yet.