### PR TITLE
fix: run apt-get update before install

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -409,7 +409,9 @@ fn package_install_for_targets(
                 }
 
                 let apts = packages.join(" ");
-                return Some(format!("sudo apt-get install {apts}").to_owned());
+                return Some(
+                    format!("sudo apt-get update && sudo apt-get install {apts}").to_owned(),
+                );
             }
             "i686-pc-windows-msvc" | "x86_64-pc-windows-msvc" | "aarch64-pc-windows-msvc" => {
                 let commands: Vec<String> = packages

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1112,7 +1112,7 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -236,7 +236,7 @@ expression: self.payload
             "runner": "buildjet-8vcpu-ubuntu-2204-arm",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools"
           },
           {
             "targets": [
@@ -253,7 +253,7 @@ expression: self.payload
             "runner": "buildjet-8vcpu-ubuntu-2204",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2015,7 +2015,7 @@ maybeInstall(true).then(run);
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1961,7 +1961,7 @@ maybeInstall(true).then(run);
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -429,7 +429,7 @@ stdout:
             "runner": "buildjet-8vcpu-ubuntu-2204-arm",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools"
           },
           {
             "targets": [
@@ -462,7 +462,7 @@ stdout:
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get install musl-tools"
+            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools"
           }
         ]
       },
@@ -476,5 +476,3 @@ stderr:
 INFO: You've enabled Axo Releases, which is currently in Closed Beta.
 If you haven't yet signed up, please join our discord
 (https://discord.gg/ECnWuUUXQk) or message hello@axo.dev to get started!
-
-


### PR DESCRIPTION
Not doing this was an oversight. There shouldn't be any harm to it.

Fixes #876.