### PR TITLE
Self update command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,8 +280,9 @@ dependencies = [
 
 [[package]]
 name = "axoupdater"
-version = "0.3.4"
-source = "git+https://github.com/axodotdev/axoupdater.git?branch=rename_current_exe#0c709196b57421aa3667f6ace3348270dd7fdd7b"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1b0e2e0db3801ead3402564783c751048c823a7e38ea24a57f7306d6a4aa85"
 dependencies = [
  "axoasset 0.9.1",
  "axoprocess",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "axoupdater"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e18b628756d7e73bcd3b7330e5834a44f841b115e92bad8563c3dc616a64131"
+dependencies = [
+ "axoasset 0.9.1",
+ "axoprocess",
+ "camino",
+ "gazenot",
+ "homedir",
+ "miette 7.2.0",
+ "reqwest",
+ "serde",
+ "temp-dir",
+ "thiserror",
+]
+
+[[package]]
 name = "backon"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +434,7 @@ dependencies = [
  "axoprocess",
  "axoproject",
  "axotag",
+ "axoupdater",
  "camino",
  "cargo-dist-schema",
  "cargo-wix",
@@ -1133,6 +1152,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "homedir"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22074da8bba2ef26fc1737ae6c777b5baab5524c2dc403b5c6a76166766ccda5"
+dependencies = [
+ "cfg-if",
+ "nix",
+ "serde",
+ "widestring",
+ "windows-sys 0.48.0",
+ "wmi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,7 +1359,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -1617,6 +1650,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374c335b2df19e62d4cb323103473cbc6510980253119180de862d89184f6a83"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miette"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1774,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -3317,6 +3372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
+name = "widestring"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3348,12 +3409,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -3514,6 +3618,20 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wmi"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f0a4062ca522aad4705a2948fd4061b3857537990202a8ddd5af21607f79a"
+dependencies = [
+ "chrono",
+ "futures",
+ "log 0.4.20",
+ "serde",
+ "thiserror",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "flate2",
  "gazenot",
  "goblin",
+ "homedir",
  "include_dir",
  "insta",
  "itertools 0.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "axoupdater"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e18b628756d7e73bcd3b7330e5834a44f841b115e92bad8563c3dc616a64131"
+checksum = "f8c9734fdcf2f393941efd59eab11f882e87477bdc4ae79dc001dbada98fbef6"
 dependencies = [
  "axoasset 0.9.1",
  "axoprocess",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,8 +281,7 @@ dependencies = [
 [[package]]
 name = "axoupdater"
 version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c9734fdcf2f393941efd59eab11f882e87477bdc4ae79dc001dbada98fbef6"
+source = "git+https://github.com/axodotdev/axoupdater.git?branch=rename_current_exe#0c709196b57421aa3667f6ace3348270dd7fdd7b"
 dependencies = [
  "axoasset 0.9.1",
  "axoprocess",

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -67,6 +67,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 temp-dir = "0.1.13"
 
 [dev-dependencies]
+homedir = "0.2.1"
 insta = { version = "1.38.0", features = ["filters"] }
 tar = "0.4.38"
 flate2 = "1.0.24"

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { version = "1.0.115", optional = true }
 console = { version = "0.15.8", optional = true }
 clap-cargo = { version = "0.14.0", optional = true }
 axocli = { version = "0.2.0", optional = true }
-axoupdater = { git = "https://github.com/axodotdev/axoupdater.git", branch = "rename_current_exe", optional = true }
+axoupdater = { version = "0.3.5", optional = true }
 
 # Features used by the cli and library
 axotag = "0.1.0"

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { version = "1.0.115", optional = true }
 console = { version = "0.15.8", optional = true }
 clap-cargo = { version = "0.14.0", optional = true }
 axocli = { version = "0.2.0", optional = true }
-axoupdater = { version = "0.3.3", optional = true }
+axoupdater = { version = "0.3.4", optional = true }
 
 # Features used by the cli and library
 axotag = "0.1.0"

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { version = "1.0.115", optional = true }
 console = { version = "0.15.8", optional = true }
 clap-cargo = { version = "0.14.0", optional = true }
 axocli = { version = "0.2.0", optional = true }
-axoupdater = { version = "0.3.4", optional = true }
+axoupdater = { git = "https://github.com/axodotdev/axoupdater.git", branch = "rename_current_exe", optional = true }
 
 # Features used by the cli and library
 axotag = "0.1.0"

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["cli"]
 
 [features]
 default = ["cli"]
-cli = ["clap", "axocli", "serde_json", "console", "clap-cargo"]
+cli = ["clap", "axocli", "serde_json", "console", "clap-cargo", "axoupdater"]
 # Use bleeding edge features that might mess up people using 'cargo install'
 # with older toolchains. This is used for our prebuilt binaries.
 fear_no_msrv = ["axoprocess/stdout_to_stderr_modern"]
@@ -32,6 +32,7 @@ serde_json = { version = "1.0.115", optional = true }
 console = { version = "0.15.8", optional = true }
 clap-cargo = { version = "0.14.0", optional = true }
 axocli = { version = "0.2.0", optional = true }
+axoupdater = { version = "0.3.3", optional = true }
 
 # Features used by the cli and library
 axotag = "0.1.0"

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -174,6 +174,10 @@ pub enum Commands {
     /// Host artifacts
     #[clap(disable_version_flag = true)]
     Host(HostArgs),
+
+    /// Performs a self-update, if a new version is available
+    #[clap(disable_version_flag = true)]
+    Update(UpdateArgs),
 }
 
 #[derive(Args, Clone, Debug)]
@@ -323,6 +327,9 @@ pub struct LinkageArgs {
 
 #[derive(Args, Clone, Debug)]
 pub struct HelpMarkdownArgs {}
+
+#[derive(Args, Clone, Debug)]
+pub struct UpdateArgs {}
 
 /// A style of CI to generate
 #[derive(ValueEnum, Clone, Copy, Debug)]

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -329,7 +329,12 @@ pub struct LinkageArgs {
 pub struct HelpMarkdownArgs {}
 
 #[derive(Args, Clone, Debug)]
-pub struct UpdateArgs {}
+pub struct UpdateArgs {
+    /// Run `cargo dist init` after performing an upgrade
+    #[clap(long)]
+    #[clap(default_value_t = true)]
+    pub run_init: bool,
+}
 
 /// A style of CI to generate
 #[derive(ValueEnum, Clone, Copy, Debug)]

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -330,10 +330,10 @@ pub struct HelpMarkdownArgs {}
 
 #[derive(Args, Clone, Debug)]
 pub struct UpdateArgs {
-    /// Run `cargo dist init` after performing an upgrade
+    /// Skip running `cargo dist init` after performing an upgrade
     #[clap(long)]
-    #[clap(default_value_t = true)]
-    pub run_init: bool,
+    #[clap(default_value_t = false)]
+    pub skip_init: bool,
 }
 
 /// A style of CI to generate

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -44,7 +44,7 @@ pub enum DistError {
 
     #[cfg(cli)]
     #[error(transparent)]
-    AxopupdaterError(#[from] axoupdater::AxoupdateError),
+    AxoupdaterError(#[from] axoupdater::AxoupdateError),
 
     /// A problem with a jinja template, which is always a cargo-dist bug
     #[error("Failed to render template")]

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -42,10 +42,6 @@ pub enum DistError {
     #[error(transparent)]
     FromUtf8Error(#[from] std::string::FromUtf8Error),
 
-    #[cfg(cli)]
-    #[error(transparent)]
-    AxoupdaterError(#[from] axoupdater::AxoupdateError),
-
     /// A problem with a jinja template, which is always a cargo-dist bug
     #[error("Failed to render template")]
     #[diagnostic(help("this is a bug in cargo-dist, let us know and we'll fix it: https://github.com/axodotdev/cargo-dist/issues/new"))]

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -42,6 +42,10 @@ pub enum DistError {
     #[error(transparent)]
     FromUtf8Error(#[from] std::string::FromUtf8Error),
 
+    #[cfg(cli)]
+    #[error(transparent)]
+    AxopupdaterError(#[from] axoupdater::AxoupdateError),
+
     /// A problem with a jinja template, which is always a cargo-dist bug
     #[error("Failed to render template")]
     #[diagnostic(help("this is a bug in cargo-dist, let us know and we'll fix it: https://github.com/axodotdev/cargo-dist/issues/new"))]

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -309,6 +309,11 @@ pub enum DistError {
         /// Name of binary
         bin_name: String,
     },
+
+    /// Error during `cargo dist update`
+    #[error("`cargo dist update` failed; the new version isn't in the place we expected")]
+    #[diagnostic(help("This is probably not your fault, please file an issue!"))]
+    UpdateFailed {},
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -559,7 +559,7 @@ async fn cmd_update(_config: &Cli, args: &cli::UpdateArgs) -> Result<(), miette:
 
     if !updater.check_receipt_is_for_this_executable()? {
         eprintln!("This installation of cargo-dist wasn't installed via a method that `cargo dist update` supports.");
-        eprintln!("Please upgrade manually.");
+        eprintln!("Please update manually.");
         return Ok(());
     }
 
@@ -594,7 +594,10 @@ async fn cmd_update(_config: &Cli, args: &cli::UpdateArgs) -> Result<(), miette:
             return Ok(());
         }
     } else {
-        eprintln!("No update necessary; up to date");
+        eprintln!(
+            "No update necessary; {} is up to date.",
+            env!("CARGO_PKG_VERSION")
+        );
         return Ok(());
     }
 

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -525,19 +525,19 @@ async fn cmd_update(_config: &Cli, args: &cli::UpdateArgs) -> Result<(), miette:
     // Do we want to treat this as an error?
     // Or do we want to sniff if this was a Homebrew installation?
     if updater.load_receipt().is_err() {
-        println!("Unable to load install receipt to check for updates.");
-        println!("If you installed this via `brew`, please `brew upgrade cargo-dist`!");
+        eprintln!("Unable to load install receipt to check for updates.");
+        eprintln!("If you installed this via `brew`, please `brew upgrade cargo-dist`!");
         return Ok(());
     }
 
     if !updater.check_receipt_is_for_this_executable()? {
-        println!("This installation of cargo-dist wasn't installed via a method that `cargo dist update` supports.");
-        println!("Please upgrade manually.");
+        eprintln!("This installation of cargo-dist wasn't installed via a method that `cargo dist update` supports.");
+        eprintln!("Please upgrade manually.");
         return Ok(());
     }
 
     if let Some(result) = updater.run().await? {
-        println!(
+        eprintln!(
             "Update performed: {} => {}",
             env!("CARGO_PKG_VERSION"),
             result.new_version
@@ -567,7 +567,7 @@ async fn cmd_update(_config: &Cli, args: &cli::UpdateArgs) -> Result<(), miette:
             return Ok(());
         }
     } else {
-        println!("No update necessary; up to date");
+        eprintln!("No update necessary; up to date");
         return Ok(());
     }
 

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -529,6 +529,12 @@ async fn cmd_update(_config: &Cli, _args: &cli::UpdateArgs) -> Result<(), miette
         return Ok(());
     }
 
+    if !updater.check_receipt_is_for_this_executable()? {
+        println!("This installation of cargo-dist wasn't installed via a method that `cargo dist update` supports.");
+        println!("Please upgrade manually.");
+        return Ok(());
+    }
+
     if let Some(result) = updater.run().await? {
         println!(
             "Update performed: {} => {}",

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -560,7 +560,7 @@ async fn cmd_update(_config: &Cli, args: &cli::UpdateArgs) -> Result<(), miette:
                 }
             }
 
-            let mut cmd = Cmd::new(new_path, "cargo-dist init");
+            let mut cmd = Cmd::new(new_path, "cargo dist init");
             cmd.arg("dist").arg("init");
             cmd.run()?;
 

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -521,7 +521,14 @@ fn cmd_manifest_schema(
 
 async fn cmd_update(_config: &Cli, _args: &cli::UpdateArgs) -> Result<(), miette::ErrReport> {
     let mut updater = AxoUpdater::new_for("cargo-dist");
-    updater.load_receipt()?;
+    // Do we want to treat this as an error?
+    // Or do we want to sniff if this was a Homebrew installation?
+    if updater.load_receipt().is_err() {
+        println!("Unable to load install receipt to check for updates.");
+        println!("If you installed this via `brew`, please `brew upgrade cargo-dist`!");
+        return Ok(());
+    }
+
     if let Some(result) = updater.run().await? {
         println!(
             "Update performed: {} => {}",

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -545,7 +545,7 @@ async fn cmd_update(_config: &Cli, args: &cli::UpdateArgs) -> Result<(), miette:
 
         // At this point, we've either updated or bailed out;
         // we can proceed with the init if the user would like us to.
-        if args.run_init {
+        if !args.skip_init {
             let mut new_path = result.install_prefix.join("bin").join("cargo-dist");
 
             // Install prefix could be a flat prefix with no "bin";

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -249,6 +249,7 @@ fn test_self_update() {
         if dist_path.exists() {
             std::fs::remove_file(dist_path).unwrap();
         }
+        assert!(!dist_path.exists());
 
         // Install to the home directory
         std::fs::copy(BIN, dist_path).unwrap();

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -247,6 +247,9 @@ fn test_self_update() {
         let output = Command::new(dist_path)
             .arg("dist")
             .arg("update")
+            // init includes interactive components, so we
+            // can't safely run it within a noninteractive test
+            .arg("--skip-init")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output()

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -212,8 +212,6 @@ fn write_receipt(version: &str, prefix: &Utf8PathBuf, config_path: &Utf8PathBuf)
 #[test]
 fn test_self_update() {
     // Only do this if RUIN_MY_COMPUTER_WITH_INSTALLERS is set
-    // Also keep it to Mac/Linux until I remember how Windows paths work
-    #[cfg(target_family = "unix")]
     if std::env::var(ENV_RUIN_ME)
         .map(|s| !s.is_empty())
         .unwrap_or(false)
@@ -227,11 +225,21 @@ fn test_self_update() {
         )
         .unwrap();
         let dist_path = &dist_home.join("cargo-dist");
+
+        #[cfg(target_family = "unix")]
         let config_path = Utf8PathBuf::from_path_buf(
             homedir::get_my_home()
                 .unwrap()
                 .unwrap()
                 .join(".config")
+                .join("cargo-dist"),
+        )
+        .unwrap();
+        #[cfg(target_family = "windows")]
+        let config_path = Utf8PathBuf::from_path_buf(
+            std::env::var("LOCALAPPDATA")
+                .map(std::path::PathBuf::from)
+                .unwrap()
                 .join("cargo-dist"),
         )
         .unwrap();

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -1,4 +1,7 @@
-use std::process::{Command, Output, Stdio};
+use std::{
+    env::consts::EXE_SUFFIX,
+    process::{Command, Output, Stdio},
+};
 
 static BIN: &str = env!("CARGO_BIN_EXE_cargo-dist");
 const ENV_RUIN_ME: &str = "RUIN_MY_COMPUTER_WITH_INSTALLERS";
@@ -224,7 +227,7 @@ fn test_self_update() {
                 .join("bin"),
         )
         .unwrap();
-        let dist_path = &dist_home.join("cargo-dist");
+        let dist_path = &dist_home.join(format!("cargo-dist{}", EXE_SUFFIX));
 
         #[cfg(target_family = "unix")]
         let config_path = Utf8PathBuf::from_path_buf(

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -244,6 +244,12 @@ fn test_self_update() {
         )
         .unwrap();
 
+        // Ensure we delete any previous copy that may exist
+        // at this path before we copy in our version.
+        if dist_path.exists() {
+            std::fs::remove_file(dist_path).unwrap();
+        }
+
         // Install to the home directory
         std::fs::copy(BIN, dist_path).unwrap();
 

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -1,9 +1,12 @@
 use std::process::{Command, Output, Stdio};
 
 static BIN: &str = env!("CARGO_BIN_EXE_cargo-dist");
+const ENV_RUIN_ME: &str = "RUIN_MY_COMPUTER_WITH_INSTALLERS";
 
 #[allow(dead_code)]
 mod gallery;
+use axoasset::LocalAsset;
+use camino::Utf8PathBuf;
 use gallery::*;
 
 fn format_outputs(output: &Output) -> String {
@@ -190,4 +193,72 @@ fn test_markdown_help() {
         insta::assert_snapshot!("markdown-help", format_outputs(&output));
     });
     assert!(output.status.success(), "{}", output.status);
+}
+
+static RECEIPT_TEMPLATE: &str = r#"{"binaries":["cargo-dist"],"install_prefix":"INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"0.10.0-prerelease.1"},"source":{"app_name":"cargo-dist","name":"cargo-dist","owner":"axodotdev","release_type":"github"},"version":"VERSION"}"#;
+
+fn install_receipt(version: &str, prefix: &Utf8PathBuf) -> String {
+    RECEIPT_TEMPLATE
+        .replace("INSTALL_PREFIX", &prefix.to_string().replace('\\', "\\\\"))
+        .replace("VERSION", version)
+}
+
+fn write_receipt(version: &str, prefix: &Utf8PathBuf, config_path: &Utf8PathBuf) {
+    let contents = install_receipt(version, prefix);
+    let receipt_name = config_path.join("cargo-dist-receipt.json");
+    LocalAsset::write_new_all(&contents, receipt_name).unwrap();
+}
+
+#[test]
+fn test_self_update() {
+    // Only do this if RUIN_MY_COMPUTER_WITH_INSTALLERS is set
+    // Also keep it to Mac/Linux until I remember how Windows paths work
+    #[cfg(target_family = "unix")]
+    if std::env::var(ENV_RUIN_ME)
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+    {
+        let dist_home = Utf8PathBuf::from_path_buf(
+            homedir::get_my_home()
+                .unwrap()
+                .unwrap()
+                .join(".cargo")
+                .join("bin"),
+        )
+        .unwrap();
+        let dist_path = &dist_home.join("cargo-dist");
+        let config_path = Utf8PathBuf::from_path_buf(
+            homedir::get_my_home()
+                .unwrap()
+                .unwrap()
+                .join(".config")
+                .join("cargo-dist"),
+        )
+        .unwrap();
+
+        // Install to the home directory
+        std::fs::copy(BIN, dist_path).unwrap();
+
+        // Create a fake install receipt
+        // We lie about being a very old version so we always
+        // consider upgrading to something.
+        write_receipt("0.5.0", &dist_home, &config_path);
+
+        let output = Command::new(dist_path)
+            .arg("dist")
+            .arg("update")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .unwrap();
+
+        let out_str = String::from_utf8_lossy(&output.stdout);
+        let err_str = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "status code: {}, stdout: {out_str}; stderr: {err_str}",
+            output.status
+        );
+    }
 }

--- a/cargo-dist/tests/snapshots/long-help.snap
+++ b/cargo-dist/tests/snapshots/long-help.snap
@@ -18,6 +18,7 @@ Commands:
   manifest  Generate the final build manifest without running any builds
   plan      Get a plan of what to build (and check project status)
   host      Host artifacts
+  update    Performs a self-update, if a new version is available
   help      Print this message or the help of the given subcommand(s)
 
 Options:
@@ -93,4 +94,3 @@ GLOBAL OPTIONS:
           Allow generated files like CI scripts to be out of date
 
 stderr:
-

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -26,6 +26,7 @@ cargo dist <COMMAND>
 * [manifest](#cargo-dist-manifest): Generate the final build manifest without running any builds
 * [plan](#cargo-dist-plan): Get a plan of what to build (and check project status)
 * [host](#cargo-dist-host): Host artifacts
+* [update](#cargo-dist-update): Performs a self-update, if a new version is available
 * [help](#cargo-dist-help): Print this message or the help of the given subcommand(s)
 
 ### Options
@@ -329,6 +330,23 @@ Print help (see a summary with '-h')
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
+## cargo dist update
+Performs a self-update, if a new version is available
+
+### Usage
+
+```text
+cargo dist update [OPTIONS]
+```
+
+### Options
+#### `-h, --help`
+Print help (see a summary with '-h')
+
+### GLOBAL OPTIONS
+This subcommand accepts all the [global options](#global-options)
+
+<br><br><br>
 ## cargo dist help
 Print this message or the help of the given subcommand(s)
 
@@ -346,6 +364,7 @@ cargo dist help [COMMAND]
 * [manifest](#cargo-dist-manifest): Generate the final build manifest without running any builds
 * [plan](#cargo-dist-plan): Get a plan of what to build (and check project status)
 * [host](#cargo-dist-host): Host artifacts
+* [update](#cargo-dist-update): Performs a self-update, if a new version is available
 * [help](#cargo-dist-help): Print this message or the help of the given subcommand(s)
 
 

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -340,8 +340,8 @@ cargo dist update [OPTIONS]
 ```
 
 ### Options
-#### `--run-init`
-Run `cargo dist init` after performing an upgrade
+#### `--skip-init`
+Skip running `cargo dist init` after performing an upgrade
 
 #### `-h, --help`
 Print help (see a summary with '-h')

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -340,6 +340,9 @@ cargo dist update [OPTIONS]
 ```
 
 ### Options
+#### `--run-init`
+Run `cargo dist init` after performing an upgrade
+
 #### `-h, --help`
 Print help (see a summary with '-h')
 

--- a/cargo-dist/tests/snapshots/short-help.snap
+++ b/cargo-dist/tests/snapshots/short-help.snap
@@ -16,6 +16,7 @@ Commands:
   manifest  Generate the final build manifest without running any builds
   plan      Get a plan of what to build (and check project status)
   host      Host artifacts
+  update    Performs a self-update, if a new version is available
   help      Print this message or the help of the given subcommand(s)
 
 Options:
@@ -33,4 +34,3 @@ GLOBAL OPTIONS:
       --allow-dirty                    Allow generated files like CI scripts to be out of date
 
 stderr:
-


### PR DESCRIPTION
An alternative to #896; this provides a `cargo dist update` command using axoupdater's lib. It also, optionally (and by default) runs `cargo dist update` from the new release after performing a successful upgrade, as suggested in #897.