### PR TITLE
docs: fix invalid link in generic-builds page

### DIFF
--- a/book/src/generic-builds.md
+++ b/book/src/generic-builds.md
@@ -79,7 +79,7 @@ All of these fields and their definitions are identical to the ones defined by [
 * `license-files`: An array containing a list of one or more license files within the source code.
 
 [cargo-toml]: https://doc.rust-lang.org/cargo/reference/manifest.html
-[quickstart]: /book/way-too-quickstart.html
+[quickstart]: ./way-too-quickstart.md
 [spdx]: https://spdx.org/licenses
 [target-triple]: https://doc.rust-lang.org/nightly/rustc/platform-support.html
 [toml]: https://en.wikipedia.org/wiki/TOML


### PR DESCRIPTION
This is a tiny fix for a documentation link.

Update a [main quickstart documentation](https://opensource.axo.dev/book/way-too-quickstart.html) link which does't seem to work in [Generic Builds](https://opensource.axo.dev/cargo-dist/book/generic-builds.html#quickstart) page.

Thank you.