### PR TITLE
chore: break out selfupdate test via helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,8 +280,9 @@ dependencies = [
 
 [[package]]
 name = "axoupdater"
-version = "0.3.6"
-source = "git+https://github.com/axodotdev/axoupdater/?branch=main#3707d4387e0a0add8cd7d1bacbc06b78e1cc7c7c"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7306cf5b4c3e7037d27ed5e9f7dc1b24d9941c77601e1e24c7d87839df6d8a2"
 dependencies = [
  "axoasset 0.9.1",
  "axoprocess",

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { version = "1.0.115", optional = true }
 console = { version = "0.15.8", optional = true }
 clap-cargo = { version = "0.14.0", optional = true }
 axocli = { version = "0.2.0", optional = true }
-axoupdater = { version = "0.3.6", optional = true, git = "https://github.com/axodotdev/axoupdater/", branch="main" }
+axoupdater = { version = "0.4.0", optional = true }
 
 # Features used by the cli and library
 axotag = "0.2.0"

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -1,5 +1,5 @@
 use std::{
-    env::consts::EXE_SUFFIX,
+    path::PathBuf,
     process::{Command, Output, Stdio},
 };
 
@@ -8,8 +8,7 @@ const ENV_RUIN_ME: &str = "RUIN_MY_COMPUTER_WITH_INSTALLERS";
 
 #[allow(dead_code)]
 mod gallery;
-use axoasset::LocalAsset;
-use camino::Utf8PathBuf;
+use axoupdater::{test::helpers::RuntestArgs, ReleaseSourceType};
 use gallery::*;
 
 fn format_outputs(output: &Output) -> String {
@@ -198,20 +197,6 @@ fn test_markdown_help() {
     assert!(output.status.success(), "{}", output.status);
 }
 
-static RECEIPT_TEMPLATE: &str = r#"{"binaries":["cargo-dist"],"install_prefix":"INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"0.10.0-prerelease.1"},"source":{"app_name":"cargo-dist","name":"cargo-dist","owner":"axodotdev","release_type":"github"},"version":"VERSION"}"#;
-
-fn install_receipt(version: &str, prefix: &Utf8PathBuf) -> String {
-    RECEIPT_TEMPLATE
-        .replace("INSTALL_PREFIX", &prefix.to_string().replace('\\', "\\\\"))
-        .replace("VERSION", version)
-}
-
-fn write_receipt(version: &str, prefix: &Utf8PathBuf, config_path: &Utf8PathBuf) {
-    let contents = install_receipt(version, prefix);
-    let receipt_name = config_path.join("cargo-dist-receipt.json");
-    LocalAsset::write_new_all(&contents, receipt_name).unwrap();
-}
-
 #[test]
 fn test_self_update() {
     // Only do this if RUIN_MY_COMPUTER_WITH_INSTALLERS is set
@@ -219,67 +204,22 @@ fn test_self_update() {
         .map(|s| !s.is_empty())
         .unwrap_or(false)
     {
-        let dist_home = Utf8PathBuf::from_path_buf(
-            homedir::get_my_home()
-                .unwrap()
-                .unwrap()
-                .join(".cargo")
-                .join("bin"),
-        )
-        .unwrap();
-        let dist_path = &dist_home.join(format!("cargo-dist{}", EXE_SUFFIX));
+        let args = RuntestArgs {
+            app_name: "cargo-dist".to_owned(),
+            package: "cargo-dist".to_owned(),
+            owner: "axodotdev".to_owned(),
+            bin: PathBuf::from(BIN),
+            binaries: vec!["cargo-dist".to_owned()],
+            args: vec![
+                "dist".to_owned(),
+                "update".to_owned(),
+                // init includes interactive components, so we
+                // can't safely run it within a noninteractive test
+                "--skip-init".to_owned(),
+            ],
+            release_type: ReleaseSourceType::GitHub,
+        };
 
-        #[cfg(target_family = "unix")]
-        let config_path = Utf8PathBuf::from_path_buf(
-            homedir::get_my_home()
-                .unwrap()
-                .unwrap()
-                .join(".config")
-                .join("cargo-dist"),
-        )
-        .unwrap();
-        #[cfg(target_family = "windows")]
-        let config_path = Utf8PathBuf::from_path_buf(
-            std::env::var("LOCALAPPDATA")
-                .map(std::path::PathBuf::from)
-                .unwrap()
-                .join("cargo-dist"),
-        )
-        .unwrap();
-
-        // Ensure we delete any previous copy that may exist
-        // at this path before we copy in our version.
-        if dist_path.exists() {
-            std::fs::remove_file(dist_path).unwrap();
-        }
-        assert!(!dist_path.exists());
-
-        // Install to the home directory
-        std::fs::copy(BIN, dist_path).unwrap();
-
-        // Create a fake install receipt
-        // We lie about being a very old version so we always
-        // consider upgrading to something.
-        write_receipt("0.5.0", &dist_home, &config_path);
-
-        let output = Command::new(dist_path)
-            .arg("dist")
-            .arg("selfupdate")
-            // init includes interactive components, so we
-            // can't safely run it within a noninteractive test
-            .arg("--skip-init")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .unwrap();
-
-        let out_str = String::from_utf8_lossy(&output.stdout);
-        let err_str = String::from_utf8_lossy(&output.stderr);
-
-        assert!(
-            output.status.success(),
-            "status code: {}, stdout: {out_str}; stderr: {err_str}",
-            output.status
-        );
+        axoupdater::test::helpers::perform_runtest(&args);
     }
 }


### PR DESCRIPTION
This uses a new helper introduced in axoupdater in place of implementing it itself.