### PR TITLE
fix: re-add HOME to paths in updater

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -348,8 +348,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -341,8 +341,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -341,8 +341,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -341,8 +341,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -341,8 +341,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -341,8 +341,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -329,8 +329,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -310,8 +310,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -310,8 +310,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -310,8 +310,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -310,8 +310,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -310,8 +310,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -310,8 +310,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -310,8 +310,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -310,8 +310,10 @@ install() {
         _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
+        # make sure to re-$HOME these paths, so that we don't needlessly
+        # pollute files with duplicate entries
+        _install_dir_expr=$(echo "$_install_dir" | sed "s,$HOME,\$HOME,")
+        _env_script_path_expr=$(echo "$_env_script_path" | sed "s,$HOME,\$HOME,")
     fi
 
     # Replace the temporary cargo home with the calculated one


### PR DESCRIPTION
I'm not sure if this is the ideal solution, because there's a few cases where we actually wouldn't have $HOME (EnvSubdir or the user actually setting $CARGO_HOME)... ideally we check for both forms.