### PR TITLE
feat: test building installers in updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "axoupdater"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2245976a147040f18b5b02ecb72b8705efa60f75225e32f51dd717cd5f9d79d1"
+checksum = "04daf26062f90764242d0e144ad52d1952cb0d02ef7ce3ffbb9127b4f1340f36"
 dependencies = [
  "axoasset 0.9.1",
  "axoprocess",

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { version = "1.0.115", optional = true }
 console = { version = "0.15.8", optional = true }
 clap-cargo = { version = "0.14.0", optional = true }
 axocli = { version = "0.2.0", optional = true }
-axoupdater = { version = "0.4.1", optional = true }
+axoupdater = { version = "0.5.0", optional = true }
 
 # Features used by the cli and library
 axotag = "0.2.0"

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -590,6 +590,15 @@ async fn cmd_update(_config: &Cli, args: &cli::UpdateArgs) -> Result<(), miette:
     };
     updater.configure_version_specifier(specifier);
 
+    // This uses debug assertions because we want to avoid this
+    // being compiled into the release build; this is purely for
+    // testing.
+    #[cfg(debug_assertions)]
+    if let Ok(installer_path) = std::env::var("CARGO_DIST_USE_INSTALLER_AT_PATH") {
+        let path = Utf8PathBuf::from(installer_path);
+        updater.configure_installer_path(path);
+    }
+
     // Do we want to treat this as an error?
     // Or do we want to sniff if this was a Homebrew installation?
     if updater.load_receipt().is_err() {

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -3,12 +3,18 @@ use std::{
     process::{Command, Output, Stdio},
 };
 
+#[cfg(unix)]
+use std::{fs::File, os::unix::fs::PermissionsExt};
+
 static BIN: &str = env!("CARGO_BIN_EXE_cargo-dist");
 const ENV_RUIN_ME: &str = "RUIN_MY_COMPUTER_WITH_INSTALLERS";
 
 #[allow(dead_code)]
 mod gallery;
-use axoupdater::{test::helpers::RuntestArgs, ReleaseSourceType};
+use axoasset::LocalAsset;
+use axoprocess::Cmd;
+use axoupdater::{test::helpers::RuntestArgs, AxoUpdater, ReleaseSourceType};
+use camino::Utf8PathBuf;
 use gallery::*;
 
 fn format_outputs(output: &Output) -> String {
@@ -197,6 +203,69 @@ fn test_markdown_help() {
     assert!(output.status.success(), "{}", output.status);
 }
 
+fn generate_installer(version: &axotag::Version, release_type: ReleaseSourceType) -> Utf8PathBuf {
+    let tools = Tools::default();
+
+    // On Windows, we need a debug build of cargo-dist present
+    // in order to be able to build the global artifacts. This is
+    // due to the extra-artifacts, which we don't yet have a CLI
+    // option to turn off during `cargo dist build`.
+    Cmd::new("cargo", "run debug build")
+        .arg("build")
+        .status()
+        .unwrap();
+
+    // First update the cargo-dist version so we can safely `cargo dist build`
+    tools
+        .cargo_dist
+        .output_checked(|cmd| cmd.arg("dist").arg("init").arg("--yes"))
+        .unwrap();
+
+    // Now we run cargo-dist to generate an installer for the current version
+    tools
+        .cargo_dist
+        .output_checked(|cmd| cmd.arg("dist").arg("build").arg("--artifacts=global"))
+        .unwrap();
+
+    let ext = if cfg!(windows) { ".ps1" } else { ".sh" };
+    let root = env!("CARGO_MANIFEST_DIR");
+    let installer_path = Utf8PathBuf::from(root)
+        .parent()
+        .unwrap()
+        .join("target")
+        .join("distrib")
+        .join(format!("cargo-dist-installer{ext}"));
+    let installer_string = std::fs::read_to_string(&installer_path).unwrap();
+
+    let installer_url = match release_type {
+        ReleaseSourceType::Axo => {
+            format!("https://axodotdev.artifacts.axodotdev.host/cargo-dist/v{version}",)
+        }
+        ReleaseSourceType::GitHub => {
+            format!("https://github.com/axodotdev/cargo-dist/releases/download/v{version}",)
+        }
+    };
+
+    let installer_string = installer_string
+        .replace(env!("CARGO_PKG_VERSION"), &version.to_string())
+        .replace(
+            "https://fake.axo.dev/faker/cargo-dist/fake-id-do-not-upload",
+            &installer_url,
+        );
+
+    #[cfg(unix)]
+    {
+        let installer_file = File::create(&installer_path).unwrap();
+        let mut perms = installer_file.metadata().unwrap().permissions();
+        perms.set_mode(0o744);
+        installer_file.set_permissions(perms).unwrap();
+    }
+
+    LocalAsset::write_new(&installer_string, &installer_path).unwrap();
+
+    installer_path
+}
+
 #[test]
 fn test_self_update() {
     // Only do this if RUIN_MY_COMPUTER_WITH_INSTALLERS is set
@@ -235,6 +304,58 @@ fn test_self_update() {
         // Then rerun with Axo; this is in one function because
         // they touch the same global files and can't happen
         // in parallel.
+        args.release_type = ReleaseSourceType::Axo;
+        let installed_bin = axoupdater::test::helpers::perform_runtest(&args);
+        assert!(installed_bin.exists());
+        let status = Command::new(&installed_bin)
+            .arg("--version")
+            .status()
+            .expect("binary didn't exist or --version returned nonzero");
+        assert!(status.success());
+
+        // Next two runtests: like the above, but we produce
+        // new installers so that we test against the latest installer
+        // code in this PR instead of the installers that were generated
+        // for the releases we're fetching.
+        let tokio = tokio::runtime::Builder::new_current_thread()
+            .worker_threads(1)
+            .max_blocking_threads(128)
+            .enable_all()
+            .build()
+            .expect("Initializing tokio runtime failed");
+
+        let mut updater = AxoUpdater::new_for("cargo-dist");
+        updater.set_release_source(axoupdater::ReleaseSource {
+            release_type: ReleaseSourceType::Axo,
+            owner: "axodotdev".to_owned(),
+            name: "cargo-dist".to_owned(),
+            app_name: "cargo-dist".to_owned(),
+        });
+        // This is the new version that we'll create alternate installers for.
+        let new_version = tokio
+            .block_on(updater.query_new_version())
+            .unwrap()
+            .unwrap();
+
+        let installer_path = generate_installer(new_version, ReleaseSourceType::GitHub);
+
+        // OK now, finally, we have an installer at `installer_path`
+        // with URLs pointing at the exact version we want to test.
+        // Point cargo-dist at it.
+        std::env::set_var("CARGO_DIST_USE_INSTALLER_AT_PATH", installer_path);
+
+        args.release_type = ReleaseSourceType::GitHub;
+        let installed_bin = axoupdater::test::helpers::perform_runtest(&args);
+        assert!(installed_bin.exists());
+        let status = Command::new(&installed_bin)
+            .arg("--version")
+            .status()
+            .expect("binary didn't exist or --version returned nonzero");
+        assert!(status.success());
+
+        // And once more, with Axo
+        generate_installer(new_version, ReleaseSourceType::Axo);
+
         args.release_type = ReleaseSourceType::Axo;
         let installed_bin = axoupdater::test::helpers::perform_runtest(&args);
         assert!(installed_bin.exists());


### PR DESCRIPTION
This tests our own generated installers instead of the installers that were build for the version we're fetching. It asks axoupdater what version it plans to update to, then generates new installers and updates the version we're fetching to that instead of whatever cargo-dist would have generated. Using a new testing feature from axoupdater, we then substitute these new installers for the ones it would have downloaded from the new release.