### PR TITLE
feat: clean up force install behaviour

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -290,13 +290,11 @@ install() {
 {% if install_path.kind == "CargoHome" %}
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -317,7 +315,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -325,7 +322,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -293,6 +293,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -314,6 +322,17 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
@@ -325,6 +344,15 @@ install() {
         _env_script_path="$HOME/{{ install_path.subdir }}/env"
         _install_dir_expr='$HOME/{{ install_path.subdir }}'
         _env_script_path_expr='$HOME/{{ install_path.subdir }}/env'
+
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your HOME dir to install binaries to"
     fi
@@ -336,21 +364,20 @@ install() {
         _env_script_path="${{ install_path.env_key }}{% if install_path.subdir | length %}/{% endif %}{{ install_path.subdir }}/env"
         _install_dir_expr="$_install_dir"
         _env_script_path_expr="$_env_script_path"
+
+        # Override if necessary
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            _install_dir_expr="$_install_dir"
+            _env_script_path_expr="$_env_script_path"
+        fi
     else
         err "could not find your {{ install_path.env_key }} dir to install binaries to"
     fi
 {% else %}
     {{ error("unimplemented install_path format: " ~ install_path.kind) }}
 {% endif %}
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -310,6 +310,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -331,19 +339,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -307,13 +307,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -334,7 +332,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -342,7 +339,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -310,6 +310,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -331,19 +339,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -307,13 +307,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -334,7 +332,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -342,7 +339,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -310,6 +310,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -331,19 +339,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -307,13 +307,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -334,7 +332,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -342,7 +339,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -310,6 +310,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -331,19 +339,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -307,13 +307,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -334,7 +332,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -342,7 +339,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -310,6 +310,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -331,19 +339,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -307,13 +307,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -334,7 +332,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -342,7 +339,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -295,13 +295,11 @@ install() {
 
     # first try CARGO_HOME, then fallback to HOME
     if [ -n "${CARGO_HOME:-}" ]; then
-        _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         fi
@@ -322,7 +320,6 @@ install() {
             _env_script_path_expr="$_env_script_path"
         fi
     elif [ -n "${HOME:-}" ]; then
-        _install_home="$HOME/.cargo"
         _install_dir="$HOME/.cargo/bin"
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
@@ -330,7 +327,6 @@ install() {
 
         # If we need to override the above
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
-            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
             _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -298,6 +298,14 @@ install() {
         _install_home="$CARGO_HOME"
         _install_dir="$CARGO_HOME/bin"
         _env_script_path="$CARGO_HOME/env"
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$CARGO_HOME" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        fi
+
         # If CARGO_HOME was set but it ended up being the default $HOME-based path,
         # then keep things late-bound. Otherwise bake the value for safety.
         # This is what rustup does, and accurately reproducing it is useful.
@@ -319,19 +327,21 @@ install() {
         _env_script_path="$HOME/.cargo/env"
         _install_dir_expr='$HOME/.cargo/bin'
         _env_script_path_expr='$HOME/.cargo/env'
+
+        # If we need to override the above
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ] && [ "${CARGO_DIST_FORCE_INSTALL_DIR}" != "$HOME/.cargo" ]; then
+            _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/bin" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your CARGO_HOME or HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -300,19 +300,18 @@ install() {
         _env_script_path="$MY_ENV_VAR/env"
         _install_dir_expr="$_install_dir"
         _env_script_path_expr="$_env_script_path"
+
+        # Override if necessary
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            _install_dir_expr="$_install_dir"
+            _env_script_path_expr="$_env_script_path"
+        fi
     else
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -300,19 +300,18 @@ install() {
         _env_script_path="$MY_ENV_VAR/bin/env"
         _install_dir_expr="$_install_dir"
         _env_script_path_expr="$_env_script_path"
+
+        # Override if necessary
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            _install_dir_expr="$_install_dir"
+            _env_script_path_expr="$_env_script_path"
+        fi
     else
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -300,19 +300,18 @@ install() {
         _env_script_path="$MY_ENV_VAR/My Axolotlsay Documents/env"
         _install_dir_expr="$_install_dir"
         _env_script_path_expr="$_env_script_path"
+
+        # Override if necessary
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            _install_dir_expr="$_install_dir"
+            _env_script_path_expr="$_env_script_path"
+        fi
     else
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -300,19 +300,18 @@ install() {
         _env_script_path="$MY_ENV_VAR/My Axolotlsay Documents/bin/env"
         _install_dir_expr="$_install_dir"
         _env_script_path_expr="$_env_script_path"
+
+        # Override if necessary
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            _install_dir_expr="$_install_dir"
+            _env_script_path_expr="$_env_script_path"
+        fi
     else
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -300,19 +300,19 @@ install() {
         _env_script_path="$HOME/.axolotlsay/bins/env"
         _install_dir_expr='$HOME/.axolotlsay/bins'
         _env_script_path_expr='$HOME/.axolotlsay/bins/env'
+
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -300,19 +300,19 @@ install() {
         _env_script_path="$HOME/.axolotlsay/env"
         _install_dir_expr='$HOME/.axolotlsay'
         _env_script_path_expr='$HOME/.axolotlsay/env'
+
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -300,19 +300,19 @@ install() {
         _env_script_path="$HOME/My Axolotlsay Documents/env"
         _install_dir_expr='$HOME/My Axolotlsay Documents'
         _env_script_path_expr='$HOME/My Axolotlsay Documents/env'
+
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -300,19 +300,19 @@ install() {
         _env_script_path="$HOME/My Axolotlsay Documents/bin/env"
         _install_dir_expr='$HOME/My Axolotlsay Documents/bin'
         _env_script_path_expr='$HOME/My Axolotlsay Documents/bin/env'
+
+        if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+            # For these two, if the new value contains $HOME, make
+            # sure to `sed` the $HOME expression back into the expr
+            _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR" | sed "s,$HOME,\$HOME,")"
+            _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
+        fi
     else
         err "could not find your HOME dir to install binaries to"
     fi
 
-    # ...ignoring all of the above, if the user asked us to completely override
-    # those choices and use a specified directory, then pick that now
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_home="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$_install_dir"
-        _env_script_path_expr="$_env_script_path"
-    fi
 
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")


### PR DESCRIPTION
Instead of always overriding after setting the path, this places it directly inside each of the branches. This lets us customize the values to be more appropriate to each branch, fixing an issue where `/bin` would be added to paths that shouldn't have it.

In addition, it adds a new check to several branches for if `$HOME` is contained within and substitutes the literal value for the variable in the `expr` values, and avoids overwriting the configured values if the forced values are already equivalent to the defaults.