### PR TITLE
fix: check for rosetta in shell

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -627,6 +627,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -603,6 +603,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -603,6 +603,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -603,6 +603,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -603,6 +603,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -603,6 +603,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -591,6 +591,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -565,6 +565,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -565,6 +565,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -565,6 +565,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -565,6 +565,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -566,6 +566,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -566,6 +566,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -566,6 +566,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -566,6 +566,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
     if [ "$_ostype" = SunOS ]; then
         # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
         # so use "uname -o" to disambiguate.  We use the full path to the


### PR DESCRIPTION
We inherited a check for the old-style Mac `uname -m` reporting on Intel from rustup, but we're missing a case to check for Rosetta under aarch64. Makes sense to me to add one and always install the aarch64 binary even if the installer's being run from within an Intel Rosetta shell.