### PR TITLE
feat: migrate from flat to hierarchical install strategy 

### DIFF
--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -120,6 +120,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 
@@ -213,7 +225,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   }
 {% elif install_path.kind == "HomeSubdir" %}
   # Install to this subdir of the user's home dir
-  $dest_dir = if (($base_dir = $HOME)) {
+  $root = if (($base_dir = $HOME)) {
     Join-Path $base_dir "{{ install_path.subdir }}"
   } else {
     throw "ERROR: could not find your HOME dir to install binaries to"
@@ -221,11 +233,15 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # If we need to override the above
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-    $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $root = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  MigrateInstallDir -old_root $root -new_root $dest_dir -bin_paths $bin_paths
 {% elif install_path.kind == "EnvSubdir" %}
   # Install to this subdir of the user's {{ install_path.env_key }} dir
-  $dest_dir = if (($base_dir = $env:{{ install_path.env_key }})) {
+  $root = if (($base_dir = $env:{{ install_path.env_key }})) {
     Join-Path $base_dir "{{ install_path.subdir }}"
   } else {
     throw "ERROR: could not find your {{ install_path.env_key }} dir to install binaries to"
@@ -233,8 +249,12 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # If we need to override the above
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-    $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $root = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  MigrateInstallDir -old_root $root -new_root $dest_dir -bin_paths $bin_paths
 {% else %}
   {{ error("unimplemented install_path format: " ~ install_path.kind) }}
 {% endif %}

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -241,9 +241,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -336,19 +368,24 @@ install() {
     # Install to this subdir of the user's home dir
     # In this case we want to be late-bound, as $HOME is reliable/nice.
     if [ -n "${HOME:-}" ]; then
-        _install_dir="$HOME/{{ install_path.subdir }}"
+        _install_root="$HOME/{{ install_path.subdir }}"
+        _install_dir="$HOME/{{ install_path.subdir }}/bin"
         _env_script_path="$HOME/{{ install_path.subdir }}/env"
-        _install_dir_expr='$HOME/{{ install_path.subdir }}'
+        _install_dir_expr='$HOME/{{ install_path.subdir }}/bin'
         _env_script_path_expr='$HOME/{{ install_path.subdir }}/env'
 
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_root="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make
             # sure to `sed` the $HOME expression back into the expr
             _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR" | sed "s,$HOME,\$HOME,")"
             _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
         fi
+
+        # Migrate from the old flat directory path to the new location
+        migrate_install_dir "$_install_root" "$_install_dir" "$_bins"
     else
         err "could not find your HOME dir to install binaries to"
     fi
@@ -356,18 +393,23 @@ install() {
     # Install to this subdir of the user's {{ install_path.env_key }} dir.
     # In this case we want to be early-bound, as the env-var can't be trusted longterm.
     if [ -n "{{ "${" }}{{ install_path.env_key }}:-}" ]; then
-        _install_dir="${{ install_path.env_key }}{% if install_path.subdir | length %}/{% endif %}{{ install_path.subdir }}"
+        _install_root="${{ install_path.env_key }}{% if install_path.subdir | length %}/{% endif %}{{ install_path.subdir }}"
+        _install_dir="$_install_root/bin"
         _env_script_path="${{ install_path.env_key }}{% if install_path.subdir | length %}/{% endif %}{{ install_path.subdir }}/env"
         _install_dir_expr="$_install_dir"
         _env_script_path_expr="$_env_script_path"
 
         # Override if necessary
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_root="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             _install_dir_expr="$_install_dir"
             _env_script_path_expr="$_env_script_path"
         fi
+
+        # Migrate from the old flat directory path to the new location
+        migrate_install_dir "$_install_root" "$_install_dir" "$_bins"
     else
         err "could not find your {{ install_path.env_key }} dir to install binaries to"
     fi
@@ -382,8 +424,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/gallery/dist.rs
+++ b/cargo-dist/tests/gallery/dist.rs
@@ -701,15 +701,8 @@ impl DistResult {
             ];
             let receipt_file = tempdir.join(format!(".config/{app_name}/{app_name}-receipt.json"));
             let expected_bin_dir = Utf8PathBuf::from(expected_bin_dir);
-            let bin_dir = tempdir.join(&expected_bin_dir);
-            let env_dir = if expected_bin_dir
-                .components()
-                .any(|d| d.as_str() == ".cargo")
-            {
-                bin_dir.parent().unwrap()
-            } else {
-                &bin_dir
-            };
+            let bin_dir = tempdir.join(expected_bin_dir);
+            let env_dir = bin_dir.parent().unwrap();
             let env_script = env_dir.join("env");
 
             assert!(bin_dir.exists(), "bin dir wasn't created");

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -1016,7 +1016,7 @@ windows-archive = ".tar.gz"
         ))?;
 
         let results = ctx.cargo_dist_build_and_plan(test_name)?;
-        results.check_all(ctx, ".axolotlsay/")?.snap();
+        results.check_all(ctx, ".axolotlsay/bin/")?.snap();
 
         Ok(())
     })
@@ -1043,7 +1043,7 @@ windows-archive = ".tar.gz"
         ))?;
 
         let results = ctx.cargo_dist_build_and_plan(test_name)?;
-        results.check_all(ctx, ".axolotlsay/bins")?.snap();
+        results.check_all(ctx, ".axolotlsay/bins/bin/")?.snap();
 
         Ok(())
     })
@@ -1070,7 +1070,7 @@ windows-archive = ".tar.gz"
         ))?;
 
         let results = ctx.cargo_dist_build_and_plan(test_name)?;
-        results.check_all(ctx, "My Axolotlsay Documents/")?.snap();
+        results.check_all(ctx, "My Axolotlsay Documents/bin/")?.snap();
 
         Ok(())
     })
@@ -1096,7 +1096,7 @@ windows-archive = ".tar.gz"
         ))?;
 
         let results = ctx.cargo_dist_build_and_plan(test_name)?;
-        results.check_all(ctx, "My Axolotlsay Documents/bin/")?.snap();
+        results.check_all(ctx, "My Axolotlsay Documents/bin/bin/")?.snap();
 
         Ok(())
     })
@@ -1123,7 +1123,7 @@ windows-archive = ".tar.gz"
         ))?;
 
         let results = ctx.cargo_dist_build_and_plan(test_name)?;
-        results.check_all(ctx, ".axolotlsay/")?.snap();
+        results.check_all(ctx, ".axolotlsay/bin/")?.snap();
 
         Ok(())
     })
@@ -1150,7 +1150,7 @@ windows-archive = ".tar.gz"
         ))?;
 
         let results = ctx.cargo_dist_build_and_plan(test_name)?;
-        results.check_all(ctx, ".axolotlsay/bin/")?.snap();
+        results.check_all(ctx, ".axolotlsay/bin/bin/")?.snap();
 
         Ok(())
     })
@@ -1177,7 +1177,7 @@ windows-archive = ".tar.gz"
         ))?;
 
         let results = ctx.cargo_dist_build_and_plan(test_name)?;
-        results.check_all(ctx, ".axolotlsay/My Axolotlsay Documents/")?.snap();
+        results.check_all(ctx, ".axolotlsay/My Axolotlsay Documents/bin/")?.snap();
 
         Ok(())
     })
@@ -1204,7 +1204,7 @@ windows-archive = ".tar.gz"
         ))?;
 
         let results = ctx.cargo_dist_build_and_plan(test_name)?;
-        results.check_all(ctx, ".axolotlsay/My Axolotlsay Documents/bin/")?.snap();
+        results.check_all(ctx, ".axolotlsay/My Axolotlsay Documents/bin/bin/")?.snap();
 
         Ok(())
     })

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -258,9 +258,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -358,8 +390,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -258,9 +258,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -358,8 +390,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1044,6 +1044,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1031,6 +1031,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -258,9 +258,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -358,8 +390,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -258,9 +258,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -358,8 +390,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -987,6 +987,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -987,6 +987,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -258,9 +258,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -358,8 +390,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1044,6 +1044,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1028,6 +1028,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -346,8 +378,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1007,6 +1007,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 
@@ -1083,7 +1095,7 @@ function Download($download_url, $platforms) {
 function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's MY_ENV_VAR dir
-  $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
+  $root = if (($base_dir = $env:MY_ENV_VAR)) {
     Join-Path $base_dir ""
   } else {
     throw "ERROR: could not find your MY_ENV_VAR dir to install binaries to"
@@ -1091,8 +1103,12 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # If we need to override the above
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-    $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $root = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  MigrateInstallDir -old_root $root -new_root $dest_dir -bin_paths $bin_paths
 
 
   # The replace call here ensures proper escaping is inlined into the receipt

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -296,18 +328,23 @@ install() {
     # Install to this subdir of the user's MY_ENV_VAR dir.
     # In this case we want to be early-bound, as the env-var can't be trusted longterm.
     if [ -n "${MY_ENV_VAR:-}" ]; then
-        _install_dir="$MY_ENV_VAR"
+        _install_root="$MY_ENV_VAR"
+        _install_dir="$_install_root/bin"
         _env_script_path="$MY_ENV_VAR/env"
         _install_dir_expr="$_install_dir"
         _env_script_path_expr="$_env_script_path"
 
         # Override if necessary
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_root="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             _install_dir_expr="$_install_dir"
             _env_script_path_expr="$_env_script_path"
         fi
+
+        # Migrate from the old flat directory path to the new location
+        migrate_install_dir "$_install_root" "$_install_dir" "$_bins"
     else
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
@@ -320,8 +357,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1007,6 +1007,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 
@@ -1083,7 +1095,7 @@ function Download($download_url, $platforms) {
 function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's MY_ENV_VAR dir
-  $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
+  $root = if (($base_dir = $env:MY_ENV_VAR)) {
     Join-Path $base_dir "bin"
   } else {
     throw "ERROR: could not find your MY_ENV_VAR dir to install binaries to"
@@ -1091,8 +1103,12 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # If we need to override the above
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-    $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $root = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  MigrateInstallDir -old_root $root -new_root $dest_dir -bin_paths $bin_paths
 
 
   # The replace call here ensures proper escaping is inlined into the receipt

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -296,18 +328,23 @@ install() {
     # Install to this subdir of the user's MY_ENV_VAR dir.
     # In this case we want to be early-bound, as the env-var can't be trusted longterm.
     if [ -n "${MY_ENV_VAR:-}" ]; then
-        _install_dir="$MY_ENV_VAR/bin"
+        _install_root="$MY_ENV_VAR/bin"
+        _install_dir="$_install_root/bin"
         _env_script_path="$MY_ENV_VAR/bin/env"
         _install_dir_expr="$_install_dir"
         _env_script_path_expr="$_env_script_path"
 
         # Override if necessary
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_root="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             _install_dir_expr="$_install_dir"
             _env_script_path_expr="$_env_script_path"
         fi
+
+        # Migrate from the old flat directory path to the new location
+        migrate_install_dir "$_install_root" "$_install_dir" "$_bins"
     else
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
@@ -320,8 +357,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1007,6 +1007,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 
@@ -1083,7 +1095,7 @@ function Download($download_url, $platforms) {
 function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's MY_ENV_VAR dir
-  $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
+  $root = if (($base_dir = $env:MY_ENV_VAR)) {
     Join-Path $base_dir "My Axolotlsay Documents"
   } else {
     throw "ERROR: could not find your MY_ENV_VAR dir to install binaries to"
@@ -1091,8 +1103,12 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # If we need to override the above
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-    $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $root = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  MigrateInstallDir -old_root $root -new_root $dest_dir -bin_paths $bin_paths
 
 
   # The replace call here ensures proper escaping is inlined into the receipt

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -296,18 +328,23 @@ install() {
     # Install to this subdir of the user's MY_ENV_VAR dir.
     # In this case we want to be early-bound, as the env-var can't be trusted longterm.
     if [ -n "${MY_ENV_VAR:-}" ]; then
-        _install_dir="$MY_ENV_VAR/My Axolotlsay Documents"
+        _install_root="$MY_ENV_VAR/My Axolotlsay Documents"
+        _install_dir="$_install_root/bin"
         _env_script_path="$MY_ENV_VAR/My Axolotlsay Documents/env"
         _install_dir_expr="$_install_dir"
         _env_script_path_expr="$_env_script_path"
 
         # Override if necessary
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_root="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             _install_dir_expr="$_install_dir"
             _env_script_path_expr="$_env_script_path"
         fi
+
+        # Migrate from the old flat directory path to the new location
+        migrate_install_dir "$_install_root" "$_install_dir" "$_bins"
     else
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
@@ -320,8 +357,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1007,6 +1007,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 
@@ -1083,7 +1095,7 @@ function Download($download_url, $platforms) {
 function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's MY_ENV_VAR dir
-  $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
+  $root = if (($base_dir = $env:MY_ENV_VAR)) {
     Join-Path $base_dir "My Axolotlsay Documents/bin"
   } else {
     throw "ERROR: could not find your MY_ENV_VAR dir to install binaries to"
@@ -1091,8 +1103,12 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # If we need to override the above
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-    $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $root = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  MigrateInstallDir -old_root $root -new_root $dest_dir -bin_paths $bin_paths
 
 
   # The replace call here ensures proper escaping is inlined into the receipt

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -296,18 +328,23 @@ install() {
     # Install to this subdir of the user's MY_ENV_VAR dir.
     # In this case we want to be early-bound, as the env-var can't be trusted longterm.
     if [ -n "${MY_ENV_VAR:-}" ]; then
-        _install_dir="$MY_ENV_VAR/My Axolotlsay Documents/bin"
+        _install_root="$MY_ENV_VAR/My Axolotlsay Documents/bin"
+        _install_dir="$_install_root/bin"
         _env_script_path="$MY_ENV_VAR/My Axolotlsay Documents/bin/env"
         _install_dir_expr="$_install_dir"
         _env_script_path_expr="$_env_script_path"
 
         # Override if necessary
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_root="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             _install_dir_expr="$_install_dir"
             _env_script_path_expr="$_env_script_path"
         fi
+
+        # Migrate from the old flat directory path to the new location
+        migrate_install_dir "$_install_root" "$_install_dir" "$_bins"
     else
         err "could not find your MY_ENV_VAR dir to install binaries to"
     fi
@@ -320,8 +357,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -296,19 +328,24 @@ install() {
     # Install to this subdir of the user's home dir
     # In this case we want to be late-bound, as $HOME is reliable/nice.
     if [ -n "${HOME:-}" ]; then
-        _install_dir="$HOME/.axolotlsay/bins"
+        _install_root="$HOME/.axolotlsay/bins"
+        _install_dir="$HOME/.axolotlsay/bins/bin"
         _env_script_path="$HOME/.axolotlsay/bins/env"
-        _install_dir_expr='$HOME/.axolotlsay/bins'
+        _install_dir_expr='$HOME/.axolotlsay/bins/bin'
         _env_script_path_expr='$HOME/.axolotlsay/bins/env'
 
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_root="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make
             # sure to `sed` the $HOME expression back into the expr
             _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR" | sed "s,$HOME,\$HOME,")"
             _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
         fi
+
+        # Migrate from the old flat directory path to the new location
+        migrate_install_dir "$_install_root" "$_install_dir" "$_bins"
     else
         err "could not find your HOME dir to install binaries to"
     fi
@@ -321,8 +358,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1008,6 +1008,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 
@@ -1084,7 +1096,7 @@ function Download($download_url, $platforms) {
 function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's home dir
-  $dest_dir = if (($base_dir = $HOME)) {
+  $root = if (($base_dir = $HOME)) {
     Join-Path $base_dir ".axolotlsay/bins"
   } else {
     throw "ERROR: could not find your HOME dir to install binaries to"
@@ -1092,8 +1104,12 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # If we need to override the above
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-    $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $root = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  MigrateInstallDir -old_root $root -new_root $dest_dir -bin_paths $bin_paths
 
 
   # The replace call here ensures proper escaping is inlined into the receipt

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -296,19 +328,24 @@ install() {
     # Install to this subdir of the user's home dir
     # In this case we want to be late-bound, as $HOME is reliable/nice.
     if [ -n "${HOME:-}" ]; then
-        _install_dir="$HOME/.axolotlsay"
+        _install_root="$HOME/.axolotlsay"
+        _install_dir="$HOME/.axolotlsay/bin"
         _env_script_path="$HOME/.axolotlsay/env"
-        _install_dir_expr='$HOME/.axolotlsay'
+        _install_dir_expr='$HOME/.axolotlsay/bin'
         _env_script_path_expr='$HOME/.axolotlsay/env'
 
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_root="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make
             # sure to `sed` the $HOME expression back into the expr
             _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR" | sed "s,$HOME,\$HOME,")"
             _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
         fi
+
+        # Migrate from the old flat directory path to the new location
+        migrate_install_dir "$_install_root" "$_install_dir" "$_bins"
     else
         err "could not find your HOME dir to install binaries to"
     fi
@@ -321,8 +358,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1008,6 +1008,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 
@@ -1084,7 +1096,7 @@ function Download($download_url, $platforms) {
 function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's home dir
-  $dest_dir = if (($base_dir = $HOME)) {
+  $root = if (($base_dir = $HOME)) {
     Join-Path $base_dir ".axolotlsay"
   } else {
     throw "ERROR: could not find your HOME dir to install binaries to"
@@ -1092,8 +1104,12 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # If we need to override the above
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-    $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $root = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  MigrateInstallDir -old_root $root -new_root $dest_dir -bin_paths $bin_paths
 
 
   # The replace call here ensures proper escaping is inlined into the receipt

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1008,6 +1008,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 
@@ -1084,7 +1096,7 @@ function Download($download_url, $platforms) {
 function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's home dir
-  $dest_dir = if (($base_dir = $HOME)) {
+  $root = if (($base_dir = $HOME)) {
     Join-Path $base_dir "My Axolotlsay Documents"
   } else {
     throw "ERROR: could not find your HOME dir to install binaries to"
@@ -1092,8 +1104,12 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # If we need to override the above
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-    $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $root = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  MigrateInstallDir -old_root $root -new_root $dest_dir -bin_paths $bin_paths
 
 
   # The replace call here ensures proper escaping is inlined into the receipt

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -296,19 +328,24 @@ install() {
     # Install to this subdir of the user's home dir
     # In this case we want to be late-bound, as $HOME is reliable/nice.
     if [ -n "${HOME:-}" ]; then
-        _install_dir="$HOME/My Axolotlsay Documents"
+        _install_root="$HOME/My Axolotlsay Documents"
+        _install_dir="$HOME/My Axolotlsay Documents/bin"
         _env_script_path="$HOME/My Axolotlsay Documents/env"
-        _install_dir_expr='$HOME/My Axolotlsay Documents'
+        _install_dir_expr='$HOME/My Axolotlsay Documents/bin'
         _env_script_path_expr='$HOME/My Axolotlsay Documents/env'
 
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_root="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make
             # sure to `sed` the $HOME expression back into the expr
             _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR" | sed "s,$HOME,\$HOME,")"
             _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
         fi
+
+        # Migrate from the old flat directory path to the new location
+        migrate_install_dir "$_install_root" "$_install_dir" "$_bins"
     else
         err "could not find your HOME dir to install binaries to"
     fi
@@ -321,8 +358,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -246,9 +246,41 @@ download_binary_and_run_installer() {
     return "$_retval"
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+migrate_install_dir() {
+    local _old_root="$1"
+    local _new_root="$2"
+    local _bins="$3"
+
+    ensure mkdir -p "$_new_root"
+    # Check for a previous installation that's in the root
+    # instead of the root plus /bin; this may be left over
+    # from before we migrated to always use FHS-style layouts.
+    for _bin_name in $_bins; do
+        local _old_path="$_old_root/$_bin_name"
+        local _new_path="$_new_root/$_bin_name"
+        # We move this into the new path expecting them
+        # to be overwritten later. Doing that, instead of
+        # just deleting them now, guards against the
+        # possibility that the install fails: if that were
+        # to happen, we'd have deleted them without
+        # producing new copies, leaving the user without
+        # any binaries left at all.
+        if [ -f "$_old_path" ]; then
+            ensure mv "$_old_path" "$_new_path"
+            say_verbose "Migrated $_old_path to $_new_path"
+        fi
+    done
+}
+
 # See discussion of late-bound vs early-bound for why we use single-quotes with env vars
 # shellcheck disable=SC2016
 install() {
+    # Assign parameters immediately, before doing anything else
+    local _src_dir="$1"
+    local _bins="$2"
+
     # This code needs to both compute certain paths for itself to write to, and
     # also write them to shell/rc files so that they can look them up to e.g.
     # add them to PATH. This requires an active distinction between paths
@@ -296,19 +328,24 @@ install() {
     # Install to this subdir of the user's home dir
     # In this case we want to be late-bound, as $HOME is reliable/nice.
     if [ -n "${HOME:-}" ]; then
-        _install_dir="$HOME/My Axolotlsay Documents/bin"
+        _install_root="$HOME/My Axolotlsay Documents/bin"
+        _install_dir="$HOME/My Axolotlsay Documents/bin/bin"
         _env_script_path="$HOME/My Axolotlsay Documents/bin/env"
-        _install_dir_expr='$HOME/My Axolotlsay Documents/bin'
+        _install_dir_expr='$HOME/My Axolotlsay Documents/bin/bin'
         _env_script_path_expr='$HOME/My Axolotlsay Documents/bin/env'
 
         if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_root="$CARGO_DIST_FORCE_INSTALL_DIR"
+            _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
             _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
             # For these two, if the new value contains $HOME, make
             # sure to `sed` the $HOME expression back into the expr
             _install_dir_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR" | sed "s,$HOME,\$HOME,")"
             _env_script_path_expr="$(echo "$CARGO_DIST_FORCE_INSTALL_DIR/env" | sed "s,$HOME,\$HOME,")"
         fi
+
+        # Migrate from the old flat directory path to the new location
+        migrate_install_dir "$_install_root" "$_install_dir" "$_bins"
     else
         err "could not find your HOME dir to install binaries to"
     fi
@@ -321,8 +358,6 @@ install() {
     ensure mkdir -p "$_install_dir"
 
     # copy all the binaries to the install dir
-    local _src_dir="$1"
-    local _bins="$2"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1008,6 +1008,18 @@ function Get-TargetTriple() {
   }
 }
 
+# Provides a way to migrate from an old "flat" layout to the new
+# FHS-style organized layout.
+function MigrateInstallDir($old_root, $new_root, $bin_paths) {
+  foreach ($bin_name in $bin_paths) {
+    $bin_path = "$old_root\$bin_name"
+      if (Test-Path -Path "$bin_path") {
+        Copy-Item "$bin_path" -Destination "$new_root"
+        Write-Verbose "Migrated $bin_path to $new_root\$bin_name"
+      }
+  }
+}
+
 function Download($download_url, $platforms) {
   $arch = Get-TargetTriple
 
@@ -1084,7 +1096,7 @@ function Download($download_url, $platforms) {
 function Invoke-Installer($bin_paths, $platforms) {
 
   # Install to this subdir of the user's home dir
-  $dest_dir = if (($base_dir = $HOME)) {
+  $root = if (($base_dir = $HOME)) {
     Join-Path $base_dir "My Axolotlsay Documents/bin"
   } else {
     throw "ERROR: could not find your HOME dir to install binaries to"
@@ -1092,8 +1104,12 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # If we need to override the above
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-    $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $root = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
+
+  $dest_dir = Join-Path $root "bin"
+
+  MigrateInstallDir -old_root $root -new_root $dest_dir -bin_paths $bin_paths
 
 
   # The replace call here ensures proper escaping is inlined into the receipt


### PR DESCRIPTION
Before this commit, we had two different installation layouts:

* Cargo home produced an FHS-style installation layout, with binaries installed into the `bin` directory within an install prefix.
* Env subdir and home subdir produced a flat installation layout, with binaries and all other files placed in a single directory.

Going forward, it will be advantageous for us to have a unified strategy where we can predict the layout of an install directory no matter which path we're following.

This doesn't just change the default, but also performs a migration: any binaries that this installer would install that exist in the old default path are migrated to the new path before the installation itself begins.

We'll want to make sure this gets some testing before merging, though the "ruin me" env var tests in CI should also give us some active testing.

Fixes #934.