### PR TITLE
chore: update toml_edit, type alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
  "tar",
  "thiserror",
  "toml",
- "toml_edit 0.22.5",
+ "toml_edit 0.22.9",
  "url",
  "walkdir",
  "xz2",
@@ -2966,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.5"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e68c159e8f5ba8a28c4eb7b0c0c190d77bb479047ca713270048145a9ad28a"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
  "indexmap 2.2.3",
  "toml_datetime",

--- a/cargo-dist/src/backend/installer/msi.rs
+++ b/cargo-dist/src/backend/installer/msi.rs
@@ -176,7 +176,7 @@ fn diff_render(render: Option<RenderOutput>) -> DistResult<()> {
 ///
 /// This ensures that regenerating the installer produces a stable result.
 /// Returns whether modifications were made (and should be written to disk)
-fn update_wix_metadata(package_toml: &mut toml_edit::Document) -> bool {
+fn update_wix_metadata(package_toml: &mut toml_edit::DocumentMut) -> bool {
     let metadata = config::get_toml_metadata(package_toml, false);
 
     // Get the subtable

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -1382,14 +1382,14 @@ pub fn get_project() -> std::result::Result<axoproject::WorkspaceInfo, ProjectEr
 }
 
 /// Load a Cargo.toml into toml-edit form
-pub fn load_cargo_toml(manifest_path: &Utf8Path) -> DistResult<toml_edit::Document> {
+pub fn load_cargo_toml(manifest_path: &Utf8Path) -> DistResult<toml_edit::DocumentMut> {
     let src = axoasset::SourceFile::load_local(manifest_path)?;
     let toml = src.deserialize_toml_edit()?;
     Ok(toml)
 }
 
 /// Save a Cargo.toml from toml-edit form
-pub fn save_cargo_toml(manifest_path: &Utf8Path, toml: toml_edit::Document) -> DistResult<()> {
+pub fn save_cargo_toml(manifest_path: &Utf8Path, toml: toml_edit::DocumentMut) -> DistResult<()> {
     let toml_text = toml.to_string();
     axoasset::LocalAsset::write_new(&toml_text, manifest_path)?;
     Ok(())
@@ -1397,7 +1397,7 @@ pub fn save_cargo_toml(manifest_path: &Utf8Path, toml: toml_edit::Document) -> D
 
 /// Get the `[workspace.metadata]` or `[package.metadata]` (based on `is_workspace`)
 pub fn get_toml_metadata(
-    toml: &mut toml_edit::Document,
+    toml: &mut toml_edit::DocumentMut,
     is_workspace: bool,
 ) -> &mut toml_edit::Item {
     // Walk down/prepare the components...

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -136,7 +136,10 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
     Ok(())
 }
 
-fn init_dist_profile(_cfg: &Config, workspace_toml: &mut toml_edit::Document) -> DistResult<bool> {
+fn init_dist_profile(
+    _cfg: &Config,
+    workspace_toml: &mut toml_edit::DocumentMut,
+) -> DistResult<bool> {
     let profiles = workspace_toml["profile"].or_insert(toml_edit::table());
     if let Some(t) = profiles.as_table_mut() {
         t.set_implicit(true)
@@ -761,7 +764,7 @@ fn get_new_dist_metadata(
 
 /// Update a workspace toml-edit document with the current DistMetadata value
 pub(crate) fn apply_dist_to_workspace_toml(
-    workspace_toml: &mut toml_edit::Document,
+    workspace_toml: &mut toml_edit::DocumentMut,
     workspace_kind: WorkspaceKind,
     meta: &DistMetadata,
 ) {


### PR DESCRIPTION
The toml_edit::Document type [moved to DocumentMut in 0.22.7](https://github.com/toml-rs/toml/blob/48f968b449d64a3b7bcefab37c3f08438ba857ec/crates/toml_edit/CHANGELOG.md?plain=1#L31).

I noticed that certain from-source git builds of cargo-dist were pulling in the newer toml_edit, so I figured it was worth it to update the locked version and switch to the new type.