### PR TITLE
fix: cargo dist update messages

### DIFF
--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -315,12 +315,12 @@ pub enum DistError {
         bin_name: String,
     },
 
-    /// Error during `cargo dist update`
-    #[error("`cargo dist update` failed; the new version isn't in the place we expected")]
+    /// Error during `cargo dist selfupdate`
+    #[error("`cargo dist selfupdate` failed; the new version isn't in the place we expected")]
     #[diagnostic(help("This is probably not your fault, please file an issue!"))]
     UpdateFailed {},
 
-    /// Trying to run cargo dist update in a random dir
+    /// Trying to run cargo dist selfupdate in a random dir
     #[error("`cargo dist selfupdate` needs to be run in a project")]
     #[diagnostic(help(
         "If you just want to update cargo-dist and not your project, pass --skip-init"

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -608,7 +608,7 @@ async fn cmd_update(_config: &Cli, args: &cli::UpdateArgs) -> Result<(), miette:
     }
 
     if !updater.check_receipt_is_for_this_executable()? {
-        eprintln!("This installation of cargo-dist wasn't installed via a method that `cargo dist update` supports.");
+        eprintln!("This installation of cargo-dist wasn't installed via a method that `cargo dist selfupdate` supports.");
         eprintln!("Please update manually.");
         return Ok(());
     }


### PR DESCRIPTION
These were missed with the switch to `cargo dist selfupdate`.