### PR TITLE
feat: add fish support to shell installers

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -372,6 +372,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -392,18 +398,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -442,6 +454,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -480,7 +493,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -499,10 +516,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -511,7 +539,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -527,6 +555,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -358,6 +358,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -378,18 +384,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -428,6 +440,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -466,7 +479,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -485,10 +502,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -497,7 +525,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -513,6 +541,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -358,6 +358,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -378,18 +384,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -428,6 +440,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -466,7 +479,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -485,10 +502,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -497,7 +525,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -513,6 +541,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -358,6 +358,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -378,18 +384,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -428,6 +440,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -466,7 +479,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -485,10 +502,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -497,7 +525,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -513,6 +541,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -358,6 +358,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -378,18 +384,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -428,6 +440,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -466,7 +479,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -485,10 +502,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -497,7 +525,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -513,6 +541,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -358,6 +358,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -378,18 +384,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -428,6 +440,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -466,7 +479,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -485,10 +502,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -497,7 +525,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -513,6 +541,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -346,6 +346,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -366,18 +372,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -416,6 +428,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -454,7 +467,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -473,10 +490,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -485,7 +513,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -501,6 +529,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -331,6 +331,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -351,18 +357,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -401,6 +413,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -439,7 +452,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -458,10 +475,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -470,7 +498,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -486,6 +514,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -331,6 +331,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -351,18 +357,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -401,6 +413,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -439,7 +452,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -458,10 +475,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -470,7 +498,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -486,6 +514,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -331,6 +331,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -351,18 +357,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -401,6 +413,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -439,7 +452,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -458,10 +475,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -470,7 +498,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -486,6 +514,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -331,6 +331,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -351,18 +357,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -401,6 +413,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -439,7 +452,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -458,10 +475,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -470,7 +498,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -486,6 +514,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -341,6 +341,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -361,18 +367,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -411,6 +423,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -449,7 +462,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -468,10 +485,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -480,7 +508,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -496,6 +524,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -331,6 +331,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -351,18 +357,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -401,6 +413,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -439,7 +452,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -458,10 +475,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -470,7 +498,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -486,6 +514,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -331,6 +331,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -351,18 +357,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -401,6 +413,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -439,7 +452,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -458,10 +475,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -470,7 +498,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -486,6 +514,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -331,6 +331,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -351,18 +357,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -401,6 +413,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -439,7 +452,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -458,10 +475,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -470,7 +498,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -486,6 +514,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -331,6 +331,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -351,18 +357,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -401,6 +413,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -439,7 +452,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -458,10 +475,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -470,7 +498,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -486,6 +514,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -341,6 +341,12 @@ install() {
         err "could not find a valid path to install to!"
     fi
 
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
     # Replace the temporary cargo home with the calculated one
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_install_dir,")
 
@@ -361,18 +367,24 @@ install() {
     say "everything's installed!"
 
     if [ "0" = "$NO_MODIFY_PATH" ]; then
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
         exit1=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
         exit2=$?
-        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
         exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
 
-        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ]; then
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
             say ""
             say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
             say ""
-            say "    source $_env_script_path_expr"
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
 }
@@ -411,6 +423,7 @@ add_install_dir_to_path() {
     local _env_script_path="$2"
     local _env_script_path_expr="$3"
     local _rcfiles="$4"
+    local _shell="$5"
 
     if [ -n "${HOME:-}" ]; then
         local _target
@@ -449,7 +462,11 @@ add_install_dir_to_path() {
         # Add the env script if it doesn't already exist
         if [ ! -f "$_env_script_path" ]; then
             say_verbose "creating $_env_script_path"
-            write_env_script "$_install_dir_expr" "$_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
         else
             say_verbose "$_env_script_path already exists"
         fi
@@ -468,10 +485,21 @@ add_install_dir_to_path() {
             # If the script now exists, add the line to source it to the rcfile
             # (This will also create the rcfile if it doesn't exist)
             if [ -f "$_env_script_path" ]; then
-                say_verbose "adding $_robust_line to $_target"
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
                 # prepend an extra newline in case the user's file is missing a trailing one
                 ensure echo "" >> "$_target"
-                ensure echo "$_robust_line" >> "$_target"
+                ensure echo "$_line" >> "$_target"
                 return 1
             fi
         else
@@ -480,7 +508,7 @@ add_install_dir_to_path() {
     fi
 }
 
-write_env_script() {
+write_env_script_sh() {
     # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
     local _install_dir_expr="$1"
     local _env_script_path="$2"
@@ -496,6 +524,18 @@ case ":\${PATH}:" in
         export PATH="$_install_dir_expr:\$PATH"
         ;;
 esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
 EOF
 }
 


### PR DESCRIPTION
This adds support for fish as a shell. Like with sh, I took inspiration from rustup's implementation. This broadly leans on the existing shell support, but has a few distinct features.

* Instead of writing to an existing configuration file like `~/.bashrc`, we write to a file in fish's `conf.d` path. This is a directory which is autoloaded on shell boot, which means we can create an app-specific path and can avoid having to edit the user's own configuration file.
* Unique to fish, since `conf.d` may not exist at the time we want to interact with it, I've added an `mkdir -p` call.
* I've used fish's [`fish_add_path`](https://fishshell.com/docs/current/cmds/fish_add_path.html) helper, which encapsulates the logic of "only prepend to the path if it's not already on the `PATH`" without us having to write it ourselves. (Note that `fish_add_path` was introduced in fish 3.2.0, which was released in 2020. Since that version is available in the current LTS release of Ubuntu and Debian stable, I believe it's old enough to be safe for us to use it.)
* I updated our existing shell writing code to make it aware of what shell we're writing so I could branch which form of envfile to write, and whether to output `source` or `.` statements. (fish strongly prefers `source` and has stated `.` may be removed in the future.)

I gave this a test locally; it appears to be working fine, and, like with the sh side, doesn't overwrite cargo's configuration for `CargoHome` installs.