### PR TITLE
feat: add release-branch config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.15.0-prerelease.1"
+version = "0.15.0-prerelease.2"
 dependencies = [
  "axoasset",
  "axocli",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.15.0-prerelease.1"
+version = "0.15.0-prerelease.2"
 dependencies = [
  "camino",
  "gazenot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.14.1"
+version = "0.15.0-prerelease.1"
 dependencies = [
  "axoasset",
  "axocli",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.14.1"
+version = "0.15.0-prerelease.1"
 dependencies = [
  "camino",
  "gazenot",

--- a/cargo-dist-schema/Cargo.toml
+++ b/cargo-dist-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-dist-schema"
 description = "Schema information for cargo-dist's dist-manifest.json"
-version = "0.15.0-prerelease.1"
+version = "0.15.0-prerelease.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"

--- a/cargo-dist-schema/Cargo.toml
+++ b/cargo-dist-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-dist-schema"
 description = "Schema information for cargo-dist's dist-manifest.json"
-version = "0.14.1"
+version = "0.15.0-prerelease.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-dist"
 description = "Shippable application packaging for Rust"
-version = "0.14.1"
+version = "0.15.0-prerelease.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
@@ -36,7 +36,7 @@ axoupdater = { version = "0.6.1", optional = true }
 
 # Features used by the cli and library
 axotag = "0.2.0"
-cargo-dist-schema = { version = "=0.14.1", path = "../cargo-dist-schema" }
+cargo-dist-schema = { version = "=0.15.0-prerelease.1", path = "../cargo-dist-schema" }
 axoasset = { version = "0.9.3", features = ["json-serde", "toml-serde", "toml-edit", "compression"] }
 axoprocess = { version = "0.2.0" }
 axoproject = { version = "0.7.1", default-features = false, features = ["cargo-projects", "generic-projects"] }

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-dist"
 description = "Shippable application packaging for Rust"
-version = "0.15.0-prerelease.1"
+version = "0.15.0-prerelease.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
@@ -36,7 +36,7 @@ axoupdater = { version = "0.6.1", optional = true }
 
 # Features used by the cli and library
 axotag = "0.2.0"
-cargo-dist-schema = { version = "=0.15.0-prerelease.1", path = "../cargo-dist-schema" }
+cargo-dist-schema = { version = "=0.15.0-prerelease.2", path = "../cargo-dist-schema" }
 axoasset = { version = "0.9.3", features = ["json-serde", "toml-serde", "toml-edit", "compression"] }
 axoprocess = { version = "0.2.0" }
 axoproject = { version = "0.7.1", default-features = false, features = ["cargo-projects", "generic-projects"] }

--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -509,13 +509,14 @@ fn timestamp_version(version: &mut Version) {
         // FIXME?: should we actually unconditionally do this?
         version.pre = semver::Prerelease::new("alpha").unwrap();
     }
+
     // FIXME?: this could be configurable to be a git commit, but timestamps
     // are nicer as a default (so sorting the releases works right)
     let now = std::time::SystemTime::now();
     let secs = now.duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
     // TODO?: use chrono for better format, or at least guarantee sorting work reliably
     // (confirm how buildid sorting works in SemVer Version).
-    version.build = semver::BuildMetadata::new(&format!("{secs}")).unwrap();
+    version.pre = semver::Prerelease::new(&format!("{}.{}", version.pre, secs)).unwrap();
 }
 
 /// Get the maximum version among the given packages

--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -32,7 +32,7 @@ pub(crate) struct AnnouncementTag {
 /// Settings for `select_tag`
 #[derive(Debug, Clone)]
 pub struct TagSettings {
-    /// Whether the tag and versions need to be coherent with eachother.
+    /// Whether the tag and versions need to be coherent with each other.
     ///
     /// If false, `select_tag` is allowed to make up a fake tag/version
     /// that doesn't need to match the packages.
@@ -287,17 +287,17 @@ fn require_axotag_consistency(
         }
         (
             ReleaseType::Package {
-                idx: _,
-                version: computed_version,
+                version: computed_ver,
+                ..
             },
             ReleaseType::Package {
-                idx: _,
-                version: expected_version,
+                version: expected_ver,
+                ..
             },
         ) => {
             // FIXME: compare indices (use original package list to make them comparable?)
             assert_eq!(
-                computed_version, expected_version,
+                computed_ver, expected_ver,
                 "internal dist error: axotag parsed a different version from tag"
             );
         }
@@ -500,7 +500,7 @@ fn ensure_tag(
     Ok(())
 }
 
-/// Modify
+/// Modify the version to include a timestamp in the prerelease portion
 fn timestamp_version(version: &mut Version) {
     // FIXME: it would be nice if this was configurable with a template
     // the current template here is `{version}-alpha.{timestamp}`.
@@ -510,12 +510,9 @@ fn timestamp_version(version: &mut Version) {
         version.pre = semver::Prerelease::new("alpha").unwrap();
     }
 
-    // FIXME?: this could be configurable to be a git commit, but timestamps
-    // are nicer as a default (so sorting the releases works right)
     let now = std::time::SystemTime::now();
     let secs = now.duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-    // TODO?: use chrono for better format, or at least guarantee sorting work reliably
-    // (confirm how buildid sorting works in SemVer Version).
+    // FIXME?: use chrono for better format
     version.pre = semver::Prerelease::new(&format!("{}.{}", version.pre, secs)).unwrap();
 }
 
@@ -524,24 +521,12 @@ fn maximum_version(
     graph: &DistGraphBuilder,
     packages: impl IntoIterator<Item = PackageIdx>,
 ) -> Option<Version> {
-    let mut max_ver = None;
-    for pkg_idx in packages {
-        let version = graph
-            .workspace()
-            .package(pkg_idx)
-            .version
-            .as_ref()
-            .unwrap()
-            .cargo();
-        let Some(cur_max) = &max_ver else {
-            max_ver = Some(version.clone());
-            continue;
-        };
-        if version > cur_max {
-            max_ver = Some(version.clone());
-        }
-    }
-    max_ver
+    packages
+        .into_iter()
+        .filter_map(|pkg_idx| graph.workspace().package(pkg_idx).version.as_ref())
+        .map(|v| v.cargo())
+        .max()
+        .cloned()
 }
 
 /// Overwrite the versions of the given packages

--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 //! Computing the Announcement
 //!
 //! This is both "selection of what we're announcing via the tag" and "changelog stuff"
@@ -27,6 +29,20 @@ pub(crate) struct AnnouncementTag {
     pub prerelease: bool,
     /// Which packages+bins we're announcing
     pub rust_releases: Vec<(PackageIdx, Vec<String>)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TagSettings {
+    pub needs_coherence: bool,
+    pub tag: TagMode,
+}
+
+#[derive(Debug, Clone)]
+pub enum TagMode {
+    Infer,
+    Select(String),
+    Force(String),
+    ForceMax,
 }
 
 type ReleasesAndBins = Vec<(PackageIdx, Vec<String>)>;
@@ -164,25 +180,17 @@ fn check_dist_package(
 /// in the workspace.
 pub(crate) fn select_tag(
     graph: &mut DistGraphBuilder,
-    tag: Option<&str>,
-    needs_coherent_announcement_tag: bool,
+    settings: &TagSettings,
 ) -> DistResult<AnnouncementTag> {
-    let mut announcing = if let Some(tag) = tag {
-        // If we're given a specific real tag to use, ask axotag to parse it
-        // and identify which packages are selected by it.
-        let packages: Vec<Package> = graph
-            .workspace()
-            .packages()
-            .map(|(_, info)| Package {
-                name: info.name.clone(),
-                version: info.version.clone().map(|v| v.semver().clone()),
-            })
-            .collect();
-
-        parse_tag(&packages, tag)?
-    } else {
-        // Otherwise, start with all packages
-        PartialAnnouncementTag::default()
+    let mut announcing = match &settings.tag {
+        TagMode::Select(tag) => {
+            // If we're given a selection tag, immediately parse it to use as a selector
+            parse_tag_for_all_packages(graph, tag)?
+        }
+        TagMode::Infer | TagMode::ForceMax | TagMode::Force(_) => {
+            // Otherwise, start with all packages
+            PartialAnnouncementTag::default()
+        }
     };
 
     // Further filter down the list of packages based on whether they're "distable",
@@ -193,20 +201,10 @@ pub(crate) fn select_tag(
     require_releases(graph, &releases)?;
 
     // If we still need to compute a tag, do so now
-    ensure_tag(
-        graph,
-        &releases,
-        &mut announcing,
-        needs_coherent_announcement_tag,
-    )?;
+    ensure_tag(graph, &releases, &mut announcing, settings)?;
 
     // Make sure axotag agrees with what we did
-    require_axotag_consistency(
-        graph,
-        &announcing,
-        &releases,
-        needs_coherent_announcement_tag,
-    )?;
+    require_axotag_consistency(graph, &announcing, settings)?;
 
     // Ok, we're done, return the result
     let mut version = None;
@@ -232,26 +230,15 @@ pub(crate) fn select_tag(
 fn require_axotag_consistency(
     graph: &mut DistGraphBuilder,
     announcing: &PartialAnnouncementTag,
-    releases: &ReleasesAndBins,
-    needs_coherent_announcement_tag: bool,
+    settings: &TagSettings,
 ) -> DistResult<()> {
-    if !needs_coherent_announcement_tag {
+    if !settings.needs_coherence {
         // Don't care
         return Ok(());
     }
 
     let expected = announcing;
-    let packages = releases
-        .iter()
-        .map(|(p, _)| {
-            let info = graph.workspace().package(*p);
-            Package {
-                name: info.name.clone(),
-                version: info.version.clone().map(|v| v.semver().clone()),
-            }
-        })
-        .collect::<Vec<_>>();
-    let computed = parse_tag(&packages, &announcing.tag)?;
+    let computed = parse_tag_for_all_packages(graph, &announcing.tag)?;
 
     match (&computed.release, &expected.release) {
         (ReleaseType::Version(computed), ReleaseType::Version(expected)) => {
@@ -375,7 +362,7 @@ fn ensure_tag(
     graph: &mut DistGraphBuilder,
     releases: &ReleasesAndBins,
     announcing: &mut PartialAnnouncementTag,
-    needs_coherent_announcement_tag: bool,
+    settings: &TagSettings,
 ) -> DistResult<()> {
     // This extra logic only applies if we didn't already have a tag,
     // which would have set ReleaseType
@@ -383,34 +370,162 @@ fn ensure_tag(
         return Ok(());
     }
 
-    // Group distable packages by version, if there's only one then use that as the tag
-    let versions = possible_tags(graph, releases.iter().map(|(idx, _)| *idx));
-    if versions.len() == 1 {
-        // Nice, one version, use it
-        let version = *versions.first_key_value().unwrap().0;
-        let tag = format!("v{version}");
-        info!("inferred Announcement tag: {}", tag);
-        announcing.tag = tag;
-        announcing.prerelease = !version.pre.is_empty();
-        announcing.release = ReleaseType::Version(version.clone());
-    } else if needs_coherent_announcement_tag {
-        // More than one version, give the user some suggestions
-        let help = tag_help(
-            graph,
-            versions,
-            "Please either specify --tag, or give them all the same version",
-        );
-        return Err(DistError::TooManyUnrelatedApps { help });
-    } else {
-        // Ok we got more than one version but we're being run by a command
-        // like `init` or `generate` which just wants us to hand it everything
-        // and doesn't care about coherent announcements. So use a fake tag
-        // and hand it the fully unconstrained list of rust_releases.
-        announcing.tag = "v1.0.0-FAKEVER".to_owned();
-        announcing.prerelease = true;
-        announcing.release = ReleaseType::Version("1.0.0-FAKEVER".parse().unwrap());
+    match &settings.tag {
+        TagMode::Select(_) => {
+            unreachable!("internal dist error: tag selection should have picked a tag");
+        }
+        TagMode::Infer => {
+            // Group distable packages by version, if there's only one then use that as the tag
+            let versions = possible_tags(graph, releases.iter().map(|(idx, _)| *idx));
+            if versions.len() == 1 {
+                // Nice, one version, use it
+                let version = *versions.first_key_value().unwrap().0;
+                let tag = format!("v{version}");
+                info!("inferred Announcement tag: {}", tag);
+                *announcing = parse_tag_for_all_packages(graph, &tag)?;
+            } else if settings.needs_coherence {
+                // More than one version, give the user some suggestions
+                let help = tag_help(
+                    graph,
+                    versions,
+                    "Please either specify --tag, or give them all the same version",
+                );
+                return Err(DistError::TooManyUnrelatedApps { help });
+            } else {
+                // Ok we got more than one version but we're being run by a command
+                // like `init` or `generate` which just wants us to hand it everything
+                // and doesn't care about coherent announcements. So use a fake tag
+                // and hand it the fully unconstrained list of rust_releases.
+                //
+                // Note that we (currently) intentionally don't use overwrite_package_versions,
+                // as this mode is intended to be for things like integrity checks
+                "v1.0.0-FAKEVER".clone_into(&mut announcing.tag);
+                announcing.prerelease = true;
+                announcing.release = ReleaseType::Version("1.0.0-FAKEVER".parse().unwrap());
+            }
+        }
+        TagMode::Force(tag) => {
+            // We've been given a tag (presumably from a previous plan step)
+            // to force all distable packages to conform to, mutating their versions to match.
+            //
+            // First, ask axotag to parse the tag for us. It doesn't matter that the version
+            // doesn't match the packages, axotag only uses the list of packages for parsing
+            // the "my-app" prefix out of my-app-v1.0.0. If the tag is just a unified version,
+            // then it will parse that out for us.
+            *announcing = parse_tag_for_all_packages(graph, tag)?;
+            match &announcing.release {
+                ReleaseType::None => {
+                    unreachable!("internal dist error: tag selection should have picked a tag")
+                }
+                ReleaseType::Version(version) => {
+                    // It was indeed a version tag, force all distable packages to have that version
+                    let packages = releases.iter().map(|(idx, _)| *idx);
+                    overwrite_package_versions(graph, packages.clone(), version);
+                }
+                ReleaseType::Package { idx, version } => {
+                    // If this was a package tag, force just that one package to have that version
+                    //
+                    // NOTE: I believe currently axotag will actually error out on an integrity
+                    // check for whether the version actually matches, so this branch is
+                    // probably useless/impossible. However if we ever drop the limit in axotag,
+                    // might as well make this work while we're thinking about this.
+                    //
+                    // ...that said this also probably requires mutating the input `releases` list
+                    overwrite_package_versions(graph, Some(PackageIdx(*idx)), version);
+                }
+            }
+        }
+        TagMode::ForceMax => {
+            // We've just been told to release all distable packages at all cost.
+            //
+            // The biggest issue with this is that they might be different versions,
+            // but we need to make a tag that axotag agrees matches all the packages
+            // we're trying to release (because e.g. axo Releases will check that server-side).
+            //
+            // So we do the following set of transforms to ensure that.
+            let packages = releases.iter().map(|(idx, _)| *idx);
+            // First, get the maximum version of all distable packages, as a way to get
+            // a "reasonable" version. This will work for a fully unified version workspace,
+            // or for a workspace where packages that didn't change are allowed to not bump ver.
+            let mut forced_version = maximum_version(graph, packages.clone()).unwrap();
+            // Add a timestamp buildid to the version so this release is unique and a prerelease.
+            timestamp_version(&mut forced_version);
+            // Overwrite all distable packages to have this new version
+            overwrite_package_versions(graph, packages.clone(), &forced_version);
+            // Make a tag for that version
+            let tag = format!("v{forced_version}");
+            // Ask axotag to make sense of it all
+            *announcing = parse_tag_for_all_packages(graph, &tag)?;
+        }
     }
+
     Ok(())
+}
+
+fn timestamp_version(version: &mut Version) {
+    // Could be optional
+    if version.pre.is_empty() {
+        version.pre = semver::Prerelease::new("alpha").unwrap();
+    }
+    // Could be git commit (but that wouldn't provide chronology well)
+    let now = std::time::SystemTime::now();
+    let secs = now.duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+    // Use chrono for better format?
+    version.build = semver::BuildMetadata::new(&format!("{secs}")).unwrap();
+}
+
+fn maximum_version(
+    graph: &DistGraphBuilder,
+    packages: impl Iterator<Item = PackageIdx>,
+) -> Option<Version> {
+    let mut max_ver = None;
+    for pkg_idx in packages {
+        let version = graph
+            .workspace()
+            .package(pkg_idx)
+            .version
+            .as_ref()
+            .unwrap()
+            .cargo();
+        let Some(cur_max) = &max_ver else {
+            max_ver = Some(version.clone());
+            continue;
+        };
+        if version > cur_max {
+            max_ver = Some(version.clone());
+        }
+    }
+    max_ver
+}
+
+fn overwrite_package_versions(
+    graph: &mut DistGraphBuilder,
+    packages: impl IntoIterator<Item = PackageIdx>,
+    version: &Version,
+) {
+    for pkg_idx in packages {
+        graph.workspace.package_info[pkg_idx.0].version =
+            Some(axoproject::Version::Cargo(version.clone()));
+    }
+}
+
+fn parse_tag_for_all_packages(
+    graph: &DistGraphBuilder,
+    tag: &str,
+) -> DistResult<PartialAnnouncementTag> {
+    // If we're given a specific real tag to use, ask axotag to parse it
+    // and identify which packages are selected by it.
+    let packages: Vec<Package> = graph
+        .workspace()
+        .packages()
+        .map(|(_, info)| Package {
+            name: info.name.clone(),
+            version: info.version.clone().map(|v| v.semver().clone()),
+        })
+        .collect();
+
+    let announcing = parse_tag(&packages, tag)?;
+    Ok(announcing)
 }
 
 /// Get a list of possible version --tags to use, given a list of packages we want to Announce

--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -29,12 +29,12 @@ pub(crate) struct AnnouncementTag {
     pub rust_releases: Vec<(PackageIdx, Vec<String>)>,
 }
 
-/// Settings for [`select_tag`][]
+/// Settings for `select_tag`
 #[derive(Debug, Clone)]
 pub struct TagSettings {
     /// Whether the tag and versions need to be coherent with eachother.
     ///
-    /// If false, [`select_tag`][] is allowed to make up a fake tag/version
+    /// If false, `select_tag` is allowed to make up a fake tag/version
     /// that doesn't need to match the packages.
     ///
     /// This is allowed to be false for commands which are intended to

--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -36,6 +36,8 @@ pub struct GithubCiInfo {
     pub build_local_artifacts: bool,
     /// Whether to make CI get dispatched manually instead of by tag
     pub dispatch_releases: bool,
+    /// Trigger releases on pushes to this branch instead of ci
+    pub release_branch: Option<String>,
     /// Matrix for upload-local-artifacts
     pub artifacts_matrix: cargo_dist_schema::GithubMatrix,
     /// What kind of job to run on pull request
@@ -85,6 +87,7 @@ impl GithubCiInfo {
         let fail_fast = dist.fail_fast;
         let build_local_artifacts = dist.build_local_artifacts;
         let dispatch_releases = dist.dispatch_releases;
+        let release_branch = dist.release_branch.clone();
         let create_release = dist.create_release;
         let github_releases_repo = dist.github_releases_repo.clone().map(|r| r.into_jinja());
         let ssldotcom_windows_sign = dist.ssldotcom_windows_sign.clone();
@@ -168,6 +171,7 @@ impl GithubCiInfo {
             fail_fast,
             build_local_artifacts,
             dispatch_releases,
+            release_branch,
             tap,
             plan_jobs,
             local_artifacts_jobs,

--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -368,7 +368,7 @@ fn package_install_for_targets(
     targets: &Vec<&TargetTriple>,
     packages: &SystemDependencies,
 ) -> Option<String> {
-    // TODO handle mixed-OS targets
+    // FIXME?: handle mixed-OS targets
     for target in targets {
         match target.as_str() {
             "i686-apple-darwin" | "x86_64-apple-darwin" | "aarch64-apple-darwin" => {

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -517,7 +517,7 @@ impl Cli {
             tag: if let Some(tag) = &self.tag {
                 if tag == "timestamp" {
                     assert!(self.force_tag, "TODO");
-                    TagMode::ForceMax
+                    TagMode::ForceMaxAndTimestamp
                 } else if self.force_tag {
                     TagMode::Force(tag.clone())
                 } else {

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -1,6 +1,7 @@
 //! All the clap stuff for parsing/documenting the cli
 
 use camino::Utf8PathBuf;
+use cargo_dist::announce::{TagMode, TagSettings};
 use clap::{
     builder::{PossibleValuesParser, TypedValueParser},
     Args, Parser, Subcommand, ValueEnum,
@@ -103,6 +104,10 @@ pub struct Cli {
     #[clap(long)]
     #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
     pub tag: Option<String>,
+    /// Force package versions to match the tag
+    #[clap(long)]
+    #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
+    pub force_tag: bool,
     /// Allow generated files like CI scripts to be out of date
     #[clap(long)]
     #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
@@ -502,5 +507,25 @@ impl std::fmt::Display for HostingStyle {
             HostingStyle::Axodotdev => "axodotdev",
         };
         string.fmt(f)
+    }
+}
+
+impl Cli {
+    pub fn tag_settings(&self, needs_coherence: bool) -> TagSettings {
+        TagSettings {
+            needs_coherence,
+            tag: if let Some(tag) = &self.tag {
+                if tag == "timestamp" {
+                    assert!(self.force_tag, "TODO");
+                    TagMode::ForceMax
+                } else if self.force_tag {
+                    TagMode::Force(tag.clone())
+                } else {
+                    TagMode::Select(tag.clone())
+                }
+            } else {
+                TagMode::Infer
+            },
+        }
     }
 }

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -516,7 +516,10 @@ impl Cli {
             needs_coherence,
             tag: if let Some(tag) = &self.tag {
                 if tag == "timestamp" {
-                    assert!(self.force_tag, "TODO");
+                    assert!(
+                        self.force_tag,
+                        "--tag=timestamp currently requires --force-tag"
+                    );
                     TagMode::ForceMaxAndTimestamp
                 } else if self.force_tag {
                     TagMode::Force(tag.clone())

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -10,6 +10,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use tracing::log::warn;
 
+use crate::announce::TagSettings;
 use crate::ProjectError;
 use crate::{
     errors::{DistError, DistResult},
@@ -648,10 +649,8 @@ impl DistMetadata {
 /// Global config for commands
 #[derive(Debug, Clone)]
 pub struct Config {
-    /// Whether we need to compute an announcement tag or if we can fudge it
-    ///
-    /// Commands like generate and init don't need announcements, but want to run gather_work
-    pub needs_coherent_announcement_tag: bool,
+    /// Settings for the announcement tag
+    pub tag_settings: TagSettings,
     /// Whether to actually try to side-effectfully create a hosting directory on a server
     ///
     /// this is used for compute_hosting
@@ -668,8 +667,6 @@ pub struct Config {
     pub ci: Vec<CiStyle>,
     /// Installers we want to generate
     pub installers: Vec<InstallerStyle>,
-    /// The (git) tag to use for this Announcement.
-    pub announcement_tag: Option<String>,
     /// What command was being invoked here, used for SystemIds
     pub root_cmd: String,
 }

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -233,6 +233,10 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dispatch_releases: Option<bool>,
 
+    /// Instead of triggering releases on tags, trigger on pushing to a specific branch
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_branch: Option<String>,
+
     /// The strategy to use for selecting a path to install things at:
     ///
     /// * `CARGO_HOME`: (default) install as if cargo did
@@ -388,6 +392,7 @@ impl DistMetadata {
             merge_tasks: _,
             build_local_artifacts: _,
             dispatch_releases: _,
+            release_branch: _,
             install_path: _,
             features: _,
             default_features: _,
@@ -460,6 +465,7 @@ impl DistMetadata {
             fail_fast,
             build_local_artifacts,
             dispatch_releases,
+            release_branch,
             install_path,
             features,
             default_features,
@@ -510,6 +516,9 @@ impl DistMetadata {
         }
         if dispatch_releases.is_some() {
             warn!("package.metadata.dist.dispatch-releases is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
+        }
+        if release_branch.is_some() {
+            warn!("package.metadata.dist.release-branch is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
         }
         if create_release.is_some() {
             warn!("package.metadata.dist.create-release is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -241,6 +241,7 @@ fn get_new_dist_metadata(
             fail_fast: None,
             build_local_artifacts: None,
             dispatch_releases: None,
+            release_branch: None,
             install_path: None,
             features: None,
             default_features: None,
@@ -816,6 +817,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         fail_fast,
         build_local_artifacts,
         dispatch_releases,
+        release_branch,
         install_path,
         features,
         all_features,
@@ -975,6 +977,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "dispatch-releases",
         "# Whether CI should trigger releases with dispatches instead of tag pushes\n",
         *dispatch_releases,
+    );
+
+    apply_optional_value(
+        table,
+        "release-branch",
+        "# Trigger releases on pushes to this branch instead of tag pushes\n",
+        release_branch.as_ref(),
     );
 
     apply_optional_value(

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -324,7 +324,7 @@ fn build_fake(
         }) => generate_fake_source_tarball(dist_graph, committish, prefix, target)?,
         // Or extra artifacts, which may involve real builds
         BuildStep::Extra(target) => run_fake_extra_artifacts_build(dist_graph, target)?,
-        BuildStep::Updater(_) => todo!(),
+        BuildStep::Updater(_) => unimplemented!(),
     }
     Ok(())
 }

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -12,6 +12,7 @@
 
 use std::io::Write;
 
+use announce::{TagMode, TagSettings};
 use axoasset::{LocalAsset, RemoteAsset};
 use axoprocess::Cmd;
 use backend::{
@@ -630,7 +631,10 @@ pub fn check_integrity(cfg: &Config) -> DistResult<()> {
     // so construct a clean copy of config to run the check generate
     let check_config = Config {
         // check the whole system is in a good state
-        needs_coherent_announcement_tag: false,
+        tag_settings: TagSettings {
+            needs_coherence: false,
+            tag: TagMode::Infer,
+        },
         // don't do side-effecting networking
         create_hosting: false,
         artifact_mode: ArtifactMode::All,
@@ -639,7 +643,6 @@ pub fn check_integrity(cfg: &Config) -> DistResult<()> {
         targets: vec![],
         ci: vec![],
         installers: vec![],
-        announcement_tag: None,
         root_cmd: "check".to_owned(),
     };
     let (dist, _manifest) = tasks::gather_work(&check_config)?;

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -191,7 +191,7 @@ fn print_human_linkage(out: &mut Term, report: &DistManifest) -> Result<(), std:
 
 fn cmd_build(cli: &Cli, args: &BuildArgs) -> Result<(), miette::Report> {
     let config = cargo_dist::config::Config {
-        needs_coherent_announcement_tag: true,
+        tag_settings: cli.tag_settings(true),
         create_hosting: false,
         artifact_mode: args.artifacts.to_lib(),
         no_local_paths: cli.no_local_paths,
@@ -199,7 +199,6 @@ fn cmd_build(cli: &Cli, args: &BuildArgs) -> Result<(), miette::Report> {
         targets: cli.target.clone(),
         ci: cli.ci.iter().map(|ci| ci.to_lib()).collect(),
         installers: cli.installer.iter().map(|ins| ins.to_lib()).collect(),
-        announcement_tag: cli.tag.clone(),
         root_cmd: "build".to_owned(),
     };
     let report = do_build(&config)?;
@@ -223,7 +222,7 @@ fn cmd_host(cli: &Cli, args: &HostArgs) -> Result<(), miette::Report> {
         .collect::<Vec<_>>()
         .join(",");
     let config = cargo_dist::config::Config {
-        needs_coherent_announcement_tag: true,
+        tag_settings: cli.tag_settings(true),
         create_hosting: false,
         artifact_mode: config::ArtifactMode::All,
         no_local_paths: true,
@@ -231,7 +230,6 @@ fn cmd_host(cli: &Cli, args: &HostArgs) -> Result<(), miette::Report> {
         targets: cli.target.clone(),
         ci: cli.ci.iter().map(|ci| ci.to_lib()).collect(),
         installers: cli.installer.iter().map(|ins| ins.to_lib()).collect(),
-        announcement_tag: cli.tag.clone(),
         root_cmd: format!("host:{arg_key}"),
     };
 
@@ -241,7 +239,7 @@ fn cmd_host(cli: &Cli, args: &HostArgs) -> Result<(), miette::Report> {
 
 fn cmd_manifest(cli: &Cli, args: &ManifestArgs) -> Result<(), miette::Report> {
     let config = cargo_dist::config::Config {
-        needs_coherent_announcement_tag: true,
+        tag_settings: cli.tag_settings(true),
         create_hosting: false,
         artifact_mode: args.build_args.artifacts.to_lib(),
         no_local_paths: cli.no_local_paths,
@@ -249,7 +247,6 @@ fn cmd_manifest(cli: &Cli, args: &ManifestArgs) -> Result<(), miette::Report> {
         targets: cli.target.clone(),
         ci: cli.ci.iter().map(|ci| ci.to_lib()).collect(),
         installers: cli.installer.iter().map(|ins| ins.to_lib()).collect(),
-        announcement_tag: cli.tag.clone(),
         root_cmd: "plan".to_owned(),
     };
     let report = do_manifest(&config)?;
@@ -273,7 +270,7 @@ fn cmd_plan(cli: &Cli, _args: &PlanArgs) -> Result<(), miette::Report> {
 
 fn cmd_init(cli: &Cli, args: &InitArgs) -> Result<(), miette::Report> {
     let config = cargo_dist::config::Config {
-        needs_coherent_announcement_tag: false,
+        tag_settings: cli.tag_settings(false),
         create_hosting: false,
         artifact_mode: cargo_dist::config::ArtifactMode::All,
         no_local_paths: cli.no_local_paths,
@@ -281,7 +278,6 @@ fn cmd_init(cli: &Cli, args: &InitArgs) -> Result<(), miette::Report> {
         targets: cli.target.clone(),
         ci: cli.ci.iter().map(|ci| ci.to_lib()).collect(),
         installers: cli.installer.iter().map(|ins| ins.to_lib()).collect(),
-        announcement_tag: cli.tag.clone(),
         root_cmd: "init".to_owned(),
     };
     let args = cargo_dist::InitArgs {
@@ -296,7 +292,7 @@ fn cmd_init(cli: &Cli, args: &InitArgs) -> Result<(), miette::Report> {
 
 fn cmd_generate(cli: &Cli, args: &GenerateArgs) -> Result<(), miette::Report> {
     let config = cargo_dist::config::Config {
-        needs_coherent_announcement_tag: false,
+        tag_settings: cli.tag_settings(false),
         create_hosting: false,
         artifact_mode: cargo_dist::config::ArtifactMode::All,
         no_local_paths: cli.no_local_paths,
@@ -304,7 +300,6 @@ fn cmd_generate(cli: &Cli, args: &GenerateArgs) -> Result<(), miette::Report> {
         targets: cli.target.clone(),
         ci: cli.ci.iter().map(|ci| ci.to_lib()).collect(),
         installers: cli.installer.iter().map(|ins| ins.to_lib()).collect(),
-        announcement_tag: cli.tag.clone(),
         root_cmd: "generate".to_owned(),
     };
     let args = cargo_dist::GenerateArgs {
@@ -317,7 +312,7 @@ fn cmd_generate(cli: &Cli, args: &GenerateArgs) -> Result<(), miette::Report> {
 
 fn cmd_linkage(cli: &Cli, args: &LinkageArgs) -> Result<(), miette::Report> {
     let config = cargo_dist::config::Config {
-        needs_coherent_announcement_tag: false,
+        tag_settings: cli.tag_settings(false),
         create_hosting: false,
         artifact_mode: cargo_dist::config::ArtifactMode::All,
         no_local_paths: cli.no_local_paths,
@@ -325,7 +320,6 @@ fn cmd_linkage(cli: &Cli, args: &LinkageArgs) -> Result<(), miette::Report> {
         targets: cli.target.clone(),
         ci: cli.ci.iter().map(|ci| ci.to_lib()).collect(),
         installers: cli.installer.iter().map(|ins| ins.to_lib()).collect(),
-        announcement_tag: cli.tag.clone(),
         root_cmd: "linkage".to_owned(),
     };
     let mut options = cargo_dist::linkage::LinkageArgs {

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -749,7 +749,7 @@ pub enum CargoTargetPackages {
 pub(crate) struct DistGraphBuilder<'pkg_graph> {
     pub(crate) inner: DistGraph,
     pub(crate) manifest: DistManifest,
-    pub(crate) workspace: &'pkg_graph WorkspaceInfo,
+    pub(crate) workspace: &'pkg_graph mut WorkspaceInfo,
     artifact_mode: ArtifactMode,
     binaries_by_id: FastMap<String, BinaryIdx>,
     workspace_metadata: DistMetadata,
@@ -760,7 +760,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
     pub(crate) fn new(
         system_id: SystemId,
         tools: Tools,
-        workspace: &'pkg_graph WorkspaceInfo,
+        workspace: &'pkg_graph mut WorkspaceInfo,
         artifact_mode: ArtifactMode,
         allow_all_dirty: bool,
         announcement_tag_is_implicit: bool,
@@ -2461,7 +2461,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         self.release_mut(release).platform_support = support;
     }
 
-    pub(crate) fn workspace(&self) -> &'pkg_graph WorkspaceInfo {
+    pub(crate) fn workspace(&self) -> &WorkspaceInfo {
         self.workspace
     }
     pub(crate) fn binary(&self, idx: BinaryIdx) -> &Binary {
@@ -2531,7 +2531,7 @@ impl DistGraph {
 pub fn gather_work(cfg: &Config) -> DistResult<(DistGraph, DistManifest)> {
     info!("analyzing workspace:");
     let tools = tool_info()?;
-    let workspace = crate::config::get_project()?;
+    let mut workspace = crate::config::get_project()?;
     let system_id = format!(
         "{}:{}:{}",
         cfg.root_cmd,
@@ -2541,7 +2541,7 @@ pub fn gather_work(cfg: &Config) -> DistResult<(DistGraph, DistManifest)> {
     let mut graph = DistGraphBuilder::new(
         system_id,
         tools,
-        &workspace,
+        &mut workspace,
         cfg.artifact_mode,
         cfg.allow_all_dirty,
         cfg.announcement_tag.is_none(),
@@ -2602,7 +2602,7 @@ pub fn gather_work(cfg: &Config) -> DistResult<(DistGraph, DistManifest)> {
 
     // Figure out what packages we're announcing
     let announcing = announce::select_tag(
-        &graph,
+        &mut graph,
         cfg.announcement_tag.as_deref(),
         cfg.needs_coherent_announcement_tag,
     )?;

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -205,6 +205,8 @@ pub struct DistGraph {
     pub dispatch_releases: bool,
     /// Whether to create a github release or edit an existing draft
     pub create_release: bool,
+    /// Trigger releases with pushes to this branch, instead of tags
+    pub release_branch: Option<String>,
     /// \[unstable\] if Some, sign binaries with ssl.com
     pub ssldotcom_windows_sign: Option<ProductionMode>,
     /// The desired cargo-dist version for handling this project
@@ -790,6 +792,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             fail_fast,
             build_local_artifacts,
             dispatch_releases,
+            release_branch,
             ssldotcom_windows_sign,
             tag_namespace,
             // Partially Processed elsewhere
@@ -870,6 +873,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let create_release = create_release.unwrap_or(true);
         let build_local_artifacts = build_local_artifacts.unwrap_or(true);
         let dispatch_releases = dispatch_releases.unwrap_or(false);
+        let release_branch = release_branch.clone();
         let msvc_crt_static = msvc_crt_static.unwrap_or(true);
         let local_builds_are_lies = artifact_mode == ArtifactMode::Lies;
         let ssldotcom_windows_sign = ssldotcom_windows_sign.clone();
@@ -1038,6 +1042,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 merge_tasks,
                 build_local_artifacts,
                 dispatch_releases,
+                release_branch,
                 create_release,
                 github_releases_repo,
                 ssldotcom_windows_sign,

--- a/cargo-dist/src/tests/tag.rs
+++ b/cargo-dist/src/tests/tag.rs
@@ -7,7 +7,7 @@
 use super::mock::*;
 use semver::Version;
 
-use crate::announce::select_tag;
+use crate::announce::{select_tag, TagMode, TagSettings};
 use crate::{config::ArtifactMode, DistGraphBuilder};
 
 #[test]
@@ -27,7 +27,11 @@ fn parse_one() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -52,7 +56,11 @@ fn parse_one_v() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -77,7 +85,11 @@ fn parse_one_package_v() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -102,7 +114,11 @@ fn parse_one_package() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -127,7 +143,11 @@ fn parse_one_v_alpha() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -152,7 +172,11 @@ fn parse_one_package_v_alpha() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -177,7 +201,11 @@ fn parse_one_prefix_slashv() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -202,7 +230,11 @@ fn parse_one_prefix_slash() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -227,7 +259,11 @@ fn parse_one_prefix_slash_package_v() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -252,7 +288,11 @@ fn parse_one_prefix_slash_package_slashv() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -277,7 +317,11 @@ fn parse_one_package_slashv() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -302,7 +346,11 @@ fn parse_one_prefix_slash_package_slash() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -327,7 +375,11 @@ fn parse_one_prefix_many_slash_package_slash() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -352,7 +404,11 @@ fn parse_one_package_slash() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -377,7 +433,11 @@ fn parse_one_infer() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, None, true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Infer,
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -402,7 +462,11 @@ fn parse_unified_v() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -430,7 +494,11 @@ fn parse_unified_infer() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, None, true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Infer,
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -458,7 +526,11 @@ fn parse_unified_lib() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -483,7 +555,11 @@ fn parse_disjoint_v() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -512,7 +588,11 @@ fn parse_disjoint_infer() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, None, true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Infer,
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -540,7 +620,11 @@ fn parse_disjoint_v_oddball() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -565,7 +649,11 @@ fn parse_disjoint_lib() {
         false,
     )
     .unwrap();
-    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);

--- a/cargo-dist/src/tests/tag.rs
+++ b/cargo-dist/src/tests/tag.rs
@@ -13,21 +13,21 @@ use crate::{config::ArtifactMode, DistGraphBuilder};
 #[test]
 fn parse_one() {
     // "1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -38,21 +38,21 @@ fn parse_one() {
 #[test]
 fn parse_one_v() {
     // "v1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -63,21 +63,21 @@ fn parse_one_v() {
 #[test]
 fn parse_one_package_v() {
     // "axolotlsay-v1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("{BIN_AXO_NAME}-v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -88,21 +88,21 @@ fn parse_one_package_v() {
 #[test]
 fn parse_one_package() {
     // "axolotlsay-1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("{BIN_AXO_NAME}-{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -113,21 +113,21 @@ fn parse_one_package() {
 #[test]
 fn parse_one_v_alpha() {
     // "v1.0.0-prerelease.1" in a one package workspace
-    let workspace = workspace_just_axo_alpha();
+    let mut workspace = workspace_just_axo_alpha();
     let version: Version = BIN_AXO_VER_ALPHA.parse().unwrap();
     let tag = format!("v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -138,21 +138,21 @@ fn parse_one_v_alpha() {
 #[test]
 fn parse_one_package_v_alpha() {
     // "axolotlsay-v1.0.0-prerelease.1" in a one package workspace
-    let workspace = workspace_just_axo_alpha();
+    let mut workspace = workspace_just_axo_alpha();
     let version: Version = BIN_AXO_VER_ALPHA.parse().unwrap();
     let tag = format!("{BIN_AXO_NAME}-v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -163,21 +163,21 @@ fn parse_one_package_v_alpha() {
 #[test]
 fn parse_one_prefix_slashv() {
     // "release/v1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("release/v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -188,21 +188,21 @@ fn parse_one_prefix_slashv() {
 #[test]
 fn parse_one_prefix_slash() {
     // "release/1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("release/{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -213,21 +213,21 @@ fn parse_one_prefix_slash() {
 #[test]
 fn parse_one_prefix_slash_package_v() {
     // "release/axolotlsay-v1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("release/{BIN_AXO_NAME}-v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -238,21 +238,21 @@ fn parse_one_prefix_slash_package_v() {
 #[test]
 fn parse_one_prefix_slash_package_slashv() {
     // "releases/axolotlsay/v1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("releases/{BIN_AXO_NAME}/v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -263,21 +263,21 @@ fn parse_one_prefix_slash_package_slashv() {
 #[test]
 fn parse_one_package_slashv() {
     // "releases/axolotlsay/v1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("{BIN_AXO_NAME}/v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -288,21 +288,21 @@ fn parse_one_package_slashv() {
 #[test]
 fn parse_one_prefix_slash_package_slash() {
     // "releases/axolotlsay/v1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("releases/{BIN_AXO_NAME}/{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -313,21 +313,21 @@ fn parse_one_prefix_slash_package_slash() {
 #[test]
 fn parse_one_prefix_many_slash_package_slash() {
     // "releases/axolotlsay/v1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("blah/blah/releases/{BIN_AXO_NAME}/{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -338,21 +338,21 @@ fn parse_one_prefix_many_slash_package_slash() {
 #[test]
 fn parse_one_package_slash() {
     // "releases/axolotlsay/v1.0.0" in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("{BIN_AXO_NAME}/{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -363,21 +363,21 @@ fn parse_one_package_slash() {
 #[test]
 fn parse_one_infer() {
     // Provide no explicit tag in a one package workspace
-    let workspace = workspace_just_axo();
+    let mut workspace = workspace_just_axo();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, None, true).unwrap();
+    let announcing = select_tag(&mut graph, None, true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -388,21 +388,21 @@ fn parse_one_infer() {
 #[test]
 fn parse_unified_v() {
     // "v1.0.0" in a unified workspace
-    let workspace = workspace_unified();
+    let mut workspace = workspace_unified();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -416,21 +416,21 @@ fn parse_unified_v() {
 #[test]
 fn parse_unified_infer() {
     // Provide no explicit tag in a unified workspace
-    let workspace = workspace_unified();
+    let mut workspace = workspace_unified();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, None, true).unwrap();
+    let announcing = select_tag(&mut graph, None, true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -444,21 +444,21 @@ fn parse_unified_infer() {
 #[test]
 fn parse_unified_lib() {
     // trying to explicitly publish a library in a unified workspace
-    let workspace = workspace_unified();
+    let mut workspace = workspace_unified();
     let version: Version = LIB_SOME_VER.parse().unwrap();
     let tag = format!("{LIB_SOME_NAME}-v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -469,21 +469,21 @@ fn parse_unified_lib() {
 #[test]
 fn parse_disjoint_v() {
     // selecting the bulk packages in a disjoint workspace
-    let workspace = workspace_disjoint();
+    let mut workspace = workspace_disjoint();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -498,21 +498,21 @@ fn parse_disjoint_v() {
 #[should_panic = "TooManyUnrelatedApps"]
 fn parse_disjoint_infer() {
     // Provide no explicit tag in a disjoint workspace (SHOULD FAIL!)
-    let workspace = workspace_disjoint();
+    let mut workspace = workspace_disjoint();
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, None, true).unwrap();
+    let announcing = select_tag(&mut graph, None, true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -526,21 +526,21 @@ fn parse_disjoint_infer() {
 #[test]
 fn parse_disjoint_v_oddball() {
     // selecting the oddball package in a disjoint workspace
-    let workspace = workspace_disjoint();
+    let mut workspace = workspace_disjoint();
     let version: Version = BIN_ODDBALL_VER.parse().unwrap();
     let tag = format!("v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);
@@ -551,21 +551,21 @@ fn parse_disjoint_v_oddball() {
 #[test]
 fn parse_disjoint_lib() {
     // trying to explicitly publish a library in a disjoint workspace
-    let workspace = workspace_disjoint();
+    let mut workspace = workspace_disjoint();
     let version: Version = LIB_OTHER_VER.parse().unwrap();
     let tag = format!("{LIB_OTHER_NAME}-v{version}");
 
     let tools = mock_tools();
-    let graph = DistGraphBuilder::new(
+    let mut graph = DistGraphBuilder::new(
         "a".to_owned(),
         tools,
-        &workspace,
+        &mut workspace,
         ArtifactMode::All,
         true,
         false,
     )
     .unwrap();
-    let announcing = select_tag(&graph, Some(&tag), true).unwrap();
+    let announcing = select_tag(&mut graph, Some(&tag), true).unwrap();
 
     assert!(!announcing.prerelease);
     assert_eq!(announcing.tag, tag);

--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -27,13 +27,17 @@ name: Release
 permissions:
   contents: write
 
-{{%- if dispatch_releases %}}
+{{%- if release_branch %}}
+
+# This task will run whenever you push to {{{ release_branch }}}
+{{%- else %}}
+  {{%- if dispatch_releases %}}
 
 # This task will run whenever you workflow_dispatch with a tag that looks like a version
-{{%- else %}}
+  {{%- else %}}
 
 # This task will run whenever you push a git tag that looks like a version
-{{%- endif %}}
+  {{%- endif %}}
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
 # Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
@@ -54,6 +58,7 @@ permissions:
 #
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
+{{%- endif %}}
 on:
   {{%- if dispatch_releases %}}
   workflow_dispatch:
@@ -63,6 +68,10 @@ on:
         required: true
         default: dry-run
         type: string
+  {{%- elif release_branch %}}
+  push:
+    branches:
+      - {{{ release_branch }}}
   {{%- else %}}
   push:
     tags:
@@ -82,6 +91,10 @@ jobs:
       tag: ${{ (inputs.tag != 'dry-run' && inputs.tag) || '' }}
       tag-flag: ${{ inputs.tag && inputs.tag != 'dry-run' && format('--tag={0}', inputs.tag) || '' }}
       publishing: ${{ inputs.tag && inputs.tag != 'dry-run' }}
+      {{%- elif release_branch %}}
+      tag: ${{ steps.plan.outputs.tag }}
+      tag-flag: ${{ steps.plan.outputs.tag-flag }}
+      publishing: ${{ !github.event.pull_request }}
       {{%- else %}}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
       tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
@@ -114,6 +127,7 @@ jobs:
         run: |
           cargo dist
           {{%- if dispatch_releases %}} ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag))
+          {{%- elif release_branch %}} ${{ (!github.event.pull_request && 'host --steps=create')
           {{%- else %}} ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name))
           {{%- endif %}}
           {{%- if "axodotdev" in hosting_providers %}} || (env.AXO_RELEASES_TOKEN && 'host --steps=check') {{%- endif %}}
@@ -121,6 +135,10 @@ jobs:
           echo "cargo dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          {{%- if release_branch %}}
+          echo "tag=TODO" >> "$GITHUB_OUTPUT"
+          echo "tag-flag=TODO" >> "$GITHUB_OUTPUT"
+          {{%- endif %}}
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v4
         with:
@@ -590,6 +608,13 @@ jobs:
         {{%- endif %}}
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
+    {{%- elif workflow_dispatch or release_branch %}}
+      # TODO: if github releases are disabled AND we're using a non-tag-first workflow,
+      # then we're responsible for creating and pushing the tag!
+      - name: "tag commit"
+        run: |
+          git tag ${{ needs.plan.outputs.tag }}
+          git push origin tag ${{ needs.plan.outputs.tag }}
     {{%- endif %}}
 
 {{%- for job in post_announce_jobs %}}

--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -60,6 +60,9 @@ permissions:
 # will be marked as a prerelease.
 {{%- endif %}}
 on:
+  {{%- if pr_run_mode != "skip" %}}
+  pull_request:
+  {{%- endif %}}
   {{%- if dispatch_releases %}}
   workflow_dispatch:
     inputs:
@@ -73,17 +76,13 @@ on:
     branches:
       - {{{ release_branch }}}
 
-# don't let multiple instances of this run at the same time
+# don't let multiple instances of this run at the same time on the release branch
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   {{%- else %}}
   push:
     tags:
       - '{{%- if tag_namespace %}}{{{ tag_namespace | safe }}}{{%- endif %}}**[0-9]+.[0-9]+.[0-9]+*'
-  {{%- endif %}}
-  {{%- if pr_run_mode != "skip" %}}
-  pull_request:
   {{%- endif %}}
 
 jobs:
@@ -132,7 +131,7 @@ jobs:
         run: |
           cargo dist
           {{%- if dispatch_releases %}} ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag))
-          {{%- elif release_branch %}} ${{ (!github.event.pull_request && 'host --steps=create --tag=timestamp')
+          {{%- elif release_branch %}} ${{ (!github.event.pull_request && 'host --steps=create --tag=timestamp --force-tag')
           {{%- else %}} ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name))
           {{%- endif %}}
           {{%- if "axodotdev" in hosting_providers %}} || (env.AXO_RELEASES_TOKEN && 'host --steps=check') {{%- endif %}}
@@ -141,8 +140,8 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
           {{%- if release_branch %}}
-          echo "tag=TODO" >> "$GITHUB_OUTPUT"
-          echo "tag-flag=TODO" >> "$GITHUB_OUTPUT"
+          echo "tag=$(jq --raw-output ".announcement_tag" plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          echo "tag-flag=--tag=$(jq --raw-output ".announcement_tag" plan-dist-manifest.json) --force-tag" >> "$GITHUB_OUTPUT"
           {{%- endif %}}
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v4

--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -72,6 +72,11 @@ on:
   push:
     branches:
       - {{{ release_branch }}}
+
+# don't let multiple instances of this run at the same time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
   {{%- else %}}
   push:
     tags:
@@ -127,7 +132,7 @@ jobs:
         run: |
           cargo dist
           {{%- if dispatch_releases %}} ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag))
-          {{%- elif release_branch %}} ${{ (!github.event.pull_request && 'host --steps=create')
+          {{%- elif release_branch %}} ${{ (!github.event.pull_request && 'host --steps=create --tag=timestamp')
           {{%- else %}} ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name))
           {{%- endif %}}
           {{%- if "axodotdev" in hosting_providers %}} || (env.AXO_RELEASES_TOKEN && 'host --steps=check') {{%- endif %}}
@@ -608,13 +613,6 @@ jobs:
         {{%- endif %}}
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"
-    {{%- elif workflow_dispatch or release_branch %}}
-      # TODO: if github releases are disabled AND we're using a non-tag-first workflow,
-      # then we're responsible for creating and pushing the tag!
-      - name: "tag commit"
-        run: |
-          git tag ${{ needs.plan.outputs.tag }}
-          git push origin tag ${{ needs.plan.outputs.tag }}
     {{%- endif %}}
 
 {{%- for job in post_announce_jobs %}}

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -392,12 +392,10 @@ installers = ["shell", "powershell", "homebrew", "npm"]
 tap = "axodotdev/homebrew-packages"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
 ci = ["github"]
-hosting = ["axodotdev"]
 unix-archive = ".tar.gz"
 windows-archive = ".tar.gz"
 npm-scope = "@axodotdev"
 npm-package = "coolbeans"
-release-branch = "production"
 
 "#
         ))?;

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -362,6 +362,7 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows
 ci = ["github"]
 build-local-artifacts = false
 local-artifacts-jobs = ["./local-artifacts"]
+release-branch = "production"
 
 "#
         ))?;
@@ -391,10 +392,12 @@ installers = ["shell", "powershell", "homebrew", "npm"]
 tap = "axodotdev/homebrew-packages"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
 ci = ["github"]
+hosting = ["axodotdev"]
 unix-archive = ".tar.gz"
 windows-archive = ".tar.gz"
 npm-scope = "@axodotdev"
 npm-package = "coolbeans"
+release-branch = "production"
 
 "#
         ))?;

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -1498,7 +1498,7 @@ windows-archive = ".tar.gz"
 }
 
 #[test]
-#[should_panic(expected = r#"you have no packages in your workspace with"#)]
+#[should_panic(expected = r#"no packages"#)]
 fn axoasset_basic() {
     // This is just a library so we should error with a helpful message
     let test_name = _function_name!();

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1747,10 +1747,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1314,10 +1314,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1761,10 +1761,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1775,10 +1775,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1787,10 +1787,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3245,10 +3245,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3237,10 +3237,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3252,10 +3252,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3250,10 +3250,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3236,10 +3236,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3322,10 +3322,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -382,10 +382,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -311,10 +311,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3225,10 +3225,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -309,6 +309,7 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       tag:
@@ -316,7 +317,6 @@ on:
         required: true
         default: dry-run
         type: string
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -318,6 +318,7 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       tag:
@@ -325,7 +326,6 @@ on:
         required: true
         default: dry-run
         type: string
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -310,6 +310,7 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       tag:
@@ -317,7 +318,6 @@ on:
         required: true
         default: dry-run
         type: string
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3210,10 +3210,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3238,10 +3238,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2769,10 +2769,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2716,10 +2716,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -23,12 +23,12 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload}"
+ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -47,7 +47,7 @@ axolotlsay-installer.sh
 The installer for axolotlsay 0.2.2
 
 This script detects what platform you're on and fetches an appropriate archive from
-https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload
+https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2
 then unpacks the binaries and installs them to
 
     \$CARGO_HOME/bin (or \$HOME/.cargo/bin)
@@ -974,15 +974,15 @@ class Axolotlsay < Formula
   version "0.2.2"
   if OS.mac?
     if Hardware::CPU.arm?
-      url "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz"
     end
     if Hardware::CPU.intel?
-      url "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz"
     end
   end
   if OS.linux?
     if Hardware::CPU.intel?
-      url "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
     end
   end
   license "MIT OR Apache-2.0"
@@ -1041,7 +1041,7 @@ The installer for axolotlsay 0.2.2
 .DESCRIPTION
 
 This script detects what platform you're on and fetches an appropriate archive from
-https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload
+https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2
 then unpacks the binaries and installs them to
 
     $env:CARGO_HOME/bin (or $HOME/.cargo/bin)
@@ -1061,7 +1061,7 @@ Print help
 
 param (
     [Parameter(HelpMessage = "The URL of the directory where artifacts can be fetched from")]
-    [string]$ArtifactDownloadUrl = 'https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload',
+    [string]$ArtifactDownloadUrl = 'https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2',
     [Parameter(HelpMessage = "Don't add the install directory to PATH")]
     [switch]$NoModifyPath,
     [Parameter(HelpMessage = "Print Help")]
@@ -1072,7 +1072,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -2708,7 +2708,7 @@ install(false);
 }
 ================ npm-package.tar.gz/package/package.json ================
 {
-  "artifactDownloadUrl": "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload",
+  "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
   "bin": {
     "axolotlsay": "run-axolotlsay.js"
@@ -2802,6 +2802,7 @@ maybeInstall(true).then(() => run("axolotlsay"));
   "announcement_is_prerelease": false,
   "announcement_title": "Version 0.2.2",
   "announcement_changelog": "```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```",
+  "announcement_github_body": "## Release Notes\n\n```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Install axolotlsay 0.2.2\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\npowershell -c \"irm https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.ps1 | iex\"\n```\n\n### Install prebuilt binaries via Homebrew\n\n```sh\nbrew install axodotdev/packages/axolotlsay\n```\n\n### Install prebuilt binaries into your npm project\n\n```sh\nnpm install @axodotdev/coolbeans@0.2.2\n```\n\n## Download axolotlsay 0.2.2\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256) |\n\n",
   "releases": [
     {
       "app_name": "axolotlsay",
@@ -2823,13 +2824,8 @@ maybeInstall(true).then(() => run("axolotlsay"));
         "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256"
       ],
       "hosting": {
-        "axodotdev": {
-          "package": "axolotlsay",
-          "public_id": "fake-id-do-not-upload",
-          "set_download_url": "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload",
-          "upload_url": null,
-          "release_url": null,
-          "announce_url": null
+        "github": {
+          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2"
         }
       }
     }
@@ -2885,7 +2881,7 @@ maybeInstall(true).then(() => run("axolotlsay"));
         "aarch64-pc-windows-msvc",
         "x86_64-pc-windows-msvc"
       ],
-      "install_hint": "powershell -c \"irm https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-installer.ps1 | iex\"",
+      "install_hint": "powershell -c \"irm https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.ps1 | iex\"",
       "description": "Install prebuilt binaries via powershell script"
     },
     "axolotlsay-installer.sh": {
@@ -2897,7 +2893,7 @@ maybeInstall(true).then(() => run("axolotlsay"));
         "x86_64-pc-windows-gnu",
         "x86_64-unknown-linux-gnu"
       ],
-      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-installer.sh | sh",
+      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.sh | sh",
       "description": "Install prebuilt binaries via shell script"
     },
     "axolotlsay-npm-package.tar.gz": {
@@ -3182,23 +3178,42 @@ maybeInstall(true).then(() => run("axolotlsay"));
 # * checks for a Git Tag that looks like a release
 # * builds artifacts with cargo-dist (archives, installers, hashes)
 # * uploads those artifacts to temporary workflow zip
-# * on success, uploads the artifacts to Axo Releases and makes an Announcement
+# * on success, uploads the artifacts to a GitHub Release
+#
+# Note that the GitHub Release will be created with a generated
+# title/body based on your changelogs.
 
 name: Release
 
 permissions:
   contents: write
 
-# This task will run whenever you push to "production"
+# This task will run whenever you push a git tag that looks like a version
+# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
+# PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
+# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
+#
+# If PACKAGE_NAME is specified, then the announcement will be for that
+# package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
+#
+# If PACKAGE_NAME isn't specified, then the announcement will be for all
+# (cargo-dist-able) packages in the workspace with that version (this mode is
+# intended for workspaces with only one dist-able package, or with all dist-able
+# packages versioned/released in lockstep).
+#
+# If you push multiple tags at once, separate instances of this workflow will
+# spin up, creating an independent announcement for each one. However, GitHub
+# will hard limit this to 3 tags per commit, as it will assume more tags is a
+# mistake.
+#
+# If there's a prerelease-style suffix to the version, then the release(s)
+# will be marked as a prerelease.
 on:
   pull_request:
   push:
-    branches:
-      - "production"
-
-# don't let multiple instances of this run at the same time on the release branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    tags:
+      - '**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do
@@ -3206,12 +3221,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ steps.plan.outputs.tag }}
-      tag-flag: ${{ steps.plan.outputs.tag-flag }}
+      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
+      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
       publishing: ${{ !github.event.pull_request }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -3228,12 +3242,10 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && 'host --steps=create --tag=timestamp --force-tag') || (env.AXO_RELEASES_TOKEN && 'host --steps=check') || 'plan' }} --output-format=json > plan-dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "cargo dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
-          echo "tag=$(jq --raw-output ".announcement_tag" plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
-          echo "tag-flag=--tag=$(jq --raw-output ".announcement_tag" plan-dist-manifest.json) --force-tag" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v4
         with:
@@ -3354,16 +3366,7 @@ jobs:
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
-  # Uploads the artifacts to Axo Releases and tentatively creates Releases for them.
-  # This makes perma URLs like /v1.0.0/ live for subsequent publish steps to use, but
-  # leaves them "disconnected" from the release history (for the purposes of
-  # "list the releases" or "give me the latest releases").
-  #
-  # If all the subsequent "publish" steps succeed, the "announce" job will "connect"
-  # the releases and concepts like "latest" will be updated. Otherwise you're hopefully
-  # in a decent position to roll back the release without anyone noticing it!
-  # This is imperfect with things like "publish to crates.io" being irreversible, but
-  # at worst you're in a better position to yank the version with minimum disruption.
+  # Determines if we should publish/announce
   host:
     needs:
       - plan
@@ -3373,7 +3376,6 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     runs-on: "ubuntu-20.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
@@ -3390,7 +3392,7 @@ jobs:
           pattern: artifacts-*
           path: target/distrib/
           merge-multiple: true
-      # Upload files to Axo Releases and create the Releases
+      # This is a harmless no-op for GitHub Releases, hosting for that happens in "announce"
       - id: host
         shell: bash
         run: |
@@ -3405,7 +3407,7 @@ jobs:
           name: artifacts-dist-manifest
           path: dist-manifest.json
 
-  # Create an Announcement for all the Axo Releases, updating the "latest" release
+  # Create a GitHub Release while uploading all files to it
   announce:
     needs:
       - plan
@@ -3417,19 +3419,25 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-      - name: Fetch Axo Artifacts
+      - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@v4
         with:
           pattern: artifacts-*
-          path: target/distrib/
+          path: artifacts
           merge-multiple: true
-      - name: Announce Axo Releases
+      - name: Cleanup
         run: |
-          cargo dist host --steps=announce ${{ needs.plan.outputs.tag-flag }}
+          # Remove the granular manifests
+          rm -f artifacts/*-dist-manifest.json
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ needs.plan.outputs.tag }}
+          name: ${{ fromJson(needs.host.outputs.val).announcement_title }}
+          body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
+          prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
+          artifacts: "artifacts/*"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3191,14 +3191,14 @@ permissions:
 
 # This task will run whenever you push to "production"
 on:
+  pull_request:
   push:
     branches:
       - "production"
 
-# don't let multiple instances of this run at the same time
+# don't let multiple instances of this run at the same time on the release branch
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  pull_request:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do
@@ -3228,12 +3228,12 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && 'host --steps=create --tag=timestamp') || (env.AXO_RELEASES_TOKEN && 'host --steps=check') || 'plan' }} --output-format=json > plan-dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && 'host --steps=create --tag=timestamp --force-tag') || (env.AXO_RELEASES_TOKEN && 'host --steps=check') || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "cargo dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
-          echo "tag=TODO" >> "$GITHUB_OUTPUT"
-          echo "tag-flag=TODO" >> "$GITHUB_OUTPUT"
+          echo "tag=$(jq --raw-output ".announcement_tag" plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          echo "tag-flag=--tag=$(jq --raw-output ".announcement_tag" plan-dist-manifest.json) --force-tag" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v4
         with:

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -23,12 +23,12 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -47,7 +47,7 @@ axolotlsay-installer.sh
 The installer for axolotlsay 0.2.2
 
 This script detects what platform you're on and fetches an appropriate archive from
-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2
+https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload
 then unpacks the binaries and installs them to
 
     \$CARGO_HOME/bin (or \$HOME/.cargo/bin)
@@ -974,15 +974,15 @@ class Axolotlsay < Formula
   version "0.2.2"
   if OS.mac?
     if Hardware::CPU.arm?
-      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz"
+      url "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-aarch64-apple-darwin.tar.gz"
     end
     if Hardware::CPU.intel?
-      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz"
+      url "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-x86_64-apple-darwin.tar.gz"
     end
   end
   if OS.linux?
     if Hardware::CPU.intel?
-      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
     end
   end
   license "MIT OR Apache-2.0"
@@ -1041,7 +1041,7 @@ The installer for axolotlsay 0.2.2
 .DESCRIPTION
 
 This script detects what platform you're on and fetches an appropriate archive from
-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2
+https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload
 then unpacks the binaries and installs them to
 
     $env:CARGO_HOME/bin (or $HOME/.cargo/bin)
@@ -1061,7 +1061,7 @@ Print help
 
 param (
     [Parameter(HelpMessage = "The URL of the directory where artifacts can be fetched from")]
-    [string]$ArtifactDownloadUrl = 'https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2',
+    [string]$ArtifactDownloadUrl = 'https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload',
     [Parameter(HelpMessage = "Don't add the install directory to PATH")]
     [switch]$NoModifyPath,
     [Parameter(HelpMessage = "Print Help")]
@@ -1072,7 +1072,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -2708,7 +2708,7 @@ install(false);
 }
 ================ npm-package.tar.gz/package/package.json ================
 {
-  "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
+  "artifactDownloadUrl": "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload",
   "author": "axodotdev <hello@axo.dev>",
   "bin": {
     "axolotlsay": "run-axolotlsay.js"
@@ -2802,7 +2802,6 @@ maybeInstall(true).then(() => run("axolotlsay"));
   "announcement_is_prerelease": false,
   "announcement_title": "Version 0.2.2",
   "announcement_changelog": "```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```",
-  "announcement_github_body": "## Release Notes\n\n```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Install axolotlsay 0.2.2\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\npowershell -c \"irm https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.ps1 | iex\"\n```\n\n### Install prebuilt binaries via Homebrew\n\n```sh\nbrew install axodotdev/packages/axolotlsay\n```\n\n### Install prebuilt binaries into your npm project\n\n```sh\nnpm install @axodotdev/coolbeans@0.2.2\n```\n\n## Download axolotlsay 0.2.2\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256) |\n\n",
   "releases": [
     {
       "app_name": "axolotlsay",
@@ -2824,8 +2823,13 @@ maybeInstall(true).then(() => run("axolotlsay"));
         "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256"
       ],
       "hosting": {
-        "github": {
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2"
+        "axodotdev": {
+          "package": "axolotlsay",
+          "public_id": "fake-id-do-not-upload",
+          "set_download_url": "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload",
+          "upload_url": null,
+          "release_url": null,
+          "announce_url": null
         }
       }
     }
@@ -2881,7 +2885,7 @@ maybeInstall(true).then(() => run("axolotlsay"));
         "aarch64-pc-windows-msvc",
         "x86_64-pc-windows-msvc"
       ],
-      "install_hint": "powershell -c \"irm https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.ps1 | iex\"",
+      "install_hint": "powershell -c \"irm https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-installer.ps1 | iex\"",
       "description": "Install prebuilt binaries via powershell script"
     },
     "axolotlsay-installer.sh": {
@@ -2893,7 +2897,7 @@ maybeInstall(true).then(() => run("axolotlsay"));
         "x86_64-pc-windows-gnu",
         "x86_64-unknown-linux-gnu"
       ],
-      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.sh | sh",
+      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload/axolotlsay-installer.sh | sh",
       "description": "Install prebuilt binaries via shell script"
     },
     "axolotlsay-npm-package.tar.gz": {
@@ -3178,41 +3182,18 @@ maybeInstall(true).then(() => run("axolotlsay"));
 # * checks for a Git Tag that looks like a release
 # * builds artifacts with cargo-dist (archives, installers, hashes)
 # * uploads those artifacts to temporary workflow zip
-# * on success, uploads the artifacts to a GitHub Release
-#
-# Note that the GitHub Release will be created with a generated
-# title/body based on your changelogs.
+# * on success, uploads the artifacts to Axo Releases and makes an Announcement
 
 name: Release
 
 permissions:
   contents: write
 
-# This task will run whenever you push a git tag that looks like a version
-# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
-# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
-# PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
-# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
-#
-# If PACKAGE_NAME is specified, then the announcement will be for that
-# package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
-#
-# If PACKAGE_NAME isn't specified, then the announcement will be for all
-# (cargo-dist-able) packages in the workspace with that version (this mode is
-# intended for workspaces with only one dist-able package, or with all dist-able
-# packages versioned/released in lockstep).
-#
-# If you push multiple tags at once, separate instances of this workflow will
-# spin up, creating an independent announcement for each one. However, GitHub
-# will hard limit this to 3 tags per commit, as it will assume more tags is a
-# mistake.
-#
-# If there's a prerelease-style suffix to the version, then the release(s)
-# will be marked as a prerelease.
+# This task will run whenever you push to "production"
 on:
   push:
-    tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+    branches:
+      - "production"
   pull_request:
 
 jobs:
@@ -3221,11 +3202,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
+      tag: ${{ steps.plan.outputs.tag }}
+      tag-flag: ${{ steps.plan.outputs.tag-flag }}
       publishing: ${{ !github.event.pull_request }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -3242,10 +3224,12 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && 'host --steps=create') || (env.AXO_RELEASES_TOKEN && 'host --steps=check') || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "cargo dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          echo "tag=TODO" >> "$GITHUB_OUTPUT"
+          echo "tag-flag=TODO" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v4
         with:
@@ -3366,7 +3350,16 @@ jobs:
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
-  # Determines if we should publish/announce
+  # Uploads the artifacts to Axo Releases and tentatively creates Releases for them.
+  # This makes perma URLs like /v1.0.0/ live for subsequent publish steps to use, but
+  # leaves them "disconnected" from the release history (for the purposes of
+  # "list the releases" or "give me the latest releases").
+  #
+  # If all the subsequent "publish" steps succeed, the "announce" job will "connect"
+  # the releases and concepts like "latest" will be updated. Otherwise you're hopefully
+  # in a decent position to roll back the release without anyone noticing it!
+  # This is imperfect with things like "publish to crates.io" being irreversible, but
+  # at worst you're in a better position to yank the version with minimum disruption.
   host:
     needs:
       - plan
@@ -3376,6 +3369,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     runs-on: "ubuntu-20.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
@@ -3392,7 +3386,7 @@ jobs:
           pattern: artifacts-*
           path: target/distrib/
           merge-multiple: true
-      # This is a harmless no-op for GitHub Releases, hosting for that happens in "announce"
+      # Upload files to Axo Releases and create the Releases
       - id: host
         shell: bash
         run: |
@@ -3407,7 +3401,7 @@ jobs:
           name: artifacts-dist-manifest
           path: dist-manifest.json
 
-  # Create a GitHub Release while uploading all files to it
+  # Create an Announcement for all the Axo Releases, updating the "latest" release
   announce:
     needs:
       - plan
@@ -3419,25 +3413,25 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AXO_RELEASES_TOKEN: ${{ secrets.AXO_RELEASES_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: "Download GitHub Artifacts"
+      - name: Install cargo-dist
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+      - name: Fetch Axo Artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: artifacts-*
-          path: artifacts
+          path: target/distrib/
           merge-multiple: true
-      - name: Cleanup
+      - name: Announce Axo Releases
         run: |
-          # Remove the granular manifests
-          rm -f artifacts/*-dist-manifest.json
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ needs.plan.outputs.tag }}
-          name: ${{ fromJson(needs.host.outputs.val).announcement_title }}
-          body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
-          prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
-          artifacts: "artifacts/*"
+          cargo dist host --steps=announce ${{ needs.plan.outputs.tag-flag }}
+      # TODO: if github releases are disabled AND we're using a non-tag-first workflow,
+      # then we're responsible for creating and pushing the tag!
+      - name: "tag commit"
+        run: |
+          git tag ${{ needs.plan.outputs.tag }}
+          git push origin tag ${{ needs.plan.outputs.tag }}

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3194,6 +3194,10 @@ on:
   push:
     branches:
       - "production"
+
+# don't let multiple instances of this run at the same time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
   pull_request:
 
 jobs:
@@ -3224,7 +3228,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && 'host --steps=create') || (env.AXO_RELEASES_TOKEN && 'host --steps=check') || 'plan' }} --output-format=json > plan-dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && 'host --steps=create --tag=timestamp') || (env.AXO_RELEASES_TOKEN && 'host --steps=check') || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "cargo dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -3429,9 +3433,3 @@ jobs:
       - name: Announce Axo Releases
         run: |
           cargo dist host --steps=announce ${{ needs.plan.outputs.tag-flag }}
-      # TODO: if github releases are disabled AND we're using a non-tag-first workflow,
-      # then we're responsible for creating and pushing the tag!
-      - name: "tag commit"
-        run: |
-          git tag ${{ needs.plan.outputs.tag }}
-          git push origin tag ${{ needs.plan.outputs.tag }}

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -309,10 +309,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -292,6 +292,10 @@ on:
   push:
     branches:
       - "production"
+
+# don't let multiple instances of this run at the same time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
   pull_request:
 
 jobs:
@@ -321,7 +325,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && 'host --steps=create') || 'plan' }} --output-format=json > plan-dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && 'host --steps=create --tag=timestamp') || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "cargo dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -287,31 +287,11 @@ name: Release
 permissions:
   contents: write
 
-# This task will run whenever you push a git tag that looks like a version
-# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
-# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
-# PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
-# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
-#
-# If PACKAGE_NAME is specified, then the announcement will be for that
-# package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
-#
-# If PACKAGE_NAME isn't specified, then the announcement will be for all
-# (cargo-dist-able) packages in the workspace with that version (this mode is
-# intended for workspaces with only one dist-able package, or with all dist-able
-# packages versioned/released in lockstep).
-#
-# If you push multiple tags at once, separate instances of this workflow will
-# spin up, creating an independent announcement for each one. However, GitHub
-# will hard limit this to 3 tags per commit, as it will assume more tags is a
-# mistake.
-#
-# If there's a prerelease-style suffix to the version, then the release(s)
-# will be marked as a prerelease.
+# This task will run whenever you push to "production"
 on:
   push:
-    tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+    branches:
+      - "production"
   pull_request:
 
 jobs:
@@ -320,8 +300,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
+      tag: ${{ steps.plan.outputs.tag }}
+      tag-flag: ${{ steps.plan.outputs.tag-flag }}
       publishing: ${{ !github.event.pull_request }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -341,10 +321,12 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && 'host --steps=create') || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "cargo dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          echo "tag=TODO" >> "$GITHUB_OUTPUT"
+          echo "tag-flag=TODO" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v4
         with:

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -289,14 +289,14 @@ permissions:
 
 # This task will run whenever you push to "production"
 on:
+  pull_request:
   push:
     branches:
       - "production"
 
-# don't let multiple instances of this run at the same time
+# don't let multiple instances of this run at the same time on the release branch
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  pull_request:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do
@@ -325,12 +325,12 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && 'host --steps=create --tag=timestamp') || 'plan' }} --output-format=json > plan-dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && 'host --steps=create --tag=timestamp --force-tag') || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "cargo dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
-          echo "tag=TODO" >> "$GITHUB_OUTPUT"
-          echo "tag-flag=TODO" >> "$GITHUB_OUTPUT"
+          echo "tag=$(jq --raw-output ".announcement_tag" plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          echo "tag-flag=--tag=$(jq --raw-output ".announcement_tag" plan-dist-manifest.json) --force-tag" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v4
         with:

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3254,10 +3254,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1693,10 +1693,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1693,10 +1693,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -309,10 +309,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - 'owo**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3276,10 +3276,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3210,10 +3210,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3210,10 +3210,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3210,10 +3210,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3210,10 +3210,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3210,10 +3210,10 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/cargo-dist/tests/snapshots/long-help.snap
+++ b/cargo-dist/tests/snapshots/long-help.snap
@@ -90,6 +90,9 @@ GLOBAL OPTIONS:
           
           In the future we may try to make this look at the current git tags or something?
 
+      --force-tag
+          Force package versions to match the tag
+
       --allow-dirty
           Allow generated files like CI scripts to be out of date
 

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -92,6 +92,9 @@ If you do not specify this tag we will attempt to infer it by trying to Announce
 
 In the future we may try to make this look at the current git tags or something?
 
+#### `--force-tag`
+Force package versions to match the tag
+
 #### `--allow-dirty`
 Allow generated files like CI scripts to be out of date
 

--- a/cargo-dist/tests/snapshots/short-help.snap
+++ b/cargo-dist/tests/snapshots/short-help.snap
@@ -31,6 +31,7 @@ GLOBAL OPTIONS:
   -i, --installer <INSTALLER>          Installers we want to build [possible values: shell, powershell, npm, homebrew, msi]
   -c, --ci <CI>                        CI we want to support [possible values: github]
       --tag <TAG>                      The (git) tag to use for the Announcement that each invocation of cargo-dist is performing
+      --force-tag                      Force package versions to match the tag
       --allow-dirty                    Allow generated files like CI scripts to be out of date
 
 stderr:


### PR DESCRIPTION
This lets you specify pushing to a branch at all should trigger a release

* [x] fill in TODOs in template
* [x] write docs
* [x] come up with some way for the "plan" step to decide on a tag/version that all other steps have to agree on (in particular with a `-alpha+{timestamp}` suffix).
  * possibly this extra detail is an extra config?
  * [x] come up with a way to force-rewrite the Cargo.tomls to use that version 
    * refuse to support non-unified-version workspaces..? (cargo-dist's CI refuses to acknowledge the idea of multiple tags coming out of a single workflow run) 
* [x] debounce the workflow??? (using the gitops queue thing we do for our own production branches)
  * ostensibly users of this don't want one tag/release per commit, and just want to release "the latest"   