### PR TITLE
Update release.yml to remove extraneous command line options for cURL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.13.3/cargo-dist-installer.sh | sh"
+        run: "curl -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.13.3/cargo-dist-installer.sh | sh"
       # sure would be cool if github gave us proper conditionals...
       # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
       # functionality based on whether this is a pull_request, and whether it's from a fork.


### PR DESCRIPTION
Remove protocol switch because this is already specified in the URL with HTTPS.

Remove TLS version specificity, to allow for cURL to determine which TLS version to use based on compile-time support.

There's no real reason to have either of these in here unless you're solving for a problem that exists. To my knowledge, there is no problems with cURL determining the highest supported TLS version.