### PR TITLE
tests: use github token for updater

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
     env:
       # runtest the installer scripts
       RUIN_MY_COMPUTER_WITH_INSTALLERS: true
+      CARGO_DIST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       # Test the cross-product of these platforms+toolchains
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "axoupdater"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639ef3c97d1bebfb42f94739036fbe3e10ef0056d2f8d5ea288bf4ad5f73a5e6"
+checksum = "88381a1fce59b27e7539869ead01226f69ada31218974e1bf0d79c43b91e1867"
 dependencies = [
  "axoasset",
  "axoprocess",

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { version = "1.0.116", optional = true }
 console = { version = "0.15.8", optional = true }
 clap-cargo = { version = "0.14.0", optional = true }
 axocli = { version = "0.2.0", optional = true }
-axoupdater = { version = "0.5.1", optional = true }
+axoupdater = { version = "0.6.0", optional = true }
 
 # Features used by the cli and library
 axotag = "0.2.0"

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -602,6 +602,10 @@ async fn cmd_update(_config: &Cli, args: &cli::UpdateArgs) -> Result<(), miette:
         updater.configure_installer_path(path);
     }
 
+    if let Ok(token) = std::env::var("CARGO_DIST_GITHUB_TOKEN") {
+        updater.set_github_token(&token);
+    }
+
     // Do we want to treat this as an error?
     // Or do we want to sniff if this was a Homebrew installation?
     if updater.load_receipt().is_err() {


### PR DESCRIPTION
This should improve our flaky tests by using a token with a higher set of requests instead of unauthorized requests. Our tests have a pretty artificial environment where we perform a large number of requests in a very short amount of time, unlike real-world environments, so these rate limits weren't representative of real-world usage.

Requires https://github.com/axodotdev/axoupdater/pull/98.