### PR TITLE
fix: overwrite existing links

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -421,7 +421,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -449,7 +449,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -443,7 +443,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_repo_with_dot_git.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -455,7 +455,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -443,7 +443,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -443,7 +443,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -449,7 +449,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -449,7 +449,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -443,7 +443,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -431,7 +431,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -416,7 +416,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -416,7 +416,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -416,7 +416,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -416,7 +416,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -426,7 +426,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -416,7 +416,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -416,7 +416,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -416,7 +416,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -416,7 +416,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ installer.sh ================
@@ -426,7 +426,7 @@ install() {
         # unzip seems to need this chmod
         ensure chmod +x "$_install_dir/$_bin_name"
         for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
-            ln -s "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
     done


### PR DESCRIPTION
While the powershell version did this, the shell installer didn't.

Fixes #996.