### PR TITLE
fix: use non-reserved SECRET name for github-releases-repo

### DIFF
--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -327,7 +327,7 @@ pub struct DistMetadata {
 
     /// Publish GitHub Releases to this repo instead of the current one
     ///
-    /// The user must also set GITHUB_RELEASES_TOKEN in their SECRETS
+    /// The user must also set GH_RELEASES_TOKEN in their SECRETS
     #[serde(skip_serializing_if = "Option::is_none")]
     pub github_releases_repo: Option<GithubRepoPair>,
 

--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -576,7 +576,7 @@ jobs:
         {{%- if github_releases_repo %}}
           owner: {{{ github_releases_repo.owner }}}
           repo: {{{ github_releases_repo.repo }}}
-          token: ${{ secrets.GITHUB_RELEASES_TOKEN }}
+          token: ${{ secrets.GH_RELEASES_TOKEN }}
         {{%- endif %}}
           tag: ${{ needs.plan.outputs.tag }}
         {{%- if create_release %}}

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -1,5 +1,5 @@
 ---
-source: cargo-dist/tests/gallery/dist.rs
+source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ dist-manifest.json ================
@@ -463,7 +463,7 @@ jobs:
         with:
           owner: "custom-owner"
           repo: "cool-repo"
-          token: ${{ secrets.GITHUB_RELEASES_TOKEN }}
+          token: ${{ secrets.GH_RELEASES_TOKEN }}
           tag: ${{ needs.plan.outputs.tag }}
           name: ${{ fromJson(needs.host.outputs.val).announcement_title }}
           body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}


### PR DESCRIPTION
and clarify behaviour in docs.