### PR TITLE
chore: update npm tar

### DIFF
--- a/cargo-dist/templates/installer/npm/npm-shrinkwrap.json
+++ b/cargo-dist/templates/installer/npm/npm-shrinkwrap.json
@@ -14,7 +14,7 @@
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -372,9 +372,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -584,27 +584,19 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/tunnel": {

--- a/cargo-dist/templates/installer/npm/package.json
+++ b/cargo-dist/templates/installer/npm/package.json
@@ -23,7 +23,7 @@
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "devDependencies": {
     "prettier": "^3.2.5"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1995,7 +1995,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2360,9 +2360,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2572,7 +2572,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2580,17 +2580,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2733,7 +2725,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1994,7 +1994,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2359,9 +2359,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2571,7 +2571,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2579,17 +2579,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2731,7 +2723,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1983,7 +1983,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2348,9 +2348,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2560,7 +2560,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2568,17 +2568,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2720,7 +2712,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1569,7 +1569,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -1934,9 +1934,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2146,7 +2146,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2154,17 +2154,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2306,7 +2298,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1569,7 +1569,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -1934,9 +1934,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2146,7 +2146,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2154,17 +2154,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2306,7 +2298,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1996,7 +1996,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2361,9 +2361,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2573,7 +2573,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2581,17 +2581,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2735,7 +2727,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1988,7 +1988,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2353,9 +2353,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2565,7 +2565,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2573,17 +2573,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2725,7 +2717,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1980,7 +1980,7 @@ install(false);
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
         "rimraf": "^5.0.5",
-        "tar": "^7.0.1"
+        "tar": "^7.1.0"
       },
       "devDependencies": {
         "prettier": "^3.2.5"
@@ -2345,9 +2345,9 @@ install(false);
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "version": "7.0.4"
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/minizlib": {
       "dependencies": {
@@ -2557,7 +2557,7 @@ install(false);
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -2565,17 +2565,9 @@ install(false);
       "engines": {
         "node": ">=18"
       },
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "version": "7.0.1"
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "engines": {
-        "node": ">=8"
-      },
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "version": "5.0.0"
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "version": "7.1.0"
     },
     "node_modules/tunnel": {
       "engines": {
@@ -2717,7 +2709,7 @@ install(false);
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
     "rimraf": "^5.0.5",
-    "tar": "^7.0.1"
+    "tar": "^7.1.0"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {


### PR DESCRIPTION
Same as dependabot's PR, but with snapshots regenerated.

Closes #1010.