### PR TITLE
feat: allow specifying external commit from submodule

### DIFF
--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -420,7 +420,11 @@ GitHub Releases isn't really designed for this, so there's a few strange things 
 
 * GitHub Releases will provide a source tarball pointing at the tagged commit on `myorg/public`, but that's (presumably) not the source that your release was actually built from. This cannot be disabled, but it's also essentially harmless. However **cargo-dist uploads its own source tarball and that *WILL* contain the source of the private repo**. If you don't want this, use [the `source-tarball = false` setting](#source-tarball).
 
-In the future we'll introduce some mechanism for identifying a git submodule where the commit on `myorg/public` should be sourced from, as we expect that to be a common usecase for these kinds of remote releases.
+### github-releases-submodule-path
+
+> since 0.15.0
+
+Designed for use with `github-releases-repo` above. When specified, the cached commit of the submodule at this path will be used as the commit to tag in the target repository. If not specified, the latest commit in the target repository will be used instead.
 
 
 ### global-artifacts-jobs

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -144,6 +144,10 @@ pub struct GithubCiInfo {
     /// What kind of job to run on pull request
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pr_run_mode: Option<PrRunMode>,
+
+    /// A specific commit to tag in an external repository
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_repo_commit: Option<String>,
 }
 
 /// Github CI Matrix

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -534,6 +534,13 @@ expression: json_schema
             }
           ]
         },
+        "external_repo_commit": {
+          "description": "A specific commit to tag in an external repository",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "pr_run_mode": {
           "description": "What kind of job to run on pull request",
           "anyOf": [

--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -60,7 +60,7 @@ pub struct GithubCiInfo {
     pub post_announce_jobs: Vec<String>,
     /// whether to create the release or assume an existing one
     pub create_release: bool,
-    /// whether to prefix release.yml and the tag pattern
+    /// external repo to release to
     pub github_releases_repo: Option<JinjaGithubRepoPair>,
     /// \[unstable\] whether to add ssl.com windows binary signing
     pub ssldotcom_windows_sign: Option<ProductionMode>,

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -331,6 +331,11 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub github_releases_repo: Option<GithubRepoPair>,
 
+    /// If github-releases-repo is used, the commit ref to used will
+    /// be read from the HEAD of the submodule at this path
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub github_releases_submodule_path: Option<String>,
+
     /// \[unstable\] Whether we should sign windows binaries with ssl.com
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ssldotcom_windows_sign: Option<ProductionMode>,
@@ -412,6 +417,7 @@ impl DistMetadata {
             tag_namespace: _,
             install_updater: _,
             github_releases_repo: _,
+            github_releases_submodule_path: _,
         } = self;
         if let Some(include) = include {
             for include in include {
@@ -484,6 +490,7 @@ impl DistMetadata {
             tag_namespace,
             install_updater,
             github_releases_repo,
+            github_releases_submodule_path,
         } = self;
 
         // Check for global settings on local packages
@@ -516,6 +523,9 @@ impl DistMetadata {
         }
         if github_releases_repo.is_some() {
             warn!("package.metadata.dist.github-releases-repo is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
+        }
+        if github_releases_submodule_path.is_some() {
+            warn!("package.metadata.dist.github-releases-submodule-path is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
         }
         // Arguably should be package-local for things like msi installers, but doesn't make sense for CI,
         // so let's not support that yet for its complexity!

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -280,6 +280,14 @@ pub enum DistError {
     #[diagnostic(help("This is probably not your fault, please file an issue!"))]
     GitArchiveError {},
 
+    /// An error running `git -C path rev-parse HEAD`
+    #[error("We failed to query information about the git submodule at {path}")]
+    #[diagnostic(help("Does a submodule exist at that path? Has it been fetched with `git submodule update --init`?"))]
+    GitSubmoduleCommitError {
+        /// The path we failed to fetch
+        path: String,
+    },
+
     /// A required tool is missing
     #[error("{tool}, required to run this task, is missing")]
     #[diagnostic(help("Ensure {tool} is installed"))]

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -255,6 +255,7 @@ fn get_new_dist_metadata(
             publish_prereleases: None,
             create_release: None,
             github_releases_repo: None,
+            github_releases_submodule_path: None,
             pr_run_mode: None,
             allow_dirty: None,
             ssldotcom_windows_sign: None,
@@ -830,6 +831,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         publish_prereleases,
         create_release,
         github_releases_repo,
+        github_releases_submodule_path,
         pr_run_mode,
         allow_dirty,
         ssldotcom_windows_sign,
@@ -989,6 +991,15 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "github-releases-repo",
         "# Publish GitHub Releases to this repo instead\n",
         github_releases_repo.as_ref().map(|a| a.to_string()),
+    );
+
+    apply_optional_value(
+        table,
+        "github-releases-submodule-path",
+        "# Read the commit to be tagged from the submodule at this path\n",
+        github_releases_submodule_path
+            .as_ref()
+            .map(|a| a.to_string()),
     );
 
     apply_string_or_list(

--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -577,6 +577,7 @@ jobs:
           owner: {{{ github_releases_repo.owner }}}
           repo: {{{ github_releases_repo.repo }}}
           token: ${{ secrets.GH_RELEASES_TOKEN }}
+          commit: ${{ fromJson(needs.host.outputs.val).ci.github.external_repo_commit }}
         {{%- endif %}}
           tag: ${{ needs.plan.outputs.tag }}
         {{%- if create_release %}}

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -464,6 +464,7 @@ jobs:
           owner: "custom-owner"
           repo: "cool-repo"
           token: ${{ secrets.GH_RELEASES_TOKEN }}
+          commit: ${{ fromJson(needs.host.outputs.val).ci.github.external_repo_commit }}
           tag: ${{ needs.plan.outputs.tag }}
           name: ${{ fromJson(needs.host.outputs.val).announcement_title }}
           body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}


### PR DESCRIPTION
This is the companion to [`github-releases-repo`](https://opensource.axo.dev/cargo-dist/book/reference/config.html#github-releases-repo); when targeting creating a commit in an external repo, where that repo is also checked out as a submodule of the repository in which the release is being run, this lets you consult the latest commit of that submodule and use that commit as the tag instead of whatever happens to be the latest commit in that repository.