### PR TITLE
fix: repair and cleanup npm binary caching

### DIFF
--- a/cargo-dist/templates/installer/npm/binary-install.js
+++ b/cargo-dist/templates/installer/npm/binary-install.js
@@ -57,7 +57,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {

--- a/cargo-dist/templates/installer/npm/binary.js
+++ b/cargo-dist/templates/installer/npm/binary.js
@@ -113,17 +113,6 @@ const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
 
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
-
   package.run(binaryName, proxy);
 };
 

--- a/cargo-dist/templates/installer/npm/run.js.j2
+++ b/cargo-dist/templates/installer/npm/run.js.j2
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run({{ bin }}));
-
+const { run } = require("./binary");
+run({{ bin }});

--- a/cargo-dist/tests/gallery/dist/npm.rs
+++ b/cargo-dist/tests/gallery/dist/npm.rs
@@ -10,6 +10,7 @@ impl DistResult {
         {
             return Ok(());
         }
+
         // only do this if the formula exists
         let Some(package_tarball_path) = &self.npm_installer_package_path else {
             return Ok(());
@@ -23,7 +24,6 @@ impl DistResult {
         } else {
             package_tarball_path.to_owned()
         };
-
         // Only do this if npm and tar are installed
         let (Some(npm), Some(tar)) = (&ctx.tools.npm, &ctx.tools.tar) else {
             return Ok(());

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1787,7 +1787,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1978,17 +1985,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2823,8 +2819,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1787,7 +1787,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1978,17 +1985,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2821,8 +2817,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1776,7 +1776,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1967,17 +1974,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2810,8 +2806,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1354,7 +1354,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1545,17 +1552,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2381,8 +2377,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1354,7 +1354,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1545,17 +1552,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2381,8 +2377,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1787,7 +1787,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1978,17 +1985,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2825,8 +2821,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1781,7 +1781,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1972,17 +1979,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2815,8 +2811,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1773,7 +1773,14 @@ class Package {
   }
 
   exists() {
-    return existsSync(this.binaryPath);
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   install(fetchOptions, suppressLogs = false) {
@@ -1964,17 +1971,6 @@ const install = (suppressLogs) => {
 const run = (binaryName) => {
   const package = getPackage();
   const proxy = configureProxy(package.url);
-
-  // If no binaryName is specified, and there's one that matches the app, use that
-  if (!binaryName && package.binaries[name]) {
-    binaryName = name;
-  }
-
-  // If no binaryName is specified and there's only one binary, use that
-  const binNames = Object.keys(package.binaries);
-  if (!binaryName && binNames.length == 1) {
-    binaryName = binNames[0];
-  }
 
   package.run(binaryName, proxy);
 };
@@ -2807,8 +2803,8 @@ install(false);
 ================ npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require("./binary");
-maybeInstall(true).then(() => run("axolotlsay"));
+const { run } = require("./binary");
+run("axolotlsay");
 
 ================ dist-manifest.json ================
 {


### PR DESCRIPTION
* this.binaryPath no longer exists, which was causing us to refetch every time
* Package.run already calls Package.install as a subroutine, there's no need to call it again and duplicate the work (potentially we could also remove that, but hey integrity checks are nice?)
* The additional logic in run to select a binary to call was an artifact of development, and never actually ran (trivially provable by nothing ever omitting the argument) (this logic is performed by npx itself because we populated package.json's 'bins')