### PR TITLE
feat: allow always marking releases as stable

### DIFF
--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -389,6 +389,17 @@ formula to match the bin name as opposed to the app name (which, in Rust, is the
 
 You must set this on `[package.metadata.dist]` and not `[workspace.metadata.dist]`.
 
+### force-latest
+
+> since 0.15.0
+
+Overrides cargo-dist's default handling of prerelease versions. Ordinarily, cargo-dist uses [semver](https://semver.org) rules to determine if a version number is a prerelease or not and has some special handling if it is. With this setting, cargo-dist will always consider a version to be stable no matter what its version number is. This affects a few things:
+
+* If cargo-dist interprets a version as a prerelease, it will publish it to GitHub as a "prerelease" instead of the "latest" release.
+* cargo-dist will not publish prereleases to [Homebrew][homebrew-installer] or [npm][npm installers] by default.
+
+See also the ["publish-prereleases"](#publish-prereleases) setting.
+
 ### github-custom-runners
 
 > since 0.6.0

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -89,6 +89,9 @@ pub struct DistManifest {
     /// Whether to publish prereleases to package managers
     #[serde(default)]
     pub publish_prereleases: bool,
+    /// Where possible, announce/publish a release as "latest" regardless of semver version
+    #[serde(default)]
+    pub force_stable: bool,
     /// ci backend info
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -439,6 +442,7 @@ impl DistManifest {
             systems: Default::default(),
             assets: Default::default(),
             publish_prereleases: false,
+            force_stable: false,
             ci: None,
             linkage: vec![],
             upload_files: vec![],

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -78,6 +78,11 @@ expression: json_schema
         "null"
       ]
     },
+    "force_stable": {
+      "description": "Where possible, announce/publish a release as \"latest\" regardless of semver version",
+      "default": false,
+      "type": "boolean"
+    },
     "linkage": {
       "description": "Data about dynamic linkage in the built libraries",
       "default": [],

--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -255,11 +255,19 @@ pub(crate) fn select_tag(
         }
     }
 
+    // Ignoring whatever we calculated, mark it as stable if the
+    // user asked us to.
+    let prerelease = if graph.manifest.force_stable {
+        false
+    } else {
+        announcing.prerelease
+    };
+
     Ok(AnnouncementTag {
         tag: announcing.tag,
         version,
         package,
-        prerelease: announcing.prerelease,
+        prerelease,
         rust_releases: releases,
     })
 }

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -319,6 +319,18 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publish_prereleases: Option<bool>,
 
+    /// Always regard releases as stable
+    ///
+    /// (defaults to false)
+    ///
+    /// Ordinarily, cargo-dist tries to detect if your release
+    /// is a prerelease based on its version number using
+    /// semver standards. If it's a prerelease, it will be
+    /// marked as a prerelease in hosting services such as
+    /// GitHub and Axo Releases.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_stable: Option<bool>,
+
     /// Whether we should create the Github Release for you when you push a tag.
     ///
     /// If true (default), cargo-dist will create a new Github Release and generate
@@ -411,6 +423,7 @@ impl DistMetadata {
             publish_jobs: _,
             post_announce_jobs: _,
             publish_prereleases: _,
+            force_stable: _,
             create_release: _,
             pr_run_mode: _,
             allow_dirty: _,
@@ -485,6 +498,7 @@ impl DistMetadata {
             publish_jobs,
             post_announce_jobs,
             publish_prereleases,
+            force_stable,
             create_release,
             pr_run_mode,
             allow_dirty,
@@ -544,6 +558,9 @@ impl DistMetadata {
         }
         if publish_prereleases.is_some() {
             warn!("package.metadata.dist.publish-prereleases is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
+        }
+        if force_stable.is_some() {
+            warn!("package.metadata.dist.force-stable is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
         }
         if pr_run_mode.is_some() {
             warn!("package.metadata.dist.pr-run-mode is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -254,6 +254,7 @@ fn get_new_dist_metadata(
             publish_jobs: None,
             post_announce_jobs: None,
             publish_prereleases: None,
+            force_stable: None,
             create_release: None,
             github_releases_repo: None,
             github_releases_submodule_path: None,
@@ -831,6 +832,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         publish_jobs,
         post_announce_jobs,
         publish_prereleases,
+        force_stable,
         create_release,
         github_releases_repo,
         github_releases_submodule_path,
@@ -1093,6 +1095,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "publish-prereleases",
         "# Whether to publish prereleases to package managers\n",
         *publish_prereleases,
+    );
+
+    apply_optional_value(
+        table,
+        "always-publish-as-stable",
+        "# Always mark releases as stable, ignoring semver semantics\n",
+        *force_stable,
     );
 
     apply_optional_value(

--- a/cargo-dist/src/manifest.rs
+++ b/cargo-dist/src/manifest.rs
@@ -76,6 +76,7 @@ pub(crate) fn load_and_merge_manifests(
             announcement_changelog: _,
             announcement_github_body: _,
             publish_prereleases: _,
+            force_stable: _,
             upload_files: _,
             artifacts,
             releases,

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -850,6 +850,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             // Only the final value merged into a package_config matters
             post_announce_jobs: _,
             publish_prereleases,
+            force_stable,
             features,
             default_features,
             all_features,
@@ -1018,6 +1019,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             })
             .collect();
         let publish_prereleases = publish_prereleases.unwrap_or(false);
+        let force_stable = force_stable.unwrap_or(false);
 
         let allow_dirty = if allow_all_dirty {
             DirtyMode::AllowAll
@@ -1098,6 +1100,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 systems,
                 assets: Default::default(),
                 publish_prereleases,
+                force_stable,
                 ci: None,
                 linkage: vec![],
                 upload_files: vec![],

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1710,6 +1710,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1253,6 +1253,7 @@ download_binary_and_run_installer "$@" || exit 1
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1724,6 +1724,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1738,6 +1738,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1750,6 +1750,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3203,6 +3203,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3199,6 +3199,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3211,6 +3211,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3209,6 +3209,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3195,6 +3195,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3281,6 +3281,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -297,6 +297,7 @@ end
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -224,6 +224,7 @@ expression: self.payload
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3184,6 +3184,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -224,6 +224,7 @@ expression: self.payload
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -232,6 +232,7 @@ expression: self.payload
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -228,6 +228,7 @@ expression: self.payload
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3169,6 +3169,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3195,6 +3195,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2704,6 +2704,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2659,6 +2659,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3169,6 +3169,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -224,6 +224,7 @@ expression: self.payload
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -224,6 +224,7 @@ expression: self.payload
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3213,6 +3213,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1656,6 +1656,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1656,6 +1656,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -224,6 +224,7 @@ expression: self.payload
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3235,6 +3235,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3169,6 +3169,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3169,6 +3169,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3169,6 +3169,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3169,6 +3169,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3169,6 +3169,7 @@ run("axolotlsay");
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1703,6 +1703,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1679,6 +1679,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1679,6 +1679,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1679,6 +1679,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1679,6 +1679,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1698,6 +1698,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1679,6 +1679,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1679,6 +1679,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1679,6 +1679,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1679,6 +1679,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1698,6 +1698,7 @@ try {
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -37,6 +37,7 @@ stdout:
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {},

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -37,6 +37,7 @@ stdout:
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {},

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -419,6 +419,7 @@ stdout:
     }
   },
   "publish_prereleases": false,
+  "force_stable": false,
   "ci": {
     "github": {
       "artifacts_matrix": {


### PR DESCRIPTION
This adds a new feature which allows users to override our "is this a prerelease" detection.

By default, we use semver mechanics to determine whether a release is a prerelease or not. If it contains anything within the "pre" part of the version number, we mark it as a prerelease. This has several consequences: we won't mark that release as the latest on GitHub, and we won't publish it to sources like Homebrew. This adds a new config flag, `always-publish-as-stable`; if set, then we always count the release as stable at publish time regardless of what the version number says.