### PR TITLE
feat: vendor GitHub actions

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -2,24 +2,43 @@
 //!
 //! In the future this may get split up into submodules.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
-use axoasset::LocalAsset;
+use axoasset::{LocalAsset, RemoteAsset};
+use camino::Utf8PathBuf;
 use cargo_dist_schema::{GithubMatrix, GithubMatrixEntry};
 use serde::Serialize;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::{
     backend::{diff_files, templates::TEMPLATE_CI_GITHUB},
     config::{
-        DependencyKind, HostingStyle, JinjaGithubRepoPair, ProductionMode, SystemDependencies,
+        DependencyKind, GithubRepoPair, HostingStyle, JinjaGithubRepoPair, ProductionMode,
+        SystemDependencies,
     },
+    create_tmp,
     errors::DistResult,
     DistGraph, SortedMap, SortedSet, TargetTriple,
 };
 
+const GITHUB_ACTIONS_DIR: &str = ".github/actions/";
 const GITHUB_CI_DIR: &str = ".github/workflows/";
 const GITHUB_CI_FILE: &str = "release.yml";
+
+// These represent the latest revision of each vendored action's
+// floating tags at the time of vendoring.
+const GITHUB_VENDORED_DOWNLOAD_ARTIFACT_REPO: &str = "actions/download-artifact";
+// Floating tag: v4
+const GITHUB_VENDORED_DOWNLOAD_ARTIFACT_REVISION: &str = "65a9edc5881444af0b9093a5e628f2fe47ea3b2e";
+const GITHUB_VENDORED_RELEASE_REPO: &str = "ncipollo/release-action";
+// Floating tag: v1
+const GITHUB_VENDORED_RELEASE_REVISION: &str = "2c591bcc8ecdcd2db72b97d6147f871fcd833ba5";
+const GITHUB_VENDORED_RUST_CACHE_REPO: &str = "Swatinem/rust-cache";
+// Floating tag: v2
+const GITHUB_VENDORED_RUST_CACHE_REVISION: &str = "23bce251a8cd2ffc3c1075eaa2367cf899916d84";
+const GITHUB_VENDORED_UPLOAD_ARTIFACT_REPO: &str = "actions/upload-artifact";
+// Floating tag: v4
+const GITHUB_VENDORED_UPLOAD_ARTIFACT_REVISION: &str = "65462800fd760344b1a7b4382951275a0abb4808";
 
 /// Info about running cargo-dist in Github CI
 #[derive(Debug, Serialize)]
@@ -70,6 +89,8 @@ pub struct GithubCiInfo {
     pub hosting_providers: Vec<HostingStyle>,
     /// whether to prefix release.yml and the tag pattern
     pub tag_namespace: Option<String>,
+    /// whether to vendor all external actions
+    pub vendor_actions: bool,
 }
 
 impl GithubCiInfo {
@@ -193,6 +214,7 @@ impl GithubCiInfo {
             github_releases_repo,
             ssldotcom_windows_sign,
             hosting_providers,
+            vendor_actions: dist.vendor_workflow_deps,
         }
     }
 
@@ -217,10 +239,49 @@ impl GithubCiInfo {
         Ok(rendered)
     }
 
+    fn all_vendored_actions(&self) -> &[(&str, &str)] {
+        &[
+            (
+                GITHUB_VENDORED_DOWNLOAD_ARTIFACT_REPO,
+                GITHUB_VENDORED_DOWNLOAD_ARTIFACT_REVISION,
+            ),
+            (
+                GITHUB_VENDORED_RELEASE_REPO,
+                GITHUB_VENDORED_RELEASE_REVISION,
+            ),
+            (
+                GITHUB_VENDORED_RUST_CACHE_REPO,
+                GITHUB_VENDORED_RUST_CACHE_REVISION,
+            ),
+            (
+                GITHUB_VENDORED_UPLOAD_ARTIFACT_REPO,
+                GITHUB_VENDORED_UPLOAD_ARTIFACT_REVISION,
+            ),
+        ]
+    }
+
+    /// Generate and write the vendored actions to disk
+    pub fn write_vendored_actions(&self, dist: &DistGraph) -> DistResult<()> {
+        let path = dist.workspace_dir.join(GITHUB_ACTIONS_DIR);
+
+        for (repo, revision) in self.all_vendored_actions() {
+            vendor_repo(
+                &path,
+                &GithubRepoPair::from_str(repo).expect("failed to parse string?!"),
+                revision,
+            )?;
+        }
+
+        Ok(())
+    }
+
     /// Write release.yml to disk
     pub fn write_to_disk(&self, dist: &DistGraph) -> DistResult<()> {
         let ci_file = self.github_ci_path(dist);
         let rendered = self.generate_github_ci(dist)?;
+        if dist.vendor_workflow_deps {
+            self.write_vendored_actions(dist)?;
+        }
 
         LocalAsset::write_new_all(&rendered, &ci_file)?;
         eprintln!("generated Github CI to {}", ci_file);
@@ -236,6 +297,35 @@ impl GithubCiInfo {
         let rendered = self.generate_github_ci(dist)?;
         diff_files(&ci_file, &rendered)
     }
+}
+
+fn vendor_repo(root: &Utf8PathBuf, repo: &GithubRepoPair, revision: &str) -> DistResult<()> {
+    let url = format!("https://github.com/{repo}/archive/{revision}.tar.gz");
+
+    let repo_path = root.join(&repo.repo);
+    // If we're updating an existing vendored copy, remove it before
+    // cloning a new copy.
+    if repo_path.exists() {
+        LocalAsset::remove_dir_all(&repo_path)?;
+    }
+
+    info!("Vendoring action {}@{}", repo, revision);
+    let handle = tokio::runtime::Handle::current();
+    let bytes = handle.block_on(RemoteAsset::load_bytes(&url))?;
+
+    let (_tmp_dir, tmp_root) = create_tmp()?;
+    let artifact_file = tmp_root.join(format!("{revision}.tar.gz"));
+    std::fs::write(&artifact_file, bytes)?;
+
+    // This will produce a base directory named reponame-revision,
+    // which we'll need to rename to the desired target.
+    // If we were using the CLI tar tool, we'd just be able to
+    // pass `--strip-components`, but the tar crate doesn't have
+    // that feature.
+    LocalAsset::untar_gz_all(&artifact_file, root)?;
+    std::fs::rename(root.join(format!("{}-{}", repo.repo, revision)), repo_path)?;
+
+    Ok(())
 }
 
 /// Given a set of targets we want to build local artifacts for, map them to Github Runners

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -65,6 +65,13 @@ pub struct DistMetadata {
     #[serde(default, with = "opt_string_or_vec")]
     pub ci: Option<Vec<CiStyle>>,
 
+    /// Vendor external dependencies for CI workflows, such as external GitHub actions.
+    ///
+    /// This will substantially increase the size of your
+    /// repository, but may be desirable in some security contexts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vendor_workflow_deps: Option<bool>,
+
     /// Which actions to run on pull requests.
     ///
     /// "upload" will build and upload release artifacts, while "plan" will
@@ -393,6 +400,7 @@ impl DistMetadata {
             rust_toolchain_version: _,
             dist: _,
             ci: _,
+            vendor_workflow_deps: _,
             installers: _,
             tap: _,
             formula: _,
@@ -468,6 +476,7 @@ impl DistMetadata {
             rust_toolchain_version,
             dist,
             ci,
+            vendor_workflow_deps,
             installers,
             tap,
             formula,
@@ -523,6 +532,9 @@ impl DistMetadata {
         }
         if ci.is_some() {
             warn!("package.metadata.dist.ci is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
+        }
+        if vendor_workflow_deps.is_some() {
+            warn!("package.metadata.dist.vendor-workflow-deps is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
         }
         if precise_builds.is_some() {
             warn!("package.metadata.dist.precise-builds is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -223,6 +223,7 @@ fn get_new_dist_metadata(
             // deprecated, default to not emitting it
             rust_toolchain_version: None,
             ci: None,
+            vendor_workflow_deps: None,
             installers: None,
             tap: None,
             formula: None,
@@ -802,6 +803,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         rust_toolchain_version,
         dist,
         ci,
+        vendor_workflow_deps,
         installers,
         tap,
         formula,
@@ -863,6 +865,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
     );
 
     apply_string_or_list(table, "ci", "# CI backends to support\n", ci.as_ref());
+
+    apply_optional_value(
+        table,
+        "vendor-workflow-deps",
+        "# Whether to vendor all external workflow dependencies when generating CI config (default false)\n",
+        *vendor_workflow_deps,
+    );
 
     apply_string_list(
         table,

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -274,6 +274,8 @@ pub struct DistGraph {
     pub github_releases_repo: Option<config::GithubRepoPair>,
     /// Read the commit to be tagged from the submodule at this path
     pub github_releases_submodule_path: Option<String>,
+    /// Whether to vendor all external actions
+    pub vendor_workflow_deps: bool,
 }
 
 /// Info about artifacts should be hosted
@@ -810,6 +812,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             // after this function, seems like we should finish the job..? (Doing a big
             // refactor already, don't want to mess with this right now.)
             ci,
+            vendor_workflow_deps,
             // Only the final value merged into a package_config matters
             //
             // Note that we do *use* an auto-include from the workspace when doing
@@ -879,6 +882,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         if desired_rust_toolchain.is_some() {
             warn!("rust-toolchain-version is deprecated, use rust-toolchain.toml if you want pinned toolchains");
         }
+        let vendor_workflow_deps = vendor_workflow_deps.unwrap_or(false);
         let merge_tasks = merge_tasks.unwrap_or(false);
         let fail_fast = fail_fast.unwrap_or(false);
         let create_release = create_release.unwrap_or(true);
@@ -1099,6 +1103,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     .clone()
                     .unwrap_or_default(),
                 install_updater: install_updater.unwrap_or_default(),
+                vendor_workflow_deps,
             },
             manifest: DistManifest {
                 dist_version: Some(env!("CARGO_PKG_VERSION").to_owned()),

--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -144,7 +144,7 @@ jobs:
           echo "tag-flag=--tag=$(jq --raw-output ".announcement_tag" plan-dist-manifest.json) --force-tag" >> "$GITHUB_OUTPUT"
           {{%- endif %}}
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: {{% if vendor_actions %}}./.github/actions/upload-artifact{{% else %}}actions/upload-artifact@v4{{% endif %}}
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -204,14 +204,14 @@ jobs:
       - name: Install Rust
         run: rustup update {{{ rust_version }}} --no-self-update && rustup default {{{ rust_version }}}
       {{%- endif %}}
-      - uses: swatinem/rust-cache@v2
+      - uses: {{% if vendor_actions %}}./.github/actions/rust-cache{{% else %}}swatinem/rust-cache@v2{{% endif %}}
         with:
           key: ${{ join(matrix.targets, '-') }}
       - name: Install cargo-dist
         run: ${{ matrix.install_dist }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: {{% if vendor_actions %}}./.github/actions/download-artifact{{% else %}}actions/download-artifact@v4{{% endif %}}
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -238,7 +238,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: {{% if vendor_actions %}}./.github/actions/upload-artifact{{% else %}}actions/upload-artifact@v4{{% endif %}}
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -290,7 +290,7 @@ jobs:
         run: {{{ global_task.install_dist }}}
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: {{% if vendor_actions %}}./.github/actions/download-artifact{{% else %}}actions/download-artifact@v4{{% endif %}}
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -308,7 +308,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: {{% if vendor_actions %}}./.github/actions/upload-artifact{{% else %}}actions/upload-artifact@v4{{% endif %}}
         with:
           name: artifacts-build-global
           path: |
@@ -385,7 +385,7 @@ jobs:
         run: {{{ global_task.install_dist }}}
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v4
+        uses: {{% if vendor_actions %}}./.github/actions/download-artifact{{% else %}}actions/download-artifact@v4{{% endif %}}
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -404,7 +404,7 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: {{% if vendor_actions %}}./.github/actions/upload-artifact{{% else %}}actions/upload-artifact@v4{{% endif %}}
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
@@ -510,7 +510,7 @@ jobs:
       - name: Install cargo-dist
         run: {{{ global_task.install_dist }}}
       - name: Fetch Axo Artifacts
-        uses: actions/download-artifact@v4
+        uses: {{% if vendor_actions %}}./.github/actions/download-artifact{{% else %}}actions/download-artifact@v4{{% endif %}}
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -521,7 +521,7 @@ jobs:
     {{%- endif %}}
     {{%- if "github" in hosting_providers %}}
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v4
+        uses: {{% if vendor_actions %}}./.github/actions/download-artifact{{% else %}}actions/download-artifact@v4{{% endif %}}
         with:
           pattern: artifacts-*
           path: artifacts
@@ -531,7 +531,7 @@ jobs:
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
       - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
+        uses: {{% if vendor_actions %}}./.github/actions/release-action{{% else %}}ncipollo/release-action@v1{{% endif %}}
         with:
         {{%- if github_releases_repo %}}
           owner: {{{ github_releases_repo.owner }}}


### PR DESCRIPTION
This adds a new feature which allows vendoring actions used within GitHub Actions run. I don't expect the majority of users to want this feature, but some security-conscious users may want it in order to ensure their CI runs use known versions of actions instead of arbitrary versions from floating tags.

This implementation works by cloning the actions' repositories into a `.github/actions` repository within the user's git repo. These are intended to be committed as files within the user's git repo and aren't treated as submodules. We'd previously experimented with a take where we instead vendored the repos within cargo-dist itself and wrote them like we do with our templates; however, this bloated the executable to an unnacceptable degree.

Note that "checkout" is the one action we can't vendor because it's necessary to fetch the repo that itself contains the vendored actions.