### PR TITLE
do not apply workspace optimisation when a single package is built

### DIFF
--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -401,6 +401,15 @@ pub struct DistMetadata {
     /// How to refer to the app in release bodies
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+
+    /// Whether to force building a package for each binary
+    ///
+    /// By default cargo-dist will do a workspace-level build if you have
+    /// multiple binaries. This will speed builds up in the general case but
+    /// can cause issues if, for example, you have an unused dependency in
+    /// the workspace that cannot be built. In that case you can set this
+    /// to true to force a build for each binary.
+    pub force_per_package: Option<bool>,
 }
 
 impl DistMetadata {
@@ -460,6 +469,7 @@ impl DistMetadata {
             github_releases_submodule_path: _,
             display: _,
             display_name: _,
+            force_per_package: _,
         } = self;
         if let Some(include) = include {
             for include in include {
@@ -539,6 +549,7 @@ impl DistMetadata {
             github_releases_submodule_path,
             display,
             display_name,
+            force_per_package,
         } = self;
 
         // Check for global settings on local packages
@@ -627,6 +638,10 @@ impl DistMetadata {
         }
         if tag_namespace.is_some() {
             warn!("package.metadata.dist.tag-namespace is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
+        }
+
+        if force_per_package.is_some() {
+            warn!("package.metadata.dist.force-per-package is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
         }
 
         // Merge non-global settings

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -272,6 +272,7 @@ fn get_new_dist_metadata(
             install_updater: None,
             display: None,
             display_name: None,
+            force_per_package: None,
         }
     };
 
@@ -854,6 +855,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         install_updater,
         display,
         display_name,
+        force_per_package,
     } = &meta;
 
     apply_optional_value(
@@ -1187,6 +1189,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "display-name",
         "# Custom display name to use for this app in release bodies\n",
         display_name.as_ref(),
+    );
+
+    apply_optional_value(
+        table,
+        "force-per-package",
+        "# Whether to force building a package for each binary\n",
+        *force_per_package,
     );
 
     // Finalize the table

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -767,6 +767,7 @@ pub(crate) struct DistGraphBuilder<'pkg_graph> {
     pub(crate) inner: DistGraph,
     pub(crate) manifest: DistManifest,
     pub(crate) workspace: &'pkg_graph mut WorkspaceInfo,
+    pub(crate) force_per_package: bool,
     artifact_mode: ArtifactMode,
     binaries_by_id: FastMap<String, BinaryIdx>,
     workspace_metadata: DistMetadata,
@@ -834,6 +835,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             // after this function, seems like we should finish the job..? (Doing a big
             // refactor already, don't want to mess with this right now.)
             ci,
+            force_per_package,
             // Only the final value merged into a package_config matters
             //
             // Note that we do *use* an auto-include from the workspace when doing
@@ -1117,6 +1119,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 github_attestations,
             },
             package_metadata,
+            force_per_package: force_per_package.unwrap_or_default(),
             workspace_metadata,
             workspace,
             binaries_by_id: FastMap::new(),
@@ -1188,6 +1191,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             targets: _,
             msvc_crt_static: _,
             github_attestations: _,
+            force_per_package: _,
         } = self.package_metadata(pkg_idx);
 
         let version = package_info.version.as_ref().unwrap().semver().clone();


### PR DESCRIPTION
Closes https://github.com/axodotdev/cargo-dist/issues/1117

This PR adds two commits:
- don't apply the workspace level build optimsation if there is exactly one binary to build. this should speed things up slightly 'for free' for users with a single binary who have libraries in the workspace that their binary doesn't depend on
- add a flag `force-per-package` that allows users to opt out of the workspace-level build optimisation for cases where they are building two or more binaries and still need this behaviour

I left the case where there are 0 binaries as-is, since I am not sure whether the list of binaries is guaranteed to be nonempty. If this is the case, I would add a third match: `[] => unreachable!()`

 This change resolves the above issue, where cargo-dist does not work in workspaces with unused libraries that cannot build on a given platform.