### PR TITLE
add support for setting the cache to use

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -72,6 +72,9 @@ pub struct GithubCiInfo {
     pub hosting_providers: Vec<HostingStyle>,
     /// whether to prefix release.yml and the tag pattern
     pub tag_namespace: Option<String>,
+    /// Cache provider
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_provider: Option<String>,
 }
 
 impl GithubCiInfo {
@@ -149,6 +152,8 @@ impl GithubCiInfo {
         let user_publish_jobs = dist.user_publish_jobs.clone();
         let post_announce_jobs = dist.post_announce_jobs.clone();
 
+        let cache_provider = dist.cache_provider.map(|c| c.to_string());
+
         // Figure out what Local Artifact tasks we need
         let local_runs = if dist.merge_tasks {
             distribute_targets_to_runners_merged(local_targets, &dist.github_custom_runners)
@@ -197,6 +202,7 @@ impl GithubCiInfo {
             ssldotcom_windows_sign,
             github_attestations,
             hosting_providers,
+            cache_provider,
         }
     }
 

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -272,6 +272,7 @@ fn get_new_dist_metadata(
             install_updater: None,
             display: None,
             display_name: None,
+            cache_provider: None,
         }
     };
 
@@ -854,6 +855,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         install_updater,
         display,
         display_name,
+        cache_provider,
     } = &meta;
 
     apply_optional_value(
@@ -1187,6 +1189,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "display-name",
         "# Custom display name to use for this app in release bodies\n",
         display_name.as_ref(),
+    );
+
+    apply_optional_value(
+        table,
+        "cache-provider",
+        "# Cache provider for builds. Can be one of github or buildjet.\n",
+        cache_provider.as_ref().map(|p| p.to_string()),
     );
 
     // Finalize the table

--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -211,6 +211,9 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ join(matrix.targets, '-') }}
+          {{%- if cache_provider is defined %}}
+          cache-provider: {{{ cache_provider }}}
+          {{%- endif %}}
       - name: Install cargo-dist
         run: ${{ matrix.install_dist }}
       # Get the dist-manifest


### PR DESCRIPTION
swatinem/rust-cache supports two caching backends; github actions and buildjet.

This just plumbs that setting through defaulting to leaving the field empty.