### PR TITLE
chore: rust 1.79.0

### DIFF
--- a/cargo-dist/tests/gallery/dist/tools.rs
+++ b/cargo-dist/tests/gallery/dist/tools.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::gallery::command::CommandInfo;
 
+// Allowing dead code because some of these are platform-specific
+#[allow(dead_code)]
 pub struct Tools {
     pub git: CommandInfo,
     pub cargo_dist: CommandInfo,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78"
+channel = "1.79"
 components = ["rustc", "cargo", "rust-std", "clippy", "rustfmt"]


### PR DESCRIPTION
Might be safe for us to actually remove the rust-toolchain version now. We had it because we have a minimum Rust version that not all of our runners were shipping by default yet, but that's probably no longer a concern.