### PR TITLE
feat: pipe working directory into more CLI commands

### DIFF
--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -95,6 +95,7 @@ impl<'a> DistGraphBuilder<'a> {
                         rustflags: rustflags.clone(),
                         profile: String::from(PROFILE_DIST),
                         expected_binaries,
+                        working_dir: self.inner.workspace_dir.clone(),
                     }));
                 }
             } else {
@@ -110,6 +111,7 @@ impl<'a> DistGraphBuilder<'a> {
                     rustflags,
                     profile: String::from(PROFILE_DIST),
                     expected_binaries: binaries,
+                    working_dir: self.inner.workspace_dir.clone(),
                 }));
             }
         }
@@ -148,6 +150,7 @@ pub fn build_cargo_target(
         .arg("--target")
         .arg(&target.target_triple)
         .env("RUSTFLAGS", &rustflags)
+        .current_dir(&target.working_dir)
         .stdout(std::process::Stdio::piped());
     if !target.features.default_features {
         command.arg("--no-default-features");

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -220,12 +220,13 @@ pub fn build_cargo_target(
 }
 
 /// Build a cargo target
-pub fn rustup_toolchain(_dist_graph: &DistGraph, cmd: &RustupStep) -> DistResult<()> {
+pub fn rustup_toolchain(dist_graph: &DistGraph, cmd: &RustupStep) -> DistResult<()> {
     eprintln!("running rustup to ensure you have {} installed", cmd.target);
     Cmd::new(&cmd.rustup.cmd, "install rustup toolchain")
         .arg("target")
         .arg("add")
         .arg(&cmd.target)
+        .current_dir(&dist_graph.workspace_dir)
         .run()?;
     Ok(())
 }

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -134,7 +134,7 @@ pub fn build_cargo_target(
     let mut desired_extra_env = vec![];
     let skip_brewfile = env::var("DO_NOT_USE_BREWFILE").is_ok();
     if !skip_brewfile {
-        if let Some(env_output) = fetch_brew_env(dist_graph)? {
+        if let Some(env_output) = fetch_brew_env(dist_graph, &target.working_dir)? {
             let brew_env = parse_env(&env_output)?;
             desired_extra_env = select_brew_env(&brew_env);
             rustflags = determine_brew_rustflags(&rustflags, &brew_env);

--- a/cargo-dist/src/build/generic.rs
+++ b/cargo-dist/src/build/generic.rs
@@ -127,7 +127,7 @@ fn run_build(
     let mut ldflags = None;
     let skip_brewfile = env::var("DO_NOT_USE_BREWFILE").is_ok();
     if !skip_brewfile {
-        if let Some(env_output) = fetch_brew_env(dist_graph)? {
+        if let Some(env_output) = fetch_brew_env(dist_graph, working_dir)? {
             let brew_env = parse_env(&env_output)?;
             desired_extra_env = select_brew_env(&brew_env);
             cflags = Some(calculate_cflags(&brew_env));

--- a/cargo-dist/src/env.rs
+++ b/cargo-dist/src/env.rs
@@ -10,7 +10,10 @@ use axoprocess::Cmd;
 use camino::Utf8Path;
 
 /// Fetches the Homebrew environment from `brew bundle exec`
-pub fn fetch_brew_env(dist_graph: &DistGraph) -> DistResult<Option<String>> {
+pub fn fetch_brew_env(
+    dist_graph: &DistGraph,
+    working_dir: &Utf8Path,
+) -> DistResult<Option<String>> {
     if let Some(brew) = &dist_graph.tools.brew {
         if Utf8Path::new("Brewfile").exists() {
             // Uses `brew bundle exec` to just print its own environment,
@@ -21,6 +24,7 @@ pub fn fetch_brew_env(dist_graph: &DistGraph) -> DistResult<Option<String>> {
                 .arg("exec")
                 .arg("--")
                 .arg("/usr/bin/env")
+                .current_dir(working_dir)
                 .output()?;
 
             return Ok(Some(String::from_utf8_lossy(&result.stdout).to_string()));

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -154,7 +154,8 @@ fn run_build_step(
             committish,
             prefix,
             target,
-        }) => generate_source_tarball(dist_graph, committish, prefix, target)?,
+            working_dir,
+        }) => generate_source_tarball(dist_graph, committish, prefix, target, working_dir)?,
         BuildStep::Extra(target) => run_extra_artifacts_build(dist_graph, target)?,
         BuildStep::Updater(updater) => fetch_updater(dist_graph, updater)?,
     };
@@ -332,7 +333,8 @@ fn build_fake(
             committish,
             prefix,
             target,
-        }) => generate_fake_source_tarball(dist_graph, committish, prefix, target)?,
+            working_dir,
+        }) => generate_fake_source_tarball(dist_graph, committish, prefix, target, working_dir)?,
         // Or extra artifacts, which may involve real builds
         BuildStep::Extra(target) => run_fake_extra_artifacts_build(dist_graph, target)?,
         BuildStep::Updater(_) => unimplemented!(),
@@ -437,6 +439,7 @@ fn generate_source_tarball(
     committish: &str,
     prefix: &str,
     target: &Utf8Path,
+    working_dir: &Utf8Path,
 ) -> DistResult<()> {
     let git = if let Some(tool) = &graph.tools.git {
         tool.cmd.to_owned()
@@ -454,6 +457,7 @@ fn generate_source_tarball(
         .arg(prefix)
         .arg("--output")
         .arg(target)
+        .current_dir(working_dir)
         .run()?;
 
     Ok(())
@@ -464,6 +468,7 @@ fn generate_fake_source_tarball(
     _committish: &str,
     _prefix: &str,
     target: &Utf8Path,
+    _working_dir: &Utf8Path,
 ) -> DistResult<()> {
     LocalAsset::write_new_all("", target)?;
 

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -210,6 +210,7 @@ pub fn fetch_updater_from_source(dist_graph: &DistGraph, updater: &UpdaterStep) 
         .arg("axoupdater-cli")
         .arg("--root")
         .arg(&tmp_root)
+        .current_dir(&tmp_root)
         .arg("--bin")
         .arg("axoupdater");
 

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -412,6 +412,8 @@ pub struct CargoBuildStep {
     pub rustflags: String,
     /// Binaries we expect from this build
     pub expected_binaries: Vec<BinaryIdx>,
+    /// The working directory to run the build in
+    pub working_dir: Utf8PathBuf,
 }
 
 /// A cargo build (and copy the outputs to various locations)


### PR DESCRIPTION
Similar to the work that was done in generic builds recently, this passes a working directory to CLI commands that are pwd-sensitive. This specifically covers `cargo`, `git`, and `brew bundle`; I left things like linkage alone, because those don't do anything with the pwd.