### PR TITLE
feat: shared workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.19.0"
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!
 cargo-dist-schema = { version = "=0.19.0", path = "cargo-dist-schema" }
-axoproject = { version = "=0.19.0", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects"] }
+axoproject = { version = "=0.19.0", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
 
 # first-party deps
 axocli = { version = "0.2.0" }

--- a/axoproject/Cargo.toml
+++ b/axoproject/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["generic-projects", "cargo-projects"]
+default = ["generic-projects", "cargo-projects", "npm-projects"]
 generic-projects = []
 cargo-projects = ["guppy"]
 npm-projects = ["oro-common", "oro-package-spec", "node-semver"]

--- a/axoproject/src/generic.rs
+++ b/axoproject/src/generic.rs
@@ -1,14 +1,23 @@
 //! Support for generic projects with cargo-dist build instructions
 
-use axoasset::SourceFile;
+use axoasset::{AxoassetError, SourceFile};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
 
-use crate::{PackageInfo, Result, Version, WorkspaceInfo, WorkspaceSearch};
+use crate::{
+    errors::GenericManifestParseError, PackageInfo, Result, Version, WorkspaceInfo,
+    WorkspaceSearch, WorkspaceStructure,
+};
 
 const DIST_PACKAGE_TOML: &str = "dist.toml";
 const DIST_WORKSPACE_TOML: &str = "dist-workspace.toml";
 const DIST_TARGET_DIR: &str = "target";
+
+const MEMBER_GENERIC: &str = "dist";
+#[cfg(feature = "cargo-projects")]
+const MEMBER_CARGO: &str = "cargo";
+#[cfg(feature = "npm-projects")]
+const MEMBER_NPM: &str = "npm";
 
 #[derive(Deserialize, Debug)]
 struct WorkspaceManifest {
@@ -16,8 +25,76 @@ struct WorkspaceManifest {
 }
 
 #[derive(Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
 struct Workspace {
-    members: Vec<Utf8PathBuf>,
+    members: Vec<WorkspaceMember>,
+}
+
+#[derive(Debug)]
+enum WorkspaceMember {
+    Generic(Utf8PathBuf),
+    #[cfg(feature = "cargo-projects")]
+    Cargo(Utf8PathBuf),
+    #[cfg(feature = "npm-projects")]
+    Npm(Utf8PathBuf),
+}
+
+impl std::str::FromStr for WorkspaceMember {
+    type Err = GenericManifestParseError;
+    fn from_str(member: &str) -> std::result::Result<Self, GenericManifestParseError> {
+        let Some((kind, path)) = member.split_once(':') else {
+            return Err(GenericManifestParseError::NoPrefix {
+                val: member.to_owned(),
+            });
+        };
+        let output = match kind {
+            MEMBER_GENERIC => WorkspaceMember::Generic(path.into()),
+            #[cfg(feature = "cargo-projects")]
+            MEMBER_CARGO => WorkspaceMember::Cargo(path.into()),
+            #[cfg(feature = "npm-projects")]
+            MEMBER_NPM => WorkspaceMember::Npm(path.into()),
+            other => {
+                return Err(GenericManifestParseError::UnknownPrefix {
+                    prefix: other.to_owned(),
+                    val: member.to_owned(),
+                });
+            }
+        };
+        Ok(output)
+    }
+}
+
+impl std::fmt::Display for WorkspaceMember {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkspaceMember::Generic(path) => write!(f, "{MEMBER_GENERIC}:{path}"),
+            #[cfg(feature = "cargo-projects")]
+            WorkspaceMember::Cargo(path) => write!(f, "{MEMBER_CARGO}/{path}"),
+            #[cfg(feature = "npm-projects")]
+            WorkspaceMember::Npm(path) => write!(f, "${MEMBER_NPM}/{path}"),
+        }
+    }
+}
+
+impl serde::Serialize for WorkspaceMember {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for WorkspaceMember {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let path = String::deserialize(deserializer)?;
+        path.parse().map_err(|e| D::Error::custom(format!("{e}")))
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -28,24 +105,20 @@ struct PackageManifest {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 struct Package {
-    name: String,
+    name: Option<String>,
     repository: Option<String>,
     homepage: Option<String>,
     documentation: Option<String>,
     description: Option<String>,
     readme: Option<Utf8PathBuf>,
-    #[serde(default = "Vec::new")]
-    authors: Vec<String>,
-    binaries: Vec<String>,
+    authors: Option<Vec<String>>,
+    binaries: Option<Vec<String>>,
     license: Option<String>,
     changelog: Option<Utf8PathBuf>,
-    #[serde(default = "Vec::new")]
-    license_files: Vec<Utf8PathBuf>,
-    #[serde(default = "Vec::new")]
-    cstaticlibs: Vec<String>,
-    #[serde(default = "Vec::new")]
-    cdylibs: Vec<String>,
-    build_command: Vec<String>,
+    license_files: Option<Vec<Utf8PathBuf>>,
+    cstaticlibs: Option<Vec<String>>,
+    cdylibs: Option<Vec<String>>,
+    build_command: Option<Vec<String>>,
     version: Option<semver::Version>,
 }
 
@@ -79,69 +152,135 @@ pub fn get_workspace(start_dir: &Utf8Path, clamp_to_dir: Option<&Utf8Path>) -> W
 }
 
 // Load and process a dist-workspace.toml, and its child packages
-fn workspace_from(manifest_path: &Utf8Path) -> Result<WorkspaceInfo> {
+fn workspace_from(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
     let manifest = load_workspace_dist_toml(manifest_path)?;
     let workspace_dir = manifest_path.parent().unwrap().to_path_buf();
     let root_auto_includes = crate::find_auto_includes(&workspace_dir)?;
 
     let mut package_info = vec![];
-    for member_reldir in &manifest.workspace.members {
-        let member_dir = workspace_dir.join(member_reldir);
-        let member_manifest_path = member_dir.join(DIST_PACKAGE_TOML);
-        let mut package = package_from(&member_manifest_path)?;
-        crate::merge_auto_includes(&mut package, &root_auto_includes);
-        package_info.push(package);
+    let mut sub_workspaces = vec![];
+    for member in &manifest.workspace.members {
+        match member {
+            WorkspaceMember::Generic(member_reldir) => {
+                let member_dir = workspace_dir.join(member_reldir);
+                let member_manifest_path = member_dir.join(DIST_PACKAGE_TOML);
+                let mut package = package_from(&member_manifest_path)?;
+                crate::merge_auto_includes(&mut package, &root_auto_includes);
+                package_info.push(package);
+            }
+            #[cfg(feature = "cargo-projects")]
+            WorkspaceMember::Cargo(member_reldir) => {
+                let cargo_workspace_dir = workspace_dir.join(member_reldir);
+                let search =
+                    crate::rust::get_workspace(&cargo_workspace_dir, Some(&cargo_workspace_dir))
+                        .into_result()?;
+                sub_workspaces.push(search);
+            }
+            #[cfg(feature = "npm-projects")]
+            WorkspaceMember::Npm(member_reldir) => {
+                // First load the npm package(s)
+                let npm_workspace_dir = workspace_dir.join(member_reldir);
+                let search =
+                    crate::javascript::get_workspace(&npm_workspace_dir, Some(&npm_workspace_dir))
+                        .into_result()?;
+                sub_workspaces.push(search);
+            }
+        }
+    }
+    for sub_workspace in &mut sub_workspaces {
+        // Process packages
+        for package in &mut sub_workspace.packages {
+            // If there's a dist.toml in the same dir, load it with less validation
+            // and merge the results into the npm package
+            let paired_manifest = package.package_root.join(DIST_PACKAGE_TOML);
+            if paired_manifest.exists() {
+                let generic = raw_package_from(&paired_manifest)?;
+                merge_package_with_raw_generic(package, generic);
+            }
+
+            crate::merge_auto_includes(package, &root_auto_includes);
+        }
     }
 
-    Ok(WorkspaceInfo {
-        kind: crate::WorkspaceKind::Generic,
-        target_dir: workspace_dir.join(DIST_TARGET_DIR),
-        workspace_dir,
-        package_info,
-        manifest_path: manifest_path.to_owned(),
-        root_auto_includes,
-        warnings: vec![],
-        #[cfg(feature = "cargo-projects")]
-        cargo_metadata_table: None,
-        #[cfg(feature = "cargo-projects")]
-        cargo_profiles: crate::rust::CargoProfiles::new(),
+    Ok(WorkspaceStructure {
+        sub_workspaces,
+        packages: package_info,
+        workspace: WorkspaceInfo {
+            kind: crate::WorkspaceKind::Generic,
+            target_dir: workspace_dir.join(DIST_TARGET_DIR),
+            workspace_dir,
+            manifest_path: manifest_path.to_owned(),
+            root_auto_includes,
+            #[cfg(feature = "cargo-projects")]
+            cargo_metadata_table: None,
+            #[cfg(feature = "cargo-projects")]
+            cargo_profiles: crate::rust::CargoProfiles::new(),
+        },
     })
 }
 
 // Load and process a dist.toml, and treat it as an entire workspace
-fn single_package_workspace_from(manifest_path: &Utf8Path) -> Result<WorkspaceInfo> {
+fn single_package_workspace_from(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
     let package = package_from(manifest_path)?;
     let root_auto_includes = crate::find_auto_includes(&package.package_root)?;
-    Ok(WorkspaceInfo {
-        kind: crate::WorkspaceKind::Generic,
-        target_dir: package.package_root.join(DIST_TARGET_DIR),
-        workspace_dir: package.package_root.clone(),
-        manifest_path: package.manifest_path.clone(),
-        root_auto_includes,
-        package_info: vec![package],
-        warnings: vec![],
-        #[cfg(feature = "cargo-projects")]
-        cargo_metadata_table: None,
-        #[cfg(feature = "cargo-projects")]
-        cargo_profiles: Default::default(),
+    Ok(WorkspaceStructure {
+        workspace: WorkspaceInfo {
+            kind: crate::WorkspaceKind::Generic,
+            target_dir: package.package_root.join(DIST_TARGET_DIR),
+            workspace_dir: package.package_root.clone(),
+            manifest_path: package.manifest_path.clone(),
+            root_auto_includes,
+
+            #[cfg(feature = "cargo-projects")]
+            cargo_metadata_table: None,
+            #[cfg(feature = "cargo-projects")]
+            cargo_profiles: Default::default(),
+        },
+        sub_workspaces: vec![],
+        packages: vec![package],
     })
+}
+
+fn raw_package_from(manifest_path: &Utf8Path) -> Result<Package> {
+    let manifest = load_package_dist_toml(manifest_path)?;
+    Ok(manifest.package)
 }
 
 // Load and process a dist.toml
 fn package_from(manifest_path: &Utf8Path) -> Result<PackageInfo> {
-    let manifest = load_package_dist_toml(manifest_path)?;
-    let package = manifest.package;
+    use serde::de::Error;
+    let package = raw_package_from(manifest_path)?;
     let version = package.version.map(Version::Generic);
 
     let manifest_path = manifest_path.to_path_buf();
 
+    // Create dummy src and span for missing field errors
+    let source = SourceFile::new(manifest_path.as_str(), String::new());
+    let span = source.span_for_line_col(1, 1);
+    let Some(build_command) = package.build_command else {
+        return Err(AxoassetError::Toml {
+            source,
+            span,
+            details: axoasset::toml::de::Error::custom("missing field build-command"),
+        })?;
+    };
+    let Some(name) = package.name else {
+        return Err(AxoassetError::Toml {
+            source,
+            span,
+            details: axoasset::toml::de::Error::custom("missing field name"),
+        })?;
+    };
+
     let mut info = PackageInfo {
+        true_name: name.clone(),
+        true_version: version.clone(),
         manifest_path: manifest_path.clone(),
         package_root: manifest_path.parent().unwrap().to_owned(),
-        name: package.name,
+        name,
         version,
         description: package.description,
-        authors: package.authors,
+        authors: package.authors.unwrap_or_default(),
         license: package.license,
         publish: true,
         keywords: None,
@@ -149,12 +288,12 @@ fn package_from(manifest_path: &Utf8Path) -> Result<PackageInfo> {
         homepage_url: package.homepage,
         documentation_url: package.documentation,
         readme_file: package.readme,
-        license_files: package.license_files,
+        license_files: package.license_files.unwrap_or_default(),
         changelog_file: package.changelog,
-        binaries: package.binaries,
-        cstaticlibs: package.cstaticlibs,
-        cdylibs: package.cdylibs,
-        build_command: Some(package.build_command),
+        binaries: package.binaries.unwrap_or_default(),
+        cstaticlibs: package.cstaticlibs.unwrap_or_default(),
+        cdylibs: package.cdylibs.unwrap_or_default(),
+        build_command: Some(build_command),
         #[cfg(feature = "cargo-projects")]
         cargo_metadata_table: None,
         #[cfg(feature = "cargo-projects")]
@@ -180,4 +319,69 @@ fn load_package_dist_toml(manifest_path: &Utf8Path) -> Result<PackageManifest> {
     let manifest_src = SourceFile::load_local(manifest_path)?;
     let manifest = manifest_src.deserialize_toml()?;
     Ok(manifest)
+}
+
+fn merge_package_with_raw_generic(package: &mut PackageInfo, generic: Package) {
+    let Package {
+        name,
+        repository,
+        homepage,
+        documentation,
+        description,
+        readme,
+        authors,
+        binaries,
+        license,
+        changelog,
+        license_files,
+        cstaticlibs,
+        cdylibs,
+        build_command,
+        version,
+    } = generic;
+    if let Some(val) = name {
+        package.name = val;
+    }
+    if let Some(val) = repository {
+        package.repository_url = Some(val);
+    }
+    if let Some(val) = homepage {
+        package.homepage_url = Some(val);
+    }
+    if let Some(val) = documentation {
+        package.documentation_url = Some(val);
+    }
+    if let Some(val) = description {
+        package.description = Some(val);
+    }
+    if let Some(val) = readme {
+        package.readme_file = Some(val);
+    }
+    if let Some(val) = changelog {
+        package.changelog_file = Some(val);
+    }
+    if let Some(val) = authors {
+        package.authors = val;
+    }
+    if let Some(val) = binaries {
+        package.binaries = val;
+    }
+    if let Some(val) = license {
+        package.license = Some(val);
+    }
+    if let Some(val) = license_files {
+        package.license_files = val;
+    }
+    if let Some(val) = cstaticlibs {
+        package.cstaticlibs = val;
+    }
+    if let Some(val) = cdylibs {
+        package.cdylibs = val;
+    }
+    if let Some(val) = build_command {
+        package.build_command = Some(val);
+    }
+    if let Some(val) = version {
+        package.version = Some(Version::Generic(val));
+    }
 }

--- a/axoproject/src/javascript.rs
+++ b/axoproject/src/javascript.rs
@@ -7,7 +7,7 @@ use oro_package_spec::GitInfo;
 
 use crate::{
     errors::AxoprojectError, PackageInfo, Result, Version, WorkspaceInfo, WorkspaceKind,
-    WorkspaceSearch,
+    WorkspaceSearch, WorkspaceStructure,
 };
 
 /// Try to find an npm/js workspace at the given path.
@@ -31,7 +31,7 @@ pub fn get_workspace(start_dir: &Utf8Path, clamp_to_dir: Option<&Utf8Path>) -> W
     }
 }
 
-fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceInfo> {
+fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
     let root = manifest_path.parent().unwrap().to_owned();
     let manifest = load_manifest(manifest_path)?;
 
@@ -61,7 +61,7 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceInfo> {
         .unwrap_or_default();
 
     // FIXME: do we care that we're dropping lots of useful semantic info on the ground here?
-    let mut repository_url = manifest.repository.and_then(|url| match url {
+    let repository_url = manifest.repository.and_then(|url| match url {
         Repository::Str(magic) => {
             // This "shorthand" form can be all kinds of magic things that we need to try to
             // parse out. Thankfully oro-package-spec provides an implementation of this with
@@ -73,12 +73,6 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceInfo> {
         }
         Repository::Obj { url, .. } => url,
     });
-    // Normalize away trailing `/` on repo URL
-    if let Some(repo_url) = &mut repository_url {
-        if repo_url.ends_with('/') {
-            repo_url.pop();
-        }
-    }
 
     // FIXME: it's unfortunate that we're loading the package.json twice!
     // Also arguably we shouldn't hard fail if we fail to make sense of the
@@ -105,6 +99,8 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceInfo> {
     };
 
     let mut info = PackageInfo {
+        true_name: package_name.clone(),
+        true_version: version.clone(),
         name: package_name,
         version,
         manifest_path: manifest_path.to_owned(),
@@ -141,18 +137,21 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceInfo> {
 
     let package_info = vec![info];
 
-    Ok(WorkspaceInfo {
-        kind: WorkspaceKind::Javascript,
-        target_dir,
-        workspace_dir: root,
-        package_info,
-        manifest_path: manifest_path.to_owned(),
-        root_auto_includes,
-        warnings: vec![],
-        #[cfg(feature = "cargo-projects")]
-        cargo_metadata_table: None,
-        #[cfg(feature = "cargo-projects")]
-        cargo_profiles: crate::rust::CargoProfiles::new(),
+    Ok(WorkspaceStructure {
+        sub_workspaces: vec![],
+        packages: package_info,
+        workspace: WorkspaceInfo {
+            kind: WorkspaceKind::Javascript,
+            target_dir,
+            workspace_dir: root,
+
+            manifest_path: manifest_path.to_owned(),
+            root_auto_includes,
+            #[cfg(feature = "cargo-projects")]
+            cargo_metadata_table: None,
+            #[cfg(feature = "cargo-projects")]
+            cargo_profiles: crate::rust::CargoProfiles::new(),
+        },
     })
 }
 

--- a/axoproject/tests/projects/cargo-virtual/virtual-gui/dist.toml
+++ b/axoproject/tests/projects/cargo-virtual/virtual-gui/dist.toml
@@ -1,0 +1,3 @@
+[package]
+name = "virtual-gui-overloaded"
+version = "1.0.0"

--- a/axoproject/tests/projects/generic-workspace/dist-workspace.toml
+++ b/axoproject/tests/projects/generic-workspace/dist-workspace.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["generic1", "generic2"]
+members = ["dist:generic1", "dist:generic2"]

--- a/axoproject/tests/projects/npm-init-legacy/dist.toml
+++ b/axoproject/tests/projects/npm-init-legacy/dist.toml
@@ -1,0 +1,2 @@
+[package]
+homepage = "https://axo.dev/"

--- a/axoproject/tests/projects/shared-workspace/CHANGELOG.md
+++ b/axoproject/tests/projects/shared-workspace/CHANGELOG.md
@@ -1,0 +1,1 @@
+root fake changelog!

--- a/axoproject/tests/projects/shared-workspace/LICENSE.txt
+++ b/axoproject/tests/projects/shared-workspace/LICENSE.txt
@@ -1,0 +1,1 @@
+root fake license!

--- a/axoproject/tests/projects/shared-workspace/README.md
+++ b/axoproject/tests/projects/shared-workspace/README.md
@@ -1,0 +1,1 @@
+root fake readme!

--- a/axoproject/tests/projects/shared-workspace/dist-workspace.toml
+++ b/axoproject/tests/projects/shared-workspace/dist-workspace.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["dist:generic1", "dist:generic2", "cargo:../cargo-nonvirtual", "cargo:../cargo-virtual", "npm:../npm-init-legacy"]

--- a/axoproject/tests/projects/shared-workspace/generic1/CHANGELOG.md
+++ b/axoproject/tests/projects/shared-workspace/generic1/CHANGELOG.md
@@ -1,0 +1,1 @@
+inner fake changelog!

--- a/axoproject/tests/projects/shared-workspace/generic1/LICENSE.txt
+++ b/axoproject/tests/projects/shared-workspace/generic1/LICENSE.txt
@@ -1,0 +1,1 @@
+inner fake license!

--- a/axoproject/tests/projects/shared-workspace/generic1/Makefile
+++ b/axoproject/tests/projects/shared-workspace/generic1/Makefile
@@ -1,0 +1,13 @@
+CC := gcc
+RM := rm
+EXEEXT := 
+
+all: main$(EXEEXT)
+
+main$(EXEEXT):
+	$(CC) main.c -o main$(EXEEXT)
+
+clean:
+	$(RM) -f main$(EXEEXT)
+
+.PHONY: all clean

--- a/axoproject/tests/projects/shared-workspace/generic1/README.md
+++ b/axoproject/tests/projects/shared-workspace/generic1/README.md
@@ -1,0 +1,1 @@
+inner fake readme!

--- a/axoproject/tests/projects/shared-workspace/generic1/dist.toml
+++ b/axoproject/tests/projects/shared-workspace/generic1/dist.toml
@@ -1,0 +1,47 @@
+[package]
+name = "generic1"
+description = "A test of a C program for cargo-dist"
+version = "0.0.1"
+license = "WTFPL"
+repository = "https://github.com/mistydemeo/testprog1"
+binaries = ["main"]
+build-command = ["make"]
+
+# Config for 'cargo dist'
+[workspace.metadata.dist]
+# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.4.2"
+# CI backends to support
+ci = ["github"]
+# The installers to generate for each app
+installers = ["shell", "homebrew"]
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-musl"]
+# The archive format to use for windows builds (defaults .zip)
+windows-archive = ".tar.gz"
+# The archive format to use for non-windows builds (defaults .tar.xz)
+unix-archive = ".tar.gz"
+# A namespace to use when publishing this package to the npm registry
+npm-scope = "@axodotdev"
+# A GitHub repo to push Homebrew formulas to
+tap = "mistydemeo/homebrew-cargodisttest"
+# Publish jobs to run in CI
+publish-jobs = ["homebrew"]
+# Whether cargo-dist should create a Github Release or use an existing draft
+create-release = false
+# Whether to publish prereleases to package managers
+publish-prereleases = true
+# Publish jobs to run in CI
+pr-run-mode = "plan"
+
+[workspace.metadata.dist.dependencies.homebrew]
+cmake = { targets = ["x86_64-apple-darwin"] }
+libcue = { version = "2.2.1", targets = ["x86_64-apple-darwin"] }
+
+[workspace.metadata.dist.dependencies.apt]
+cmake = '*'
+libcue-dev = { version = "2.2.1-2" }
+
+[workspace.metadata.dist.dependencies.chocolatey]
+lftp = '*'
+cmake = '3.27.6'

--- a/axoproject/tests/projects/shared-workspace/generic1/main.c
+++ b/axoproject/tests/projects/shared-workspace/generic1/main.c
@@ -1,0 +1,3 @@
+#include <stdio.h>
+
+int main() { puts("Hello, cargo-dist!"); }

--- a/axoproject/tests/projects/shared-workspace/generic2/Makefile
+++ b/axoproject/tests/projects/shared-workspace/generic2/Makefile
@@ -1,0 +1,13 @@
+CC := gcc
+RM := rm
+EXEEXT := 
+
+all: main$(EXEEXT)
+
+main$(EXEEXT):
+	$(CC) main.c -o main$(EXEEXT)
+
+clean:
+	$(RM) -f main$(EXEEXT)
+
+.PHONY: all clean

--- a/axoproject/tests/projects/shared-workspace/generic2/dist.toml
+++ b/axoproject/tests/projects/shared-workspace/generic2/dist.toml
@@ -1,0 +1,47 @@
+[package]
+name = "generic2"
+description = "A test of a C program for cargo-dist"
+version = "0.0.1"
+license = "WTFPL"
+repository = "https://github.com/mistydemeo/testprog2"
+binaries = ["main"]
+build-command = ["make"]
+
+# Config for 'cargo dist'
+[workspace.metadata.dist]
+# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.4.2"
+# CI backends to support
+ci = ["github"]
+# The installers to generate for each app
+installers = ["shell", "homebrew"]
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-musl"]
+# The archive format to use for windows builds (defaults .zip)
+windows-archive = ".tar.gz"
+# The archive format to use for non-windows builds (defaults .tar.xz)
+unix-archive = ".tar.gz"
+# A namespace to use when publishing this package to the npm registry
+npm-scope = "@axodotdev"
+# A GitHub repo to push Homebrew formulas to
+tap = "mistydemeo/homebrew-cargodisttest"
+# Publish jobs to run in CI
+publish-jobs = ["homebrew"]
+# Whether cargo-dist should create a Github Release or use an existing draft
+create-release = false
+# Whether to publish prereleases to package managers
+publish-prereleases = true
+# Publish jobs to run in CI
+pr-run-mode = "plan"
+
+[workspace.metadata.dist.dependencies.homebrew]
+cmake = { targets = ["x86_64-apple-darwin"] }
+libcue = { version = "2.2.1", targets = ["x86_64-apple-darwin"] }
+
+[workspace.metadata.dist.dependencies.apt]
+cmake = '*'
+libcue-dev = { version = "2.2.1-2" }
+
+[workspace.metadata.dist.dependencies.chocolatey]
+lftp = '*'
+cmake = '3.27.6'

--- a/axoproject/tests/projects/shared-workspace/generic2/main.c
+++ b/axoproject/tests/projects/shared-workspace/generic2/main.c
@@ -1,0 +1,3 @@
+#include <stdio.h>
+
+int main() { puts("Hello, cargo-dist!"); }

--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -107,7 +107,11 @@ impl<'a> DistGraphBuilder<'a> {
         let info = if let Some(announcing_version) = &announcing.version {
             // Try to find the version we're announcing in the top level CHANGELOG/RELEASES
             let version = axoproject::Version::Cargo(announcing_version.clone());
-            let Ok(Some(info)) = self.workspace.changelog_for_version(&version) else {
+            let Ok(Some(info)) = self
+                .workspaces
+                .root_workspace()
+                .changelog_for_version(&version)
+            else {
                 info!(
                     "failed to find {version} in workspace changelogs, skipping changelog generation"
                 );
@@ -117,14 +121,14 @@ impl<'a> DistGraphBuilder<'a> {
             info
         } else if let Some(announcing_package) = announcing.package {
             // Try to find the package's specific CHANGELOG/RELEASES
-            let package = self.workspace.package(announcing_package);
+            let package = self.workspaces.package(announcing_package);
             let package_name = &package.name;
             let version = package
                 .version
                 .as_ref()
                 .expect("cargo package without a version!?");
             let Ok(Some(info)) = self
-                .workspace
+                .workspaces
                 .package(announcing_package)
                 .changelog_for_version(version)
             else {
@@ -209,7 +213,7 @@ fn check_dist_package(
             }
         }
         ReleaseType::Version(ver) => {
-            if pkg.version.as_ref().unwrap().semver() != ver {
+            if pkg.version.as_ref().unwrap().semver() != *ver {
                 return Some(format!("didn't match tag {}", announcing.tag));
             }
         }
@@ -357,7 +361,7 @@ fn select_packages(
     let disabled_sty = console::Style::new().dim();
     let enabled_sty = console::Style::new();
     let mut releases = vec![];
-    for (pkg_id, pkg) in graph.workspace().packages() {
+    for (pkg_id, pkg) in graph.workspaces.all_packages() {
         let pkg_name = &pkg.name;
 
         // Determine if this package's binaries should be Released
@@ -462,7 +466,7 @@ fn ensure_tag(
             let versions = possible_tags(graph, releases.iter().map(|release| release.package_idx));
             if versions.len() == 1 {
                 // Nice, one version, use it
-                let version = *versions.first_key_value().unwrap().0;
+                let version = versions.first_key_value().as_ref().unwrap().0;
                 let tag = format!("v{version}");
                 info!("inferred Announcement tag: {}", tag);
                 *announcing = parse_tag_for_all_packages(graph, &tag)?;
@@ -568,7 +572,7 @@ fn maximum_version(
 ) -> Option<Version> {
     packages
         .into_iter()
-        .filter_map(|pkg_idx| graph.workspace().package(pkg_idx).version.as_ref())
+        .filter_map(|pkg_idx| graph.workspaces.package(pkg_idx).version.as_ref())
         .map(|v| v.cargo())
         .max()
         .cloned()
@@ -583,7 +587,7 @@ fn overwrite_package_versions(
     version: &Version,
 ) {
     for pkg_idx in packages {
-        graph.workspace.package_info[pkg_idx.0].version =
+        graph.workspaces.package_mut(pkg_idx).version =
             Some(axoproject::Version::Cargo(version.clone()));
     }
 }
@@ -607,8 +611,8 @@ fn parse_tag_for_all_packages(
     // If we're given a specific real tag to use, ask axotag to parse it
     // and identify which packages are selected by it.
     let packages: Vec<Package> = graph
-        .workspace()
-        .packages()
+        .workspaces
+        .all_packages()
         .map(|(_, info)| Package {
             name: info.name.clone(),
             version: info.version.clone().map(|v| v.semver().clone()),
@@ -623,13 +627,13 @@ fn parse_tag_for_all_packages(
 ///
 /// This is the set of options used by tag inference. Inference succeeds if
 /// there's only one key in the output.
-fn possible_tags<'a>(
-    graph: &'a DistGraphBuilder,
+fn possible_tags(
+    graph: &DistGraphBuilder,
     rust_releases: impl IntoIterator<Item = PackageIdx>,
-) -> SortedMap<&'a Version, Vec<PackageIdx>> {
-    let mut versions = SortedMap::<&Version, Vec<PackageIdx>>::new();
+) -> SortedMap<Version, Vec<PackageIdx>> {
+    let mut versions = SortedMap::<Version, Vec<PackageIdx>>::new();
     for pkg_idx in rust_releases {
-        let info = graph.workspace().package(pkg_idx);
+        let info = graph.workspaces.package(pkg_idx);
         let version = info.version.as_ref().unwrap().semver();
         versions.entry(version).or_default().push(pkg_idx);
     }
@@ -639,7 +643,7 @@ fn possible_tags<'a>(
 /// Get a help printout for what --tags could have been passed
 fn tag_help(
     graph: &DistGraphBuilder,
-    versions: SortedMap<&Version, Vec<PackageIdx>>,
+    versions: SortedMap<Version, Vec<PackageIdx>>,
     base_suggestion: &str,
 ) -> String {
     use std::fmt::Write;
@@ -663,7 +667,7 @@ fn tag_help(
         write!(help, "--tag=v{version} will Announce: ").unwrap();
         let mut multi_package = false;
         for &pkg_id in packages {
-            let info = &graph.workspace().package(pkg_id);
+            let info = graph.workspaces.package(pkg_id);
             if multi_package {
                 write!(help, ", ").unwrap();
             } else {
@@ -674,7 +678,7 @@ fn tag_help(
         writeln!(help).unwrap();
     }
     help.push('\n');
-    let info = &graph.workspace().package(*some_pkg);
+    let info = graph.workspaces.package(*some_pkg);
     let some_tag = format!(
         "--tag={}-v{}",
         info.name,

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -3,6 +3,7 @@
 use std::env;
 
 use axoprocess::Cmd;
+use axoproject::WorkspaceIdx;
 use cargo_dist_schema::DistManifest;
 use miette::{Context, IntoDiagnostic};
 use tracing::warn;
@@ -15,11 +16,20 @@ use crate::{
 };
 
 impl<'a> DistGraphBuilder<'a> {
-    pub(crate) fn compute_cargo_builds(&mut self) -> Vec<BuildStep> {
+    pub(crate) fn compute_cargo_builds(&mut self, workspace_idx: WorkspaceIdx) -> Vec<BuildStep> {
         // For now we can be really simplistic and just do a workspace build for every
         // target-triple we have a binary-that-needs-a-real-build for.
         let mut targets = SortedMap::<TargetTriple, Vec<BinaryIdx>>::new();
+        let working_dir = self
+            .workspaces
+            .workspace(workspace_idx)
+            .workspace_dir
+            .clone();
         for (binary_idx, binary) in self.inner.binaries.iter().enumerate() {
+            // Only bother with binaries owned by this workspace
+            if self.workspaces.workspace_for_package(binary.pkg_idx) != workspace_idx {
+                continue;
+            }
             if !binary.copy_exe_to.is_empty() || !binary.copy_symbols_to.is_empty() {
                 targets
                     .entry(binary.target.clone())
@@ -95,7 +105,7 @@ impl<'a> DistGraphBuilder<'a> {
                         rustflags: rustflags.clone(),
                         profile: String::from(PROFILE_DIST),
                         expected_binaries,
-                        working_dir: self.inner.workspace_dir.clone(),
+                        working_dir: working_dir.clone(),
                     }));
                 }
             } else {
@@ -111,7 +121,7 @@ impl<'a> DistGraphBuilder<'a> {
                     rustflags,
                     profile: String::from(PROFILE_DIST),
                     expected_binaries: binaries,
-                    working_dir: self.inner.workspace_dir.clone(),
+                    working_dir: working_dir.clone(),
                 }));
             }
         }
@@ -216,7 +226,7 @@ pub fn build_cargo_target(
     Ok(())
 }
 
-/// Build a cargo target
+/// Run rustup to setup a cargo target
 pub fn rustup_toolchain(dist_graph: &DistGraph, cmd: &RustupStep) -> DistResult<()> {
     eprintln!("running rustup to ensure you have {} installed", cmd.target);
     Cmd::new(&cmd.rustup.cmd, "install rustup toolchain")

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -4,19 +4,18 @@ use std::collections::BTreeMap;
 
 use axoasset::{toml_edit, SourceFile};
 use axoprocess::Cmd;
-use axoproject::{WorkspaceKind, WorkspaceSearch};
+use axoproject::WorkspaceKind;
 use camino::{Utf8Path, Utf8PathBuf};
-use miette::Report;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use tracing::log::warn;
 
 use crate::announce::TagSettings;
+use crate::SortedMap;
 use crate::{
     errors::{DistError, DistResult},
     TargetTriple, METADATA_DIST,
 };
-use crate::{ProjectError, SortedMap};
 
 /// A container to assist deserializing metadata from generic, non-Cargo projects
 #[derive(Debug, Deserialize)]
@@ -1626,6 +1625,7 @@ pub(crate) fn parse_metadata_table_or_manifest(
     metadata_table: Option<&serde_json::Value>,
 ) -> DistResult<DistMetadata> {
     match workspace_type {
+        WorkspaceKind::Javascript => unimplemented!("npm packages not yet supported here"),
         // Pre-parsed Rust metadata table
         WorkspaceKind::Rust => parse_metadata_table(manifest_path, metadata_table),
         // Generic dist.toml
@@ -1671,53 +1671,13 @@ fn get_git_repo_root(run_in: &Utf8PathBuf) -> DistResult<Utf8PathBuf> {
     Ok(Utf8PathBuf::from(string))
 }
 
-/// Get the general info about the project (via axo-project)
-pub fn get_project() -> std::result::Result<axoproject::WorkspaceInfo, ProjectError> {
+/// Find the dist workspaces relative to the current directory
+pub fn get_project() -> Result<axoproject::WorkspaceGraph, axoproject::errors::ProjectError> {
     let start_dir = std::env::current_dir().expect("couldn't get current working dir!?");
     let start_dir = Utf8PathBuf::from_path_buf(start_dir).expect("project path isn't utf8!?");
-
-    let root = get_git_repo_root(&start_dir);
-
-    let clamp = if let Ok(path) = &root {
-        Some(path.as_path())
-    } else {
-        None
-    };
-
-    let workspaces = axoproject::get_workspaces(&start_dir, clamp);
-
-    let mut missing = vec![];
-
-    for ws in [workspaces.rust, workspaces.generic] {
-        match ws {
-            WorkspaceSearch::Found(mut workspace) => {
-                // This is a goofy as heck workaround for two facts:
-                //   * the convenient Report approach requires us to provide an Error by-val
-                //   * many error types (like std::io::Error) don't impl Clone, so we can't
-                //     clone axoproject Errors.
-                //
-                // So we temporarily take ownership of the warnings and then pull them back
-                // out of the Report with runtime reflection to put them back in :)
-                let mut warnings = std::mem::take(&mut workspace.warnings);
-                for warning in warnings.drain(..) {
-                    let report = Report::new(warning);
-                    warn!("{:?}", report);
-                    workspace.warnings.push(report.downcast().unwrap());
-                }
-                return Ok(workspace);
-            }
-            WorkspaceSearch::Broken {
-                manifest_path: _,
-                cause,
-            } => {
-                return Err(ProjectError::ProjectBroken { cause });
-            }
-            // Ignore the missing case; iterate through to the next project type
-            WorkspaceSearch::Missing(e) => missing.push(e),
-        }
-    }
-
-    Err(ProjectError::ProjectMissing { sources: missing })
+    let clamp_to_dir = get_git_repo_root(&start_dir).ok();
+    let workspaces = axoproject::WorkspaceGraph::find(&start_dir, clamp_to_dir.as_deref())?;
+    Ok(workspaces)
 }
 
 /// Load a Cargo.toml into toml-edit form

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -39,7 +39,7 @@ pub enum DistError {
     /// random gazenot error
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Project(#[from] ProjectError),
+    Project(#[from] axoproject::errors::ProjectError),
 
     /// random string error
     #[error(transparent)]
@@ -334,7 +334,7 @@ pub enum DistError {
     UpdateNotInWorkspace {
         /// The report about the missing workspace
         #[diagnostic_source]
-        cause: ProjectError,
+        cause: axoproject::errors::ProjectError,
     },
 
     /// Trying to include CargoHome with other install paths
@@ -398,26 +398,6 @@ pub enum DistError {
         "The only installable files are libraries, but `install-cdylibs` isn't enabled."
     ))]
     EmptyInstaller {},
-}
-
-/// Errors related to finding the project
-#[derive(Debug, Error, Diagnostic)]
-pub enum ProjectError {
-    /// No workspace found from axoproject
-    #[error("No workspace found; either your project doesn't have a Cargo.toml/dist.toml, or we couldn't read it")]
-    ProjectMissing {
-        /// axoproject's error for the unidentified project
-        #[related]
-        sources: Vec<AxoprojectError>,
-    },
-
-    /// Found a workspace but it was malformed
-    #[error("We encountered an issue trying to read your workspace")]
-    ProjectBroken {
-        /// The cause
-        #[source]
-        cause: axoproject::errors::AxoprojectError,
-    },
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1,6 +1,6 @@
 use axoasset::toml_edit;
 use axoproject::{errors::AxoprojectError, platforms::triple_to_display_name};
-use axoproject::{WorkspaceInfo, WorkspaceKind};
+use axoproject::{WorkspaceGraph, WorkspaceInfo, WorkspaceKind};
 use camino::Utf8PathBuf;
 use cargo_dist_schema::PrRunMode;
 use semver::Version;
@@ -45,22 +45,30 @@ struct MultiDistMetadata {
 
 /// Run 'cargo dist init'
 pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
-    let workspace = config::get_project()?;
-
-    // Load in the workspace toml to edit and write back
-    let mut workspace_toml = config::load_cargo_toml(&workspace.manifest_path)?;
-
+    let workspaces = config::get_project()?;
+    let root_workspace = workspaces.root_workspace();
     let check = console::style("✔".to_string()).for_stderr().green();
-
-    // Init things
-    let did_add_profile = if workspace.kind == WorkspaceKind::Rust {
-        init_dist_profile(cfg, &mut workspace_toml)?
-    } else {
-        false
-    };
 
     eprintln!("let's setup your cargo-dist config...");
     eprintln!();
+
+    // For each [workspace] Cargo.toml in the workspaces, initialize [profile]
+    let mut did_add_profile = false;
+    for workspace_idx in workspaces.all_workspace_indices() {
+        let workspace = workspaces.workspace(workspace_idx);
+        if workspace.kind == WorkspaceKind::Rust {
+            let mut workspace_toml = config::load_cargo_toml(&workspace.manifest_path)?;
+            did_add_profile |= init_dist_profile(cfg, &mut workspace_toml)?;
+            config::save_cargo_toml(&workspace.manifest_path, workspace_toml)?;
+        }
+    }
+
+    if did_add_profile {
+        eprintln!("{check} added [profile.dist] to your workspace Cargo.toml");
+    }
+
+    // Load in the root workspace toml to edit and write back
+    let mut workspace_toml = config::load_cargo_toml(&root_workspace.manifest_path)?;
 
     let multi_meta = if let Some(json_path) = &args.with_json_config {
         // json update path, read from a file and apply all requested updates verbatim
@@ -69,7 +77,7 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
         multi_meta
     } else {
         // run (potentially interactive) init logic
-        let meta = get_new_dist_metadata(cfg, args, &workspace)?;
+        let meta = get_new_dist_metadata(cfg, args, &workspaces)?;
         MultiDistMetadata {
             workspace: Some(meta),
             packages: SortedMap::new(),
@@ -77,21 +85,18 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
     };
 
     if let Some(meta) = &multi_meta.workspace {
-        apply_dist_to_workspace_toml(&mut workspace_toml, workspace.kind, meta);
+        apply_dist_to_workspace_toml(&mut workspace_toml, root_workspace.kind, meta);
     }
 
     eprintln!();
 
     // Save the workspace toml (potentially an effective no-op if we made no edits)
-    config::save_cargo_toml(&workspace.manifest_path, workspace_toml)?;
-    if did_add_profile {
-        eprintln!("{check} added [profile.dist] to your root Cargo.toml");
-    }
+    config::save_cargo_toml(&root_workspace.manifest_path, workspace_toml)?;
     eprintln!("{check} added [workspace.metadata.dist] to your root Cargo.toml");
 
     // Now that we've done the stuff that's definitely part of the root Cargo.toml,
     // Optionally apply updates to packages
-    for (_idx, package) in workspace.packages() {
+    for (_idx, package) in workspaces.all_packages() {
         // Gather up all the things we'd like to be written to this file
         let meta = multi_meta.packages.get(&package.name);
         let needs_edit = meta.is_some();
@@ -205,16 +210,17 @@ fn has_metadata_table(workspace_info: &WorkspaceInfo) -> bool {
 fn get_new_dist_metadata(
     cfg: &Config,
     args: &InitArgs,
-    workspace_info: &WorkspaceInfo,
+    workspaces: &WorkspaceGraph,
 ) -> DistResult<DistMetadata> {
     use dialoguer::{Confirm, Input, MultiSelect, Select};
-    let has_config = has_metadata_table(workspace_info);
+    let root_workspace = workspaces.root_workspace();
+    let has_config = has_metadata_table(root_workspace);
 
     let mut meta = if has_config {
         config::parse_metadata_table_or_manifest(
-            workspace_info.kind,
-            &workspace_info.manifest_path,
-            workspace_info.cargo_metadata_table.as_ref(),
+            root_workspace.kind,
+            &root_workspace.manifest_path,
+            root_workspace.cargo_metadata_table.as_ref(),
         )?
     } else {
         DistMetadata {
@@ -440,7 +446,7 @@ fn get_new_dist_metadata(
             #[allow(irrefutable_let_patterns)]
             if let CiStyle::Github = item {
                 github_key = 0;
-                if let Some(repo_url) = &workspace_info.repository_url(None).unwrap_or_default() {
+                if let Some(repo_url) = &workspaces.repository_url(None).unwrap_or_default() {
                     if repo_url.contains("github.com") {
                         default = true;
                     }
@@ -486,33 +492,43 @@ fn get_new_dist_metadata(
         .as_ref()
         .map(|ci| ci.contains(&CiStyle::Github))
         .unwrap_or(false);
+    // FIXME: we now support more precisely getting the repository url
+    // filtered to a list of packages, so that we can apply publish=false/dist=false
+    // before trying to check the repository_url is consistent. However
+    // init is in this weird state where we're setting things up, so it's awkward
+    // to apply those annotations and so init still bombs out, as it doesn't
+    // have the filter to apply (this is solveable but not trivial...)
     if has_github_ci
-        && workspace_info
+        && workspaces
             .repository_url(None)
             .unwrap_or_default()
             .is_none()
     {
-        // If axoproject complained about inconsistency, forward that
+        // If axoproject complains about inconsistency, forward that
         // Massively jank manual implementation of "clone" here because lots of error types
         // (like std::io::Error) don't implement Clone and so axoproject errors can't either
-        let conflict = workspace_info.warnings.iter().find_map(|w| {
-            if let AxoprojectError::InconsistentRepositoryKey {
-                file1,
-                url1,
-                file2,
-                url2,
-            } = w
-            {
-                Some(AxoprojectError::InconsistentRepositoryKey {
-                    file1: file1.clone(),
-                    url1: url1.clone(),
-                    file2: file2.clone(),
-                    url2: url2.clone(),
-                })
-            } else {
-                None
-            }
-        });
+        let conflict = workspaces
+            .repository_url(None)
+            .map_err(|w| {
+                if let AxoprojectError::InconsistentRepositoryKey {
+                    file1,
+                    url1,
+                    file2,
+                    url2,
+                } = w
+                {
+                    Some(AxoprojectError::InconsistentRepositoryKey {
+                        file1: file1.clone(),
+                        url1: url1.clone(),
+                        file2: file2.clone(),
+                        url2: url2.clone(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .err()
+            .unwrap_or_default();
         if let Some(inner) = conflict {
             Err(DistError::CantEnableGithubUrlInconsistent { inner })?;
         } else {

--- a/cargo-dist/src/tests/config.rs
+++ b/cargo-dist/src/tests/config.rs
@@ -19,6 +19,9 @@ fn parse_rust_config(src: SourceFile) -> DistResult<DistMetadata> {
 
 fn parse_config(src: &SourceFile, input_kind: WorkspaceKind) -> DistResult<DistMetadata> {
     match input_kind {
+        WorkspaceKind::Javascript => {
+            unimplemented!("npm packages don't have [package.metadata.dist]")
+        }
         WorkspaceKind::Rust => parse_rust_config(src.clone()),
         WorkspaceKind::Generic => parse_generic_config(src.clone()),
     }
@@ -39,6 +42,7 @@ fn format_config(
 
 fn source(input: &str, input_kind: WorkspaceKind) -> SourceFile {
     let src_name = match input_kind {
+        WorkspaceKind::Javascript => "package.json",
         WorkspaceKind::Rust => "Cargo.toml",
         WorkspaceKind::Generic => "dist.toml",
     };

--- a/cargo-dist/tests/gallery/dist.rs
+++ b/cargo-dist/tests/gallery/dist.rs
@@ -7,7 +7,7 @@ use miette::miette;
 
 use super::command::CommandInfo;
 use super::errors::Result;
-use super::repo::{Repo, TestContext, TestContextLock, ToolsImpl};
+use super::repo::{App, Repo, TestContext, TestContextLock, ToolsImpl};
 pub use snapshot::*;
 pub use tools::*;
 
@@ -39,8 +39,10 @@ pub static AXOLOTLSAY: TestContextLock<Tools> = TestContextLock::new(
         repo_owner: "axodotdev",
         repo_name: "axolotlsay",
         commit_sha: "470fef1c2e1aecc35b1c8a704960d558906c58ff",
-        app_name: "axolotlsay",
-        bins: &["axolotlsay"],
+        apps: &[App {
+            name: "axolotlsay",
+            bins: &["axolotlsay"],
+        }],
     },
 );
 /// akaikatana-repack 0.2.0 has multiple bins!
@@ -50,8 +52,10 @@ pub static AKAIKATANA_REPACK: TestContextLock<Tools> = TestContextLock::new(
         repo_owner: "mistydemeo",
         repo_name: "akaikatana-repack",
         commit_sha: "9516f77ab81b7833e0d66de766ecf802e056f91f",
-        app_name: "akaikatana-repack",
-        bins: &["akextract", "akmetadata", "akrepack"],
+        apps: &[App {
+            name: "akaikatana-repack",
+            bins: &["akextract", "akmetadata", "akrepack"],
+        }],
     },
 );
 /// axoasset only has libraries!
@@ -61,8 +65,10 @@ pub static AXOASSET: TestContextLock<Tools> = TestContextLock::new(
         repo_owner: "axodotdev",
         repo_name: "axoasset",
         commit_sha: "5d6a531428fb645bbb1259fd401575c6c651be94",
-        app_name: "axoasset",
-        bins: &[],
+        apps: &[App {
+            name: "axoasset",
+            bins: &[],
+        }],
     },
 );
 /// generic workspace containing axolotlsay-js and axolotlsay (Rust)
@@ -71,15 +77,29 @@ pub static AXOLOTLSAY_HYBRID: TestContextLock<Tools> = TestContextLock::new(
     &Repo {
         repo_owner: "axodotdev",
         repo_name: "axolotlsay-hybrid",
-        commit_sha: "d00a7e3e75a2b7e24e756dca35b3cd693f3efc49",
-        app_name: "axolotlsay-js",
-        bins: &["axolotlsay-js"],
+        commit_sha: "b29f382a67409c10c055501d920175285d12098c",
+        apps: &[
+            App {
+                name: "axolotlsay-js",
+                bins: &["axolotlsay-js"],
+            },
+            App {
+                name: "axolotlsay",
+                bins: &["axolotlsay"],
+            },
+        ],
     },
 );
 pub struct DistResult {
     test_name: String,
-    // Only used in some cfgs
+    apps: Vec<AppResult>,
+}
+
+pub struct AppResult {
+    test_name: String,
     trust_hashes: bool,
+    app_name: String,
+    bins: Vec<String>,
     shell_installer_path: Option<Utf8PathBuf>,
     homebrew_installer_path: Option<Utf8PathBuf>,
     powershell_installer_path: Option<Utf8PathBuf>,
@@ -208,51 +228,32 @@ impl<'a> TestContext<'a, Tools> {
     fn load_dist_results(&self, test_name: &str, trust_hashes: bool) -> Result<DistResult> {
         // read/analyze installers
         eprintln!("loading results...");
-        let app_name = &self.repo.app_name;
-        let target_dir = Utf8PathBuf::from("target/distrib");
-        let ps_installer = Utf8PathBuf::from(format!("{target_dir}/{app_name}-installer.ps1"));
-        let sh_installer = Utf8PathBuf::from(format!("{target_dir}/{app_name}-installer.sh"));
-        let homebrew_installer = Self::load_file_with_suffix(target_dir.clone(), ".rb");
-        let npm_installer =
-            Utf8PathBuf::from(format!("{target_dir}/{app_name}-npm-package.tar.gz"));
+        let mut app_results = vec![];
+        for app in self.repo.apps {
+            let app_name = app.name.to_owned();
+            let target_dir = Utf8PathBuf::from("target/distrib");
+            let ps_installer = Utf8PathBuf::from(format!("{target_dir}/{app_name}-installer.ps1"));
+            let sh_installer = Utf8PathBuf::from(format!("{target_dir}/{app_name}-installer.sh"));
+            let brew_app_name = self.options.homebrew_package_name(&app_name);
+            let homebrew_installer = Utf8PathBuf::from(format!("{target_dir}/{brew_app_name}.rb"));
+            let npm_installer =
+                Utf8PathBuf::from(format!("{target_dir}/{app_name}-npm-package.tar.gz"));
+            app_results.push(AppResult {
+                test_name: test_name.to_owned(),
+                trust_hashes,
+                app_name,
+                bins: app.bins.iter().map(|s| s.to_string()).collect(),
+                shell_installer_path: sh_installer.exists().then_some(sh_installer),
+                powershell_installer_path: ps_installer.exists().then_some(ps_installer),
+                homebrew_installer_path: homebrew_installer.exists().then_some(homebrew_installer),
+                npm_installer_package_path: npm_installer.exists().then_some(npm_installer),
+            })
+        }
 
         Ok(DistResult {
             test_name: test_name.to_owned(),
-            trust_hashes,
-            shell_installer_path: sh_installer.exists().then_some(sh_installer),
-            powershell_installer_path: ps_installer.exists().then_some(ps_installer),
-            homebrew_installer_path: homebrew_installer,
-            npm_installer_package_path: npm_installer.exists().then_some(npm_installer),
+            apps: app_results,
         })
-    }
-
-    fn load_file_with_suffix(dirname: Utf8PathBuf, suffix: &str) -> Option<Utf8PathBuf> {
-        let files = Self::load_files_with_suffix(dirname, suffix);
-        let number_found = files.len();
-        assert!(
-            number_found <= 1,
-            "found {} files with the suffix {}, expected 1 or 0",
-            number_found,
-            suffix
-        );
-        files.first().cloned()
-    }
-
-    fn load_files_with_suffix(dirname: Utf8PathBuf, suffix: &str) -> Vec<Utf8PathBuf> {
-        // Collect all dist-manifests and fetch the appropriate Mac ones
-        let mut files = vec![];
-        for file in dirname
-            .read_dir()
-            .expect("loading target dir failed, something has gone very wrong")
-        {
-            let path = file.unwrap().path();
-            if let Some(filename) = path.file_name() {
-                if filename.to_string_lossy().ends_with(suffix) {
-                    files.push(Utf8PathBuf::from_path_buf(path).unwrap())
-                }
-            }
-        }
-        files
     }
 
     pub fn patch_cargo_toml(&self, new_toml: String) -> Result<()> {
@@ -330,34 +331,39 @@ impl DistResult {
     }
 
     pub fn linttests(&self, ctx: &TestContext<Tools>) -> Result<()> {
-        // If we have shellcheck, check our shell script
-        self.shellcheck(ctx)?;
+        for app in &self.apps {
+            // If we have shellcheck, check our shell script
+            app.shellcheck(ctx)?;
 
-        // If we have PsScriptAnalyzer, check our powershell script
-        self.psanalyzer(ctx)?;
+            // If we have PsScriptAnalyzer, check our powershell script
+            app.psanalyzer(ctx)?;
+        }
         Ok(())
     }
 
     pub fn runtests(&self, ctx: &TestContext<Tools>, expected_bin_dir: &str) -> Result<()> {
-        // If we can, run the shell script in a temp HOME
-        self.runtest_shell_installer(ctx, expected_bin_dir)?;
+        for app in &self.apps {
+            // If we can, run the shell script in a temp HOME
+            app.runtest_shell_installer(ctx, expected_bin_dir)?;
 
-        // If we can, run the powershell script in a temp HOME
-        self.runtest_powershell_installer(ctx, expected_bin_dir)?;
+            // If we can, run the powershell script in a temp HOME
+            app.runtest_powershell_installer(ctx, expected_bin_dir)?;
 
-        // If we can, run the homebrew script in a temp HOME
-        self.runtest_homebrew_installer(ctx)?;
+            // If we can, run the homebrew script in a temp HOME
+            app.runtest_homebrew_installer(ctx)?;
 
-        // If we can, run the npm package
-        self.runtest_npm_installer(ctx)?;
-
+            // If we can, run the npm package
+            app.runtest_npm_installer(ctx)?;
+        }
         Ok(())
     }
+}
 
+impl AppResult {
     #[cfg(any(target_family = "unix", target_family = "windows"))]
     fn check_install_receipt(
         &self,
-        ctx: &TestContext<Tools>,
+        _ctx: &TestContext<Tools>,
         bin_dir: &Utf8Path,
         receipt_file: &Utf8Path,
         bin_ext: &str,
@@ -442,11 +448,10 @@ impl DistResult {
         assert!(receipt_file.exists());
         let receipt_src = SourceFile::load_local(receipt_file).expect("couldn't load receipt file");
         let receipt: InstallReceipt = receipt_src.deserialize_json().unwrap();
-        assert_eq!(receipt.source.app_name, ctx.repo.app_name);
+        assert_eq!(receipt.source.app_name, self.app_name);
         assert_eq!(
             receipt.binaries,
-            ctx.repo
-                .bins
+            self.bins
                 .iter()
                 .map(|s| format!("{s}{bin_ext}"))
                 .collect::<Vec<_>>()

--- a/cargo-dist/tests/gallery/dist/homebrew.rs
+++ b/cargo-dist/tests/gallery/dist/homebrew.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl DistResult {
+impl AppResult {
     // Runs the installer script in the system's Homebrew installation
     #[allow(unused_variables)]
     pub fn runtest_homebrew_installer(&self, ctx: &TestContext<Tools>) -> Result<()> {
@@ -10,7 +10,6 @@ impl DistResult {
         }
 
         // Only do this on macOS, and only do it if RUIN_MY_COMPUTER_WITH_INSTALLERS is set
-        #[cfg(target_os = "macos")]
         if std::env::var(ENV_RUIN_ME)
             .map(|s| s == "homebrew" || s == "all")
             .unwrap_or(false)
@@ -38,7 +37,7 @@ impl DistResult {
             let prefix = prefix_raw.strip_suffix('\n').unwrap();
             let bin = Utf8PathBuf::from(&prefix).join("bin");
 
-            for bin_name in ctx.repo.bins {
+            for bin_name in ctx.options.bins_with_aliases(&self.app_name, &self.bins) {
                 let bin_path = bin.join(bin_name);
                 assert!(bin_path.exists(), "bin wasn't created");
             }

--- a/cargo-dist/tests/gallery/dist/shell.rs
+++ b/cargo-dist/tests/gallery/dist/shell.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl DistResult {
+impl AppResult {
     // Runs the installer script in a temp dir, attempting to set env vars to contain it to that dir
     #[allow(unused_variables)]
     pub fn runtest_shell_installer(
@@ -14,7 +14,7 @@ impl DistResult {
             .map(|s| s == "shell" || s == "all")
             .unwrap_or(false)
         {
-            let app_name = ctx.repo.app_name;
+            let app_name = &self.app_name;
             let test_name = &self.test_name;
 
             // only do this if the script exists
@@ -77,12 +77,12 @@ impl DistResult {
             assert!(env_script.exists(), "env script wasn't created");
 
             // Check that all the binaries work
-            for bin_name in ctx.repo.bins {
-                let bin_path = bin_dir.join(bin_name);
+            for bin_name in ctx.options.bins_with_aliases(&self.app_name, &self.bins) {
+                let bin_path = bin_dir.join(&bin_name);
                 assert!(bin_path.exists(), "bin wasn't created");
 
-                let bin =
-                    CommandInfo::new(bin_name, Some(bin_path.as_str())).expect("failed to run bin");
+                let bin = CommandInfo::new(&bin_name, Some(bin_path.as_str()))
+                    .expect("failed to run bin");
                 assert!(bin.version().is_some(), "failed to get app version");
                 eprintln!("installer.sh worked!");
 

--- a/cargo-dist/tests/gallery/dist/snapshot.rs
+++ b/cargo-dist/tests/gallery/dist/snapshot.rs
@@ -13,26 +13,40 @@ impl DistResult {
         // in one test (necessitating rerunning it multiple times or passing special flags to get all the changes)
         let mut snapshots = String::new();
 
-        append_snapshot_file(
-            &mut snapshots,
-            "installer.sh",
-            self.shell_installer_path.as_deref(),
-        )?;
-        append_snapshot_file(
-            &mut snapshots,
-            "formula.rb",
-            self.homebrew_installer_path.as_deref(),
-        )?;
-        append_snapshot_file(
-            &mut snapshots,
-            "installer.ps1",
-            self.powershell_installer_path.as_deref(),
-        )?;
-        append_snapshot_tarball(
-            &mut snapshots,
-            "npm-package.tar.gz",
-            self.npm_installer_package_path.as_deref(),
-        )?;
+        for app in &self.apps {
+            append_snapshot_file(
+                &mut snapshots,
+                app.shell_installer_path
+                    .as_deref()
+                    .and_then(|p| p.file_name())
+                    .unwrap_or_default(),
+                app.shell_installer_path.as_deref(),
+            )?;
+            append_snapshot_file(
+                &mut snapshots,
+                app.homebrew_installer_path
+                    .as_deref()
+                    .and_then(|p| p.file_name())
+                    .unwrap_or_default(),
+                app.homebrew_installer_path.as_deref(),
+            )?;
+            append_snapshot_file(
+                &mut snapshots,
+                app.powershell_installer_path
+                    .as_deref()
+                    .and_then(|p| p.file_name())
+                    .unwrap_or_default(),
+                app.powershell_installer_path.as_deref(),
+            )?;
+            append_snapshot_tarball(
+                &mut snapshots,
+                app.npm_installer_package_path
+                    .as_deref()
+                    .and_then(|p| p.file_name())
+                    .unwrap_or_default(),
+                app.npm_installer_package_path.as_deref(),
+            )?;
+        }
 
         Ok(Snapshots {
             settings: snapshot_settings_with_gallery_filter(),

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -102,7 +102,7 @@ path-guid = "BFD25009-65A4-4D1E-97F1-0030465D90D6"
 #[test]
 fn axolotlsay_custom_formula() -> Result<(), miette::Report> {
     let test_name = _function_name!();
-    AXOLOTLSAY.run_test(|ctx| {
+    AXOLOTLSAY.run_test(|mut ctx| {
         let dist_version = ctx.tools.cargo_dist.version().unwrap();
         ctx.patch_cargo_toml(format!(r#"
 [workspace.metadata.dist]
@@ -125,6 +125,8 @@ path-guid = "BFD25009-65A4-4D1E-97F1-0030465D90D6"
 
 "#
         ))?;
+
+        ctx.options.set_options("axolotlsay").homebrew_package_name = Some("axolotl-brew".to_owned());
 
         // Run generate to make sure stuff is up to date before running other commands
         let ci_result = ctx.cargo_dist_generate(test_name)?;
@@ -404,7 +406,7 @@ cache-builds = true
 
 "#
         ))?;
-        ctx.options.npm_package_name = Some("coolbeans".to_owned());
+        ctx.options.set_options("axolotlsay").npm_package_name = Some("coolbeans".to_owned());
 
         // Run generate to make sure stuff is up to date before running other commands
         let ci_result = ctx.cargo_dist_generate(test_name)?;
@@ -1699,7 +1701,7 @@ fn axolotlsay_generic_workspace_basic() -> Result<(), miette::Report> {
         installers = ["shell", "powershell", "homebrew"]
         tap = "axodotdev/homebrew-packages"
         publish-jobs = ["homebrew"]
-        targets = ["x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+        targets = ["x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
         install-success-msg = ">o_o< everything's installed!"
         ci = ["github"]
         unix-archive = ".tar.xz"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ akaikatana-repack-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ akaikatana-repack.rb ================
 class AkaikatanaRepack < Formula
   desc "The akaikatana-repack application"
   homepage "https://github.com/mistydemeo/akaikatana-repack"
@@ -1076,7 +1076,7 @@ class AkaikatanaRepack < Formula
   end
 end
 
-================ installer.ps1 ================
+================ akaikatana-repack-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ akaikatana-repack-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ akaikatana-repack-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1028,7 +1028,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ akaikatana-repack.rb ================
 class AkaikatanaRepack < Formula
   desc "The akaikatana-repack application"
   homepage "https://github.com/mistydemeo/akaikatana-repack"
@@ -1088,7 +1088,7 @@ class AkaikatanaRepack < Formula
   end
 end
 
-================ installer.ps1 ================
+================ akaikatana-repack-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ akaikatana-repack-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1040,7 +1040,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ akaikatana-repack.rb ================
 class AkaikatanaRepack < Formula
   desc "The akaikatana-repack application"
   homepage "https://github.com/mistydemeo/akaikatana-repack"
@@ -1100,7 +1100,7 @@ class AkaikatanaRepack < Formula
   end
 end
 
-================ installer.ps1 ================
+================ akaikatana-repack-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ akaikatana-repack-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ akaikatana-repack.rb ================
 class AkaikatanaRepack < Formula
   desc "The akaikatana-repack application"
   homepage "https://github.com/mistydemeo/akaikatana-repack"
@@ -1076,7 +1076,7 @@ class AkaikatanaRepack < Formula
   end
 end
 
-================ installer.ps1 ================
+================ akaikatana-repack-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1028,7 +1028,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1088,7 +1088,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1514,11 +1514,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1559,7 +1559,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1762,7 +1762,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1789,7 +1789,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1815,7 +1815,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1958,7 +1958,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2083,13 +2083,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2882,7 +2882,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2966,7 +2966,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1028,7 +1028,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1088,7 +1088,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1514,11 +1514,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1559,7 +1559,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1762,7 +1762,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1789,7 +1789,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1815,7 +1815,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1958,7 +1958,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2083,13 +2083,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2881,7 +2881,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2964,7 +2964,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1079,7 +1079,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1503,11 +1503,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1548,7 +1548,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1751,7 +1751,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1778,7 +1778,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1804,7 +1804,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1947,7 +1947,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2072,13 +2072,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2870,7 +2870,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2953,7 +2953,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ formula.rb ================
+================ axolotl-brew.rb ================
 class AxolotlBrew < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-js-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -22,8 +22,8 @@ fi
 set -u
 
 APP_NAME="axolotlsay-js"
-APP_VERSION="0.6.0"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0}"
+APP_VERSION="0.10.2"
+ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
@@ -44,10 +44,10 @@ usage() {
     cat <<EOF
 axolotlsay-js-installer.sh
 
-The installer for axolotlsay-js 0.6.0
+The installer for axolotlsay-js 0.10.2
 
 This script detects what platform you're on and fetches an appropriate archive from
-https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0
+https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2
 then unpacks the binaries and installs them to
 
     \$CARGO_HOME/bin (or \$HOME/.cargo/bin)
@@ -139,7 +139,7 @@ download_binary_and_run_installer() {
     # Lookup what to download/unpack based on platform
     case "$_arch" in 
         "aarch64-apple-darwin")
-            _artifact_name="axolotlsay-js-x86_64-apple-darwin.tar.xz"
+            _artifact_name="axolotlsay-js-aarch64-apple-darwin.tar.xz"
             _zip_ext=".tar.xz"
             _bins="axolotlsay-js"
             _bins_js_array='"axolotlsay-js"'
@@ -1016,20 +1016,24 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay-js.rb ================
 class AxolotlsayJs < Formula
   desc "JavaScript port of axolotlsay"
-  homepage "https://github.com/axodotdev/axolotlsay-hybrid"
-  version "0.6.0"
+  version "0.10.2"
   if OS.mac?
-    url "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-x86_64-apple-darwin.tar.xz"
+    if Hardware::CPU.arm?
+      url "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-aarch64-apple-darwin.tar.xz"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-x86_64-apple-darwin.tar.xz"
+    end
   end
   if OS.linux?
     if Hardware::CPU.intel?
-      url "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-x86_64-unknown-linux-gnu.tar.xz"
+      url "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-x86_64-unknown-linux-gnu.tar.xz"
     end
   end
-  license "MIT"
+  license "MIT-or-Apache2.0"
 
   BINARY_ALIASES = {"aarch64-apple-darwin": {}, "x86_64-apple-darwin": {}, "x86_64-pc-windows-gnu": {}, "x86_64-unknown-linux-gnu": {}}
 
@@ -1071,7 +1075,7 @@ class AxolotlsayJs < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-js-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1080,12 +1084,12 @@ end
 <#
 .SYNOPSIS
 
-The installer for axolotlsay-js 0.6.0
+The installer for axolotlsay-js 0.10.2
 
 .DESCRIPTION
 
 This script detects what platform you're on and fetches an appropriate archive from
-https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0
+https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2
 then unpacks the binaries and installs them to
 
     $env:CARGO_HOME/bin (or $HOME/.cargo/bin)
@@ -1105,7 +1109,7 @@ Print help
 
 param (
     [Parameter(HelpMessage = "The URL of the directory where artifacts can be fetched from")]
-    [string]$ArtifactDownloadUrl = 'https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0',
+    [string]$ArtifactDownloadUrl = 'https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2',
     [Parameter(HelpMessage = "Don't add the install directory to PATH")]
     [switch]$NoModifyPath,
     [Parameter(HelpMessage = "Print Help")]
@@ -1113,7 +1117,7 @@ param (
 )
 
 $app_name = 'axolotlsay-js'
-$app_version = '0.6.0'
+$app_version = '0.10.2'
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1495,24 +1499,1550 @@ try {
   exit 1
 }
 
+================ axolotlsay-installer.sh ================
+#!/bin/sh
+# shellcheck shell=dash
+#
+# Licensed under the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+if [ "$KSH_VERSION" = 'Version JM 93t+ 2010-03-05' ]; then
+    # The version of ksh93 that ships with many illumos systems does not
+    # support the "local" extension.  Print a message rather than fail in
+    # subtle ways later on:
+    echo 'this installer does not work with this ksh93 version; please try bash!' >&2
+    exit 1
+fi
+
+set -u
+
+APP_NAME="axolotlsay"
+APP_VERSION="0.10.2"
+ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2}"
+PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
+PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
+NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+read -r RECEIPT <<EORECEIPT
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+EORECEIPT
+# Are we happy with this same path on Linux and Mac?
+RECEIPT_HOME="${HOME}/.config/axolotlsay"
+
+# glibc provided by our Ubuntu 20.04 runners;
+# in the future, we should actually record which glibc was on the runner,
+# and inject that into the script.
+BUILDER_GLIBC_MAJOR="2"
+BUILDER_GLIBC_SERIES="31"
+
+usage() {
+    # print help (this cat/EOF stuff is a "heredoc" string)
+    cat <<EOF
+axolotlsay-installer.sh
+
+The installer for axolotlsay 0.10.2
+
+This script detects what platform you're on and fetches an appropriate archive from
+https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2
+then unpacks the binaries and installs them to
+
+    \$CARGO_HOME/bin (or \$HOME/.cargo/bin)
+
+It will then add that dir to PATH by adding the appropriate line to your shell profiles.
+
+USAGE:
+    axolotlsay-installer.sh [OPTIONS]
+
+OPTIONS:
+    -v, --verbose
+            Enable verbose output
+
+    -q, --quiet
+            Disable progress output
+
+        --no-modify-path
+            Don't configure the PATH environment variable
+
+    -h, --help
+            Print help information
+EOF
+}
+
+download_binary_and_run_installer() {
+    downloader --check
+    need_cmd uname
+    need_cmd mktemp
+    need_cmd chmod
+    need_cmd mkdir
+    need_cmd rm
+    need_cmd tar
+    need_cmd grep
+    need_cmd cat
+
+    for arg in "$@"; do
+        case "$arg" in
+            --help)
+                usage
+                exit 0
+                ;;
+            --quiet)
+                PRINT_QUIET=1
+                ;;
+            --verbose)
+                PRINT_VERBOSE=1
+                ;;
+            --no-modify-path)
+                NO_MODIFY_PATH=1
+                ;;
+            *)
+                OPTIND=1
+                if [ "${arg%%--*}" = "" ]; then
+                    err "unknown option $arg"
+                fi
+                while getopts :hvq sub_arg "$arg"; do
+                    case "$sub_arg" in
+                        h)
+                            usage
+                            exit 0
+                            ;;
+                        v)
+                            # user wants to skip the prompt --
+                            # we don't need /dev/tty
+                            PRINT_VERBOSE=1
+                            ;;
+                        q)
+                            # user wants to skip the prompt --
+                            # we don't need /dev/tty
+                            PRINT_QUIET=1
+                            ;;
+                        *)
+                            err "unknown option -$OPTARG"
+                            ;;
+                        esac
+                done
+                ;;
+        esac
+    done
+
+    get_architecture || return 1
+    local _arch="$RETVAL"
+    assert_nz "$_arch" "arch"
+
+    local _bins
+    local _zip_ext
+    local _artifact_name
+
+    # Lookup what to download/unpack based on platform
+    case "$_arch" in 
+        "aarch64-apple-darwin")
+            _artifact_name="axolotlsay-aarch64-apple-darwin.tar.xz"
+            _zip_ext=".tar.xz"
+            _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
+            _updater_name=""
+            _updater_bin=""
+            ;;
+        "x86_64-apple-darwin")
+            _artifact_name="axolotlsay-x86_64-apple-darwin.tar.xz"
+            _zip_ext=".tar.xz"
+            _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
+            _updater_name=""
+            _updater_bin=""
+            ;;
+        "x86_64-pc-windows-gnu")
+            _artifact_name="axolotlsay-x86_64-pc-windows-msvc.zip"
+            _zip_ext=".zip"
+            _bins="axolotlsay.exe"
+            _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
+            _updater_name=""
+            _updater_bin=""
+            ;;
+        "x86_64-unknown-linux-gnu")
+            _artifact_name="axolotlsay-x86_64-unknown-linux-gnu.tar.xz"
+            _zip_ext=".tar.xz"
+            _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
+            _updater_name=""
+            _updater_bin=""
+            ;;
+        *)
+            err "there isn't a package for $_arch"
+            ;;
+    esac
+
+    # Replace the placeholder binaries with the calculated array from above
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+
+    # download the archive
+    local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
+    local _dir
+    if ! _dir="$(ensure mktemp -d)"; then
+        # Because the previous command ran in a subshell, we must manually
+        # propagate exit status.
+        exit 1
+    fi
+    local _file="$_dir/input$_zip_ext"
+
+    say "downloading $APP_NAME $APP_VERSION ${_arch}" 1>&2
+    say_verbose "  from $_url" 1>&2
+    say_verbose "  to $_file" 1>&2
+
+    ensure mkdir -p "$_dir"
+
+    if ! downloader "$_url" "$_file"; then
+      say "failed to download $_url"
+      say "this may be a standard network error, but it may also indicate"
+      say "that $APP_NAME's release process is not working. When in doubt"
+      say "please feel free to open an issue!"
+      exit 1
+    fi
+
+    # ...and then the updater, if it exists
+    if [ -n "$_updater_name" ]; then
+        local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
+        # This renames the artifact while doing the download, removing the
+        # target triple and leaving just the appname-update format
+        local _updater_file="$_dir/$APP_NAME-update"
+
+        if ! downloader "$_updater_url" "$_updater_file"; then
+          say "failed to download $_updater_url"
+          say "this may be a standard network error, but it may also indicate"
+          say "that $APP_NAME's release process is not working. When in doubt"
+          say "please feel free to open an issue!"
+          exit 1
+        fi
+
+        # Add the updater to the list of binaries to install
+        _bins="$_bins $APP_NAME-update"
+    fi
+
+    # unpack the archive
+    case "$_zip_ext" in
+        ".zip")
+            ensure unzip -q "$_file" -d "$_dir"
+            ;;
+
+        ".tar."*)
+            ensure tar xf "$_file" --strip-components 1 -C "$_dir"
+            ;;
+        *)
+            err "unknown archive format: $_zip_ext"
+            ;;
+    esac
+
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    local _retval=$?
+    if [ "$_retval" != 0 ]; then
+        return "$_retval"
+    fi
+
+    ignore rm -rf "$_dir"
+
+    # Install the install receipt
+    mkdir -p "$RECEIPT_HOME" || {
+        err "unable to create receipt directory at $RECEIPT_HOME"
+    }
+    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+    # shellcheck disable=SC2320
+    local _retval=$?
+
+    return "$_retval"
+}
+
+# Replaces $HOME with the variable name for display to the user,
+# only if $HOME is defined.
+replace_home() {
+    local _str="$1"
+
+    if [ -n "${HOME:-}" ]; then
+        echo "$_str" | sed "s,$HOME,\$HOME,"
+    else
+        echo "$_str"
+    fi
+}
+
+json_binary_aliases() {
+    local _arch="$1"
+
+    case "$_arch" in 
+    "aarch64-apple-darwin")
+        echo '{}'
+        ;;
+    "x86_64-apple-darwin")
+        echo '{}'
+        ;;
+    "x86_64-pc-windows-gnu")
+        echo '{}'
+        ;;
+    "x86_64-unknown-linux-gnu")
+        echo '{}'
+        ;;
+    esac
+}
+
+aliases_for_binary() {
+    local _bin="$1"
+    local _arch="$2"
+
+    case "$_arch" in 
+    "aarch64-apple-darwin")
+        case "$_bin" in
+        *)
+            echo ""
+            ;;
+        esac
+        ;;
+    "x86_64-apple-darwin")
+        case "$_bin" in
+        *)
+            echo ""
+            ;;
+        esac
+        ;;
+    "x86_64-pc-windows-gnu")
+        case "$_bin" in
+        *)
+            echo ""
+            ;;
+        esac
+        ;;
+    "x86_64-unknown-linux-gnu")
+        case "$_bin" in
+        *)
+            echo ""
+            ;;
+        esac
+        ;;
+    esac
+}
+
+# See discussion of late-bound vs early-bound for why we use single-quotes with env vars
+# shellcheck disable=SC2016
+install() {
+    # This code needs to both compute certain paths for itself to write to, and
+    # also write them to shell/rc files so that they can look them up to e.g.
+    # add them to PATH. This requires an active distinction between paths
+    # and expressions that can compute them.
+    #
+    # The distinction lies in when we want env-vars to be evaluated. For instance
+    # if we determine that we want to install to $HOME/.myapp, which do we add
+    # to e.g. $HOME/.profile:
+    #
+    # * early-bound: export PATH="/home/myuser/.myapp:$PATH"
+    # * late-bound:  export PATH="$HOME/.myapp:$PATH"
+    #
+    # In this case most people would prefer the late-bound version, but in other
+    # cases the early-bound version might be a better idea. In particular when using
+    # other env-vars than $HOME, they are more likely to be only set temporarily
+    # for the duration of this install script, so it's more advisable to erase their
+    # existence with early-bounding.
+    #
+    # This distinction is handled by "double-quotes" (early) vs 'single-quotes' (late).
+    #
+    # However if we detect that "$SOME_VAR/..." is a subdir of $HOME, we try to rewrite
+    # it to be '$HOME/...' to get the best of both worlds.
+    #
+    # This script has a few different variants, the most complex one being the
+    # CARGO_HOME version which attempts to install things to Cargo's bin dir,
+    # potentially setting up a minimal version if the user hasn't ever installed Cargo.
+    #
+    # In this case we need to:
+    #
+    # * Install to $HOME/.cargo/bin/
+    # * Create a shell script at $HOME/.cargo/env that:
+    #   * Checks if $HOME/.cargo/bin/ is on PATH
+    #   * and if not prepends it to PATH
+    # * Edits $HOME/.profile to run $HOME/.cargo/env (if the line doesn't exist)
+    #
+    # To do this we need these 4 values:
+
+    # The actual path we're going to install to
+    local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
+    # The install prefix we write to the receipt.
+    # For organized install methods like CargoHome, which have
+    # subdirectories, this is the root without `/bin`. For other
+    # methods, this is the same as `_install_dir`.
+    local _receipt_install_dir
+    # Path to the an shell script that adds install_dir to PATH
+    local _env_script_path
+    # Potentially-late-bound version of install_dir to write env_script
+    local _install_dir_expr
+    # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
+    local _env_script_path_expr
+
+    # Before actually consulting the configured install strategy, see
+    # if we're overriding it.
+    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
+        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
+        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    fi
+    if [ -z "${_install_dir:-}" ]; then
+        # first try $CARGO_HOME, then fallback to $HOME/.cargo
+        if [ -n "${CARGO_HOME:-}" ]; then
+            _receipt_install_dir="$CARGO_HOME"
+            _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
+            _env_script_path="$CARGO_HOME/env"
+            # Initially make this early-bound to erase the potentially-temporary env-var
+            _install_dir_expr="$_install_dir"
+            _env_script_path_expr="$_env_script_path"
+            # If CARGO_HOME was set but it ended up being the default $HOME-based path,
+            # then keep things late-bound. Otherwise bake the value for safety.
+            # This is what rustup does, and accurately reproducing it is useful.
+            if [ -n "${HOME:-}" ]; then
+                if [ "$HOME/.cargo/bin" = "$_install_dir" ]; then
+                    _install_dir_expr='$HOME/.cargo/bin'
+                    _env_script_path_expr='$HOME/.cargo/env'
+                fi
+            fi
+        elif [ -n "${HOME:-}" ]; then
+            _receipt_install_dir="$HOME/.cargo"
+            _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
+            _env_script_path="$HOME/.cargo/env"
+            _install_dir_expr='$HOME/.cargo/bin'
+            _env_script_path_expr='$HOME/.cargo/env'
+        fi
+    fi
+
+    if [ -z "$_install_dir_expr" ]; then
+        err "could not find a valid path to install to!"
+    fi
+
+    # Identical to the sh version, just with a .fish file extension
+    # We place it down here to wait until it's been assigned in every
+    # path.
+    _fish_env_script_path="${_env_script_path}.fish"
+    _fish_env_script_path_expr="${_env_script_path_expr}.fish"
+
+    # Replace the temporary cargo home with the calculated one
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    # Also replace the aliases with the arch-specific one
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+
+    say "installing to $_install_dir"
+    ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
+
+    # copy all the binaries to the install dir
+    local _src_dir="$1"
+    local _bins="$2"
+    local _libs="$3"
+    local _arch="$4"
+    for _bin_name in $_bins; do
+        local _bin="$_src_dir/$_bin_name"
+        ensure mv "$_bin" "$_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_install_dir/$_bin_name"
+        for _dest in $(aliases_for_binary "$_bin_name" "$_arch"); do
+            ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
+        done
+        say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+
+    say ">o_o< everything's installed!"
+
+    if [ "0" = "$NO_MODIFY_PATH" ]; then
+        add_install_dir_to_ci_path "$_install_dir"
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".profile" "sh"
+        exit1=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".bash_profile .bash_login .bashrc" "sh"
+        exit2=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" ".zshrc .zshenv" "sh"
+        exit3=$?
+        # This path may not exist by default
+        ensure mkdir -p "$HOME/.config/fish/conf.d"
+        exit4=$?
+        add_install_dir_to_path "$_install_dir_expr" "$_fish_env_script_path" "$_fish_env_script_path_expr" ".config/fish/conf.d/$APP_NAME.env.fish" "fish"
+        exit5=$?
+
+        if [ "${exit1:-0}" = 1 ] || [ "${exit2:-0}" = 1 ] || [ "${exit3:-0}" = 1 ] || [ "${exit4:-0}" = 1 ] || [ "${exit5:-0}" = 1 ]; then
+            say ""
+            say "To add $_install_dir_expr to your PATH, either restart your shell or run:"
+            say ""
+            say "    source $_env_script_path_expr (sh, bash, zsh)"
+            say "    source $_fish_env_script_path_expr (fish)"
+        fi
+    fi
+}
+
+print_home_for_script() {
+    local script="$1"
+
+    local _home
+    case "$script" in
+        # zsh has a special ZDOTDIR directory, which if set
+        # should be considered instead of $HOME
+        .zsh*)
+            if [ -n "${ZDOTDIR:-}" ]; then
+                _home="$ZDOTDIR"
+            else
+                _home="$HOME"
+            fi
+            ;;
+        *)
+            _home="$HOME"
+            ;;
+    esac
+
+    echo "$_home"
+}
+
+add_install_dir_to_ci_path() {
+    # Attempt to do CI-specific rituals to get the install-dir on PATH faster
+    local _install_dir="$1"
+
+    # If GITHUB_PATH is present, then write install_dir to the file it refs.
+    # After each GitHub Action, the contents will be added to PATH.
+    # So if you put a curl | sh for this script in its own "run" step,
+    # the next step will have this dir on PATH.
+    #
+    # Note that GITHUB_PATH will not resolve any variables, so we in fact
+    # want to write install_dir and not install_dir_expr
+    if [ -n "${GITHUB_PATH:-}" ]; then
+        ensure echo "$_install_dir" >> "$GITHUB_PATH"
+    fi
+}
+
+add_install_dir_to_path() {
+    # Edit rcfiles ($HOME/.profile) to add install_dir to $PATH
+    #
+    # We do this slightly indirectly by creating an "env" shell script which checks if install_dir
+    # is on $PATH already, and prepends it if not. The actual line we then add to rcfiles
+    # is to just source that script. This allows us to blast it into lots of different rcfiles and
+    # have it run multiple times without causing problems. It's also specifically compatible
+    # with the system rustup uses, so that we don't conflict with it.
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    local _env_script_path_expr="$3"
+    local _rcfiles="$4"
+    local _shell="$5"
+
+    if [ -n "${HOME:-}" ]; then
+        local _target
+        local _home
+
+        # Find the first file in the array that exists and choose
+        # that as our target to write to
+        for _rcfile_relative in $_rcfiles; do
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            local _rcfile="$_home/$_rcfile_relative"
+
+            if [ -f "$_rcfile" ]; then
+                _target="$_rcfile"
+                break
+            fi
+        done
+
+        # If we didn't find anything, pick the first entry in the
+        # list as the default to create and write to
+        if [ -z "${_target:-}" ]; then
+            local _rcfile_relative
+            _rcfile_relative="$(echo "$_rcfiles" | awk '{ print $1 }')"
+            _home="$(print_home_for_script "$_rcfile_relative")"
+            _target="$_home/$_rcfile_relative"
+        fi
+
+        # `source x` is an alias for `. x`, and the latter is more portable/actually-posix.
+        # This apparently comes up a lot on freebsd. It's easy enough to always add
+        # the more robust line to rcfiles, but when telling the user to apply the change
+        # to their current shell ". x" is pretty easy to misread/miscopy, so we use the
+        # prettier "source x" line there. Hopefully people with Weird Shells are aware
+        # this is a thing and know to tweak it (or just restart their shell).
+        local _robust_line=". \"$_env_script_path_expr\""
+        local _pretty_line="source \"$_env_script_path_expr\""
+
+        # Add the env script if it doesn't already exist
+        if [ ! -f "$_env_script_path" ]; then
+            say_verbose "creating $_env_script_path"
+            if [ "$_shell" = "sh" ]; then
+                write_env_script_sh "$_install_dir_expr" "$_env_script_path"
+            else
+                write_env_script_fish "$_install_dir_expr" "$_env_script_path"
+            fi
+        else
+            say_verbose "$_env_script_path already exists"
+        fi
+
+        # Check if the line is already in the rcfile
+        # grep: 0 if matched, 1 if no match, and 2 if an error occurred
+        #
+        # Ideally we could use quiet grep (-q), but that makes "match" and "error"
+        # have the same behaviour, when we want "no match" and "error" to be the same
+        # (on error we want to create the file, which >> conveniently does)
+        #
+        # We search for both kinds of line here just to do the right thing in more cases.
+        if ! grep -F "$_robust_line" "$_target" > /dev/null 2>/dev/null && \
+           ! grep -F "$_pretty_line" "$_target" > /dev/null 2>/dev/null
+        then
+            # If the script now exists, add the line to source it to the rcfile
+            # (This will also create the rcfile if it doesn't exist)
+            if [ -f "$_env_script_path" ]; then
+                local _line
+                # Fish has deprecated `.` as an alias for `source` and
+                # it will be removed in a later version.
+                # https://fishshell.com/docs/current/cmds/source.html
+                # By contrast, `.` is the traditional syntax in sh and
+                # `source` isn't always supported in all circumstances.
+                if [ "$_shell" = "fish" ]; then
+                    _line="$_pretty_line"
+                else
+                    _line="$_robust_line"
+                fi
+                say_verbose "adding $_line to $_target"
+                # prepend an extra newline in case the user's file is missing a trailing one
+                ensure echo "" >> "$_target"
+                ensure echo "$_line" >> "$_target"
+                return 1
+            fi
+        else
+            say_verbose "$_install_dir already on PATH"
+        fi
+    fi
+}
+
+write_env_script_sh() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+#!/bin/sh
+# add binaries to PATH if they aren't added yet
+# affix colons on either side of \$PATH to simplify matching
+case ":\${PATH}:" in
+    *:"$_install_dir_expr":*)
+        ;;
+    *)
+        # Prepending path in case a system-installed binary needs to be overridden
+        export PATH="$_install_dir_expr:\$PATH"
+        ;;
+esac
+EOF
+}
+
+write_env_script_fish() {
+    # write this env script to the given path (this cat/EOF stuff is a "heredoc" string)
+    local _install_dir_expr="$1"
+    local _env_script_path="$2"
+    ensure cat <<EOF > "$_env_script_path"
+if not contains "$_install_dir_expr" \$PATH
+    # Prepending path in case a system-installed binary needs to be overridden
+    set -x PATH "$_install_dir_expr" \$PATH
+end
+EOF
+}
+
+check_proc() {
+    # Check for /proc by looking for the /proc/self/exe link
+    # This is only run on Linux
+    if ! test -L /proc/self/exe ; then
+        err "fatal: Unable to find /proc/self/exe.  Is /proc mounted?  Installation cannot proceed without /proc."
+    fi
+}
+
+get_bitness() {
+    need_cmd head
+    # Architecture detection without dependencies beyond coreutils.
+    # ELF files start out "\x7fELF", and the following byte is
+    #   0x01 for 32-bit and
+    #   0x02 for 64-bit.
+    # The printf builtin on some shells like dash only supports octal
+    # escape sequences, so we use those.
+    local _current_exe_head
+    _current_exe_head=$(head -c 5 /proc/self/exe )
+    if [ "$_current_exe_head" = "$(printf '\177ELF\001')" ]; then
+        echo 32
+    elif [ "$_current_exe_head" = "$(printf '\177ELF\002')" ]; then
+        echo 64
+    else
+        err "unknown platform bitness"
+    fi
+}
+
+is_host_amd64_elf() {
+    need_cmd head
+    need_cmd tail
+    # ELF e_machine detection without dependencies beyond coreutils.
+    # Two-byte field at offset 0x12 indicates the CPU,
+    # but we're interested in it being 0x3E to indicate amd64, or not that.
+    local _current_exe_machine
+    _current_exe_machine=$(head -c 19 /proc/self/exe | tail -c 1)
+    [ "$_current_exe_machine" = "$(printf '\076')" ]
+}
+
+get_endianness() {
+    local cputype=$1
+    local suffix_eb=$2
+    local suffix_el=$3
+
+    # detect endianness without od/hexdump, like get_bitness() does.
+    need_cmd head
+    need_cmd tail
+
+    local _current_exe_endianness
+    _current_exe_endianness="$(head -c 6 /proc/self/exe | tail -c 1)"
+    if [ "$_current_exe_endianness" = "$(printf '\001')" ]; then
+        echo "${cputype}${suffix_el}"
+    elif [ "$_current_exe_endianness" = "$(printf '\002')" ]; then
+        echo "${cputype}${suffix_eb}"
+    else
+        err "unknown platform endianness"
+    fi
+}
+
+get_architecture() {
+    local _ostype
+    local _cputype
+    _ostype="$(uname -s)"
+    _cputype="$(uname -m)"
+    local _clibtype="gnu"
+    local _local_glibc
+
+    if [ "$_ostype" = Linux ]; then
+        if [ "$(uname -o)" = Android ]; then
+            _ostype=Android
+        fi
+        if ldd --version 2>&1 | grep -q 'musl'; then
+            _clibtype="musl-dynamic"
+        # glibc, but is it a compatible glibc?
+        else
+            # Parsing version out from line 1 like:
+            # ldd (Ubuntu GLIBC 2.35-0ubuntu3.1) 2.35
+            _local_glibc="$(ldd --version | awk -F' ' '{ if (FNR<=1) print $NF }')"
+
+            if [ "$(echo "${_local_glibc}" | awk -F. '{ print $1 }')" = $BUILDER_GLIBC_MAJOR ] && [ "$(echo "${_local_glibc}" | awk -F. '{ print $2 }')" -ge $BUILDER_GLIBC_SERIES ]; then
+                _clibtype="gnu"
+            else
+                say "System glibc version (\`${_local_glibc}') is too old; using musl" >&2
+                _clibtype="musl-static"
+            fi
+        fi
+    fi
+
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = i386 ]; then
+        # Darwin `uname -m` lies
+        if sysctl hw.optional.x86_64 | grep -q ': 1'; then
+            _cputype=x86_64
+        fi
+    fi
+
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = x86_64 ]; then
+        # Rosetta on aarch64
+        if [ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]; then
+            _cputype=aarch64
+        fi
+    fi
+
+    if [ "$_ostype" = SunOS ]; then
+        # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
+        # so use "uname -o" to disambiguate.  We use the full path to the
+        # system uname in case the user has coreutils uname first in PATH,
+        # which has historically sometimes printed the wrong value here.
+        if [ "$(/usr/bin/uname -o)" = illumos ]; then
+            _ostype=illumos
+        fi
+
+        # illumos systems have multi-arch userlands, and "uname -m" reports the
+        # machine hardware name; e.g., "i86pc" on both 32- and 64-bit x86
+        # systems.  Check for the native (widest) instruction set on the
+        # running kernel:
+        if [ "$_cputype" = i86pc ]; then
+            _cputype="$(isainfo -n)"
+        fi
+    fi
+
+    case "$_ostype" in
+
+        Android)
+            _ostype=linux-android
+            ;;
+
+        Linux)
+            check_proc
+            _ostype=unknown-linux-$_clibtype
+            _bitness=$(get_bitness)
+            ;;
+
+        FreeBSD)
+            _ostype=unknown-freebsd
+            ;;
+
+        NetBSD)
+            _ostype=unknown-netbsd
+            ;;
+
+        DragonFly)
+            _ostype=unknown-dragonfly
+            ;;
+
+        Darwin)
+            _ostype=apple-darwin
+            ;;
+
+        illumos)
+            _ostype=unknown-illumos
+            ;;
+
+        MINGW* | MSYS* | CYGWIN* | Windows_NT)
+            _ostype=pc-windows-gnu
+            ;;
+
+        *)
+            err "unrecognized OS type: $_ostype"
+            ;;
+
+    esac
+
+    case "$_cputype" in
+
+        i386 | i486 | i686 | i786 | x86)
+            _cputype=i686
+            ;;
+
+        xscale | arm)
+            _cputype=arm
+            if [ "$_ostype" = "linux-android" ]; then
+                _ostype=linux-androideabi
+            fi
+            ;;
+
+        armv6l)
+            _cputype=arm
+            if [ "$_ostype" = "linux-android" ]; then
+                _ostype=linux-androideabi
+            else
+                _ostype="${_ostype}eabihf"
+            fi
+            ;;
+
+        armv7l | armv8l)
+            _cputype=armv7
+            if [ "$_ostype" = "linux-android" ]; then
+                _ostype=linux-androideabi
+            else
+                _ostype="${_ostype}eabihf"
+            fi
+            ;;
+
+        aarch64 | arm64)
+            _cputype=aarch64
+            ;;
+
+        x86_64 | x86-64 | x64 | amd64)
+            _cputype=x86_64
+            ;;
+
+        mips)
+            _cputype=$(get_endianness mips '' el)
+            ;;
+
+        mips64)
+            if [ "$_bitness" -eq 64 ]; then
+                # only n64 ABI is supported for now
+                _ostype="${_ostype}abi64"
+                _cputype=$(get_endianness mips64 '' el)
+            fi
+            ;;
+
+        ppc)
+            _cputype=powerpc
+            ;;
+
+        ppc64)
+            _cputype=powerpc64
+            ;;
+
+        ppc64le)
+            _cputype=powerpc64le
+            ;;
+
+        s390x)
+            _cputype=s390x
+            ;;
+        riscv64)
+            _cputype=riscv64gc
+            ;;
+        loongarch64)
+            _cputype=loongarch64
+            ;;
+        *)
+            err "unknown CPU type: $_cputype"
+
+    esac
+
+    # Detect 64-bit linux with 32-bit userland
+    if [ "${_ostype}" = unknown-linux-gnu ] && [ "${_bitness}" -eq 32 ]; then
+        case $_cputype in
+            x86_64)
+                # 32-bit executable for amd64 = x32
+                if is_host_amd64_elf; then {
+                    err "x32 linux unsupported"
+                }; else
+                    _cputype=i686
+                fi
+                ;;
+            mips64)
+                _cputype=$(get_endianness mips '' el)
+                ;;
+            powerpc64)
+                _cputype=powerpc
+                ;;
+            aarch64)
+                _cputype=armv7
+                if [ "$_ostype" = "linux-android" ]; then
+                    _ostype=linux-androideabi
+                else
+                    _ostype="${_ostype}eabihf"
+                fi
+                ;;
+            riscv64gc)
+                err "riscv64 with 32-bit userland unsupported"
+                ;;
+        esac
+    fi
+
+    # treat armv7 systems without neon as plain arm
+    if [ "$_ostype" = "unknown-linux-gnueabihf" ] && [ "$_cputype" = armv7 ]; then
+        if ensure grep '^Features' /proc/cpuinfo | grep -q -v neon; then
+            # At least one processor does not have NEON.
+            _cputype=arm
+        fi
+    fi
+
+    _arch="${_cputype}-${_ostype}"
+
+    RETVAL="$_arch"
+}
+
+say() {
+    if [ "0" = "$PRINT_QUIET" ]; then
+        echo "$1"
+    fi
+}
+
+say_verbose() {
+    if [ "1" = "$PRINT_VERBOSE" ]; then
+        echo "$1"
+    fi
+}
+
+err() {
+    if [ "0" = "$PRINT_QUIET" ]; then
+        local red
+        local reset
+        red=$(tput setaf 1 2>/dev/null || echo '')
+        reset=$(tput sgr0 2>/dev/null || echo '')
+        say "${red}ERROR${reset}: $1" >&2
+    fi
+    exit 1
+}
+
+need_cmd() {
+    if ! check_cmd "$1"
+    then err "need '$1' (command not found)"
+    fi
+}
+
+check_cmd() {
+    command -v "$1" > /dev/null 2>&1
+    return $?
+}
+
+assert_nz() {
+    if [ -z "$1" ]; then err "assert_nz $2"; fi
+}
+
+# Run a command that should never fail. If the command fails execution
+# will immediately terminate with an error showing the failing
+# command.
+ensure() {
+    if ! "$@"; then err "command failed: $*"; fi
+}
+
+# This is just for indicating that commands' results are being
+# intentionally ignored. Usually, because it's being executed
+# as part of error handling.
+ignore() {
+    "$@"
+}
+
+# This wraps curl or wget. Try curl first, if not installed,
+# use wget instead.
+downloader() {
+    if check_cmd curl
+    then _dld=curl
+    elif check_cmd wget
+    then _dld=wget
+    else _dld='curl or wget' # to be used in error message of need_cmd
+    fi
+
+    if [ "$1" = --check ]
+    then need_cmd "$_dld"
+    elif [ "$_dld" = curl ]
+    then curl -sSfL "$1" -o "$2"
+    elif [ "$_dld" = wget ]
+    then wget "$1" -O "$2"
+    else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+download_binary_and_run_installer "$@" || exit 1
+
+================ axolotlsay.rb ================
+class Axolotlsay < Formula
+  desc "💬 a CLI for learning to distribute CLIs in rust"
+  homepage "https://github.com/axodotdev/axolotlsay-hybrid"
+  version "0.10.2"
+  if OS.mac?
+    if Hardware::CPU.arm?
+      url "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-aarch64-apple-darwin.tar.xz"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-x86_64-apple-darwin.tar.xz"
+    end
+  end
+  if OS.linux?
+    if Hardware::CPU.intel?
+      url "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-x86_64-unknown-linux-gnu.tar.xz"
+    end
+  end
+  license "MIT OR Apache-2.0"
+
+  BINARY_ALIASES = {"aarch64-apple-darwin": {}, "x86_64-apple-darwin": {}, "x86_64-pc-windows-gnu": {}, "x86_64-unknown-linux-gnu": {}}
+
+  def target_triple
+    cpu = Hardware::CPU.arm? ? "aarch64" : "x86_64"
+    os = OS.mac? ? "apple-darwin" : "unknown-linux-gnu"
+
+    "#{cpu}-#{os}"
+  end
+
+  def install_binary_aliases!
+    BINARY_ALIASES[target_triple.to_sym].each do |source, dests|
+      dests.each do |dest|
+        bin.install_symlink bin/source.to_s => dest
+      end
+    end
+  end
+
+  def install
+    if OS.mac? && Hardware::CPU.arm?
+      bin.install "axolotlsay"
+    end
+    if OS.mac? && Hardware::CPU.intel?
+      bin.install "axolotlsay"
+    end
+    if OS.linux? && Hardware::CPU.intel?
+      bin.install "axolotlsay"
+    end
+
+    install_binary_aliases!
+
+    # Homebrew will automatically install these, so we don't need to do that
+    doc_files = Dir["README.*", "readme.*", "LICENSE", "LICENSE.*", "CHANGELOG.*"]
+    leftover_contents = Dir["*"] - doc_files
+
+    # Install any leftover files in pkgshare; these are probably config or
+    # sample files.
+    pkgshare.install(*leftover_contents) unless leftover_contents.empty?
+  end
+end
+
+================ axolotlsay-installer.ps1 ================
+# Licensed under the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+<#
+.SYNOPSIS
+
+The installer for axolotlsay 0.10.2
+
+.DESCRIPTION
+
+This script detects what platform you're on and fetches an appropriate archive from
+https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2
+then unpacks the binaries and installs them to
+
+    $env:CARGO_HOME/bin (or $HOME/.cargo/bin)
+
+It will then add that dir to PATH by editing your Environment.Path registry key
+
+.PARAMETER ArtifactDownloadUrl
+The URL of the directory where artifacts can be fetched from
+
+.PARAMETER NoModifyPath
+Don't add the install directory to PATH
+
+.PARAMETER Help
+Print help
+
+#>
+
+param (
+    [Parameter(HelpMessage = "The URL of the directory where artifacts can be fetched from")]
+    [string]$ArtifactDownloadUrl = 'https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2',
+    [Parameter(HelpMessage = "Don't add the install directory to PATH")]
+    [switch]$NoModifyPath,
+    [Parameter(HelpMessage = "Print Help")]
+    [switch]$Help
+)
+
+$app_name = 'axolotlsay'
+$app_version = '0.10.2'
+
+$receipt = @"
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+"@
+$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
+
+function Install-Binary($install_args) {
+  if ($Help) {
+    Get-Help $PSCommandPath -Detailed
+    Exit
+  }
+
+  Initialize-Environment
+
+  # Platform info injected by cargo-dist
+  $platforms = @{
+    "aarch64-pc-windows-msvc" = @{
+      "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.zip"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
+      "zip_ext" = ".zip"
+      "aliases" = @{
+      }
+      "aliases_json" = '{}'
+    }
+    "x86_64-pc-windows-msvc" = @{
+      "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.zip"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
+      "zip_ext" = ".zip"
+      "aliases" = @{
+      }
+      "aliases_json" = '{}'
+    }
+  }
+
+  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  # FIXME: add a flag that lets the user not do this step
+  try {
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
+}
+
+function Get-TargetTriple() {
+  try {
+    # NOTE: this might return X64 on ARM64 Windows, which is OK since emulation is available.
+    # It works correctly starting in PowerShell Core 7.3 and Windows PowerShell in Win 11 22H2.
+    # Ideally this would just be
+    #   [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    # but that gets a type from the wrong assembly on Windows PowerShell (i.e. not Core)
+    $a = [System.Reflection.Assembly]::LoadWithPartialName("System.Runtime.InteropServices.RuntimeInformation")
+    $t = $a.GetType("System.Runtime.InteropServices.RuntimeInformation")
+    $p = $t.GetProperty("OSArchitecture")
+    # Possible OSArchitecture Values: https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.architecture
+    # Rust supported platforms: https://doc.rust-lang.org/stable/rustc/platform-support.html
+    switch ($p.GetValue($null).ToString())
+    {
+      "X86" { return "i686-pc-windows-msvc" }
+      "X64" { return "x86_64-pc-windows-msvc" }
+      "Arm" { return "thumbv7a-pc-windows-msvc" }
+      "Arm64" { return "aarch64-pc-windows-msvc" }
+    }
+  } catch {
+    # The above was added in .NET 4.7.1, so Windows PowerShell in versions of Windows
+    # prior to Windows 10 v1709 may not have this API.
+    Write-Verbose "Get-TargetTriple: Exception when trying to determine OS architecture."
+    Write-Verbose $_
+  }
+
+  # This is available in .NET 4.0. We already checked for PS 5, which requires .NET 4.5.
+  Write-Verbose("Get-TargetTriple: falling back to Is64BitOperatingSystem.")
+  if ([System.Environment]::Is64BitOperatingSystem) {
+    return "x86_64-pc-windows-msvc"
+  } else {
+    return "i686-pc-windows-msvc"
+  }
+}
+
+function Download($download_url, $platforms) {
+  $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
+  # Lookup what we expect this platform to look like
+  $info = $platforms[$arch]
+  $zip_ext = $info["zip_ext"]
+  $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
+  $artifact_name = $info["artifact_name"]
+
+  # Make a new temp dir to unpack things to
+  $tmp = New-Temp-Dir
+  $dir_path = "$tmp\$app_name$zip_ext"
+
+  # Download and unpack!
+  $url = "$download_url/$artifact_name"
+  Write-Information "Downloading $app_name $app_version ($arch)"
+  Write-Verbose "  from $url"
+  Write-Verbose "  to $dir_path"
+  $wc = New-Object Net.Webclient
+  $wc.downloadFile($url, $dir_path)
+
+  Write-Verbose "Unpacking to $tmp"
+
+  # Select the tool to unpack the files with.
+  #
+  # As of windows 10(?), powershell comes with tar preinstalled, but in practice
+  # it only seems to support .tar.gz, and not xz/zstd. Still, we should try to
+  # forward all tars to it in case the user has a machine that can handle it!
+  switch -Wildcard ($zip_ext) {
+    ".zip" {
+      Expand-Archive -Path $dir_path -DestinationPath "$tmp";
+      Break
+    }
+    ".tar.*" {
+      tar xf $dir_path --strip-components 1 -C "$tmp";
+      Break
+    }
+    Default {
+      throw "ERROR: unknown archive format $zip_ext"
+    }
+  }
+
+  # Let the next step know what to copy
+  $bin_paths = @()
+  foreach ($bin_name in $bin_names) {
+    Write-Verbose "  Unpacked $bin_name"
+    $bin_paths += "$tmp\$bin_name"
+  }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
+
+  if ($null -ne $info["updater"]) {
+    $updater_id = $info["updater"]["artifact_name"]
+    $updater_url = "$download_url/$updater_id"
+    $out_name = "$tmp\axolotlsay-update.exe"
+
+    $wc.downloadFile($updater_url, $out_name)
+    $bin_paths += $out_name
+  }
+
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
+}
+
+function Invoke-Installer($artifacts, $platforms) {
+  # Replaces the placeholder binary entry with the actual list of binaries
+  $arch = Get-TargetTriple
+
+  if (-not $platforms.ContainsKey($arch)) {
+    $platforms_json = ConvertTo-Json $platforms
+    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
+  }
+
+  $info = $platforms[$arch]
+
+  # The actual path we're going to install to
+  $dest_dir = $null
+  $dest_dir_lib = $null
+  # The install prefix we write to the receipt.
+  # For organized install methods like CargoHome, which have
+  # subdirectories, this is the root without `/bin`. For other
+  # methods, this is the same as `_install_dir`.
+  $receipt_dest_dir = $null
+  # Before actually consulting the configured install strategy, see
+  # if we're overriding it.
+  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+
+    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
+    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+  if (-Not $dest_dir) {
+    # first try $env:CARGO_HOME, then fallback to $HOME
+    # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
+    $root = if (($base_dir = $env:CARGO_HOME)) {
+      $base_dir
+    } elseif (($base_dir = $HOME)) {
+      Join-Path $base_dir ".cargo"
+    } else {
+      throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
+    }
+
+    $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
+    $receipt_dest_dir = $root
+  }
+
+  # Looks like all of the above assignments failed
+  if (-Not $dest_dir) {
+    throw "ERROR: could not find a valid path to install to; please check the installation instructions"
+  }
+
+  # The replace call here ensures proper escaping is inlined into the receipt
+  $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+
+  $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
+  Write-Information "Installing to $dest_dir"
+  # Just copy the binaries from the temp location to the install dir
+  foreach ($bin_path in $artifacts["bin_paths"]) {
+    $installed_file = Split-Path -Path "$bin_path" -Leaf
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+
+    if (($dests = $info["aliases"][$installed_file])) {
+      $source = Join-Path "$dest_dir" "$installed_file"
+      foreach ($dest_name in $dests) {
+          $dest = Join-Path $dest_dir $dest_name
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
+      }
+    }
+  }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
+
+  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  # Also replace the aliases with the arch-specific one
+  $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
+
+  # Write the install receipt
+  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+  # default in newer .NETs but I'd rather not rely on that at this point).
+  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+
+  Write-Information ">o_o< everything's installed!"
+  if (-not $NoModifyPath) {
+    Add-Ci-Path $dest_dir
+    if (Add-Path $dest_dir) {
+        Write-Information ""
+        Write-Information "$dest_dir was added to your PATH, you may need to restart your shell for that to take effect."
+    }
+  }
+}
+
+# Attempt to do CI-specific rituals to get the install-dir on PATH faster
+function Add-Ci-Path($OrigPathToAdd) {
+  # If GITHUB_PATH is present, then write install_dir to the file it refs.
+  # After each GitHub Action, the contents will be added to PATH.
+  # So if you put a curl | sh for this script in its own "run" step,
+  # the next step will have this dir on PATH.
+  #
+  # Note that GITHUB_PATH will not resolve any variables, so we in fact
+  # want to write the install dir and not an expression that evals to it
+  if (($gh_path = $env:GITHUB_PATH)) {
+    Write-Output "$OrigPathToAdd" | Out-File -FilePath "$gh_path" -Encoding utf8 -Append
+  }
+}
+
+# Try to add the given path to PATH via the registry
+#
+# Returns true if the registry was modified, otherwise returns false
+# (indicating it was already on PATH)
+function Add-Path($OrigPathToAdd) {
+  Write-Verbose "Adding $OrigPathToAdd to your PATH"
+  $RegistryPath = "HKCU:\Environment"
+  $PropertyName = "Path"
+  $PathToAdd = $OrigPathToAdd
+
+  $Item = if (Test-Path $RegistryPath) {
+    # If the registry key exists, get it
+    Get-Item -Path $RegistryPath
+  } else {
+    # If the registry key doesn't exist, create it
+    Write-Verbose  "Creating $RegistryPath"
+    New-Item -Path $RegistryPath -Force
+  }
+
+  $OldPath = ""
+  try {
+    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
+    # Otherwise assume there's already paths in here and use a ; separator
+    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
+    $PathToAdd = "$PathToAdd;"
+  } catch {
+    # We'll be creating the PATH from scratch
+    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
+  }
+
+  # Check if the path is already there
+  #
+  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
+  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
+  # both sides of the input, allowing us to pretend we're always in the middle of a list.
+  Write-Verbose "Old $PropertyName Property is $OldPath"
+  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
+    # Already on path, nothing to do
+    Write-Verbose "install dir already on PATH, all done!"
+    return $false
+  } else {
+    # Actually update PATH
+    Write-Verbose "Actually mutating $PropertyName Property"
+    $NewPath = $PathToAdd + $OldPath
+    # We use -Force here to make the value already existing not be an error
+    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    return $true
+  }
+}
+
+function Initialize-Environment() {
+  If (($PSVersionTable.PSVersion.Major) -lt 5) {
+    throw @"
+Error: PowerShell 5 or later is required to install $app_name.
+Upgrade PowerShell:
+
+    https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell
+
+"@
+  }
+
+  # show notification to change execution policy:
+  $allowedExecutionPolicy = @('Unrestricted', 'RemoteSigned', 'ByPass')
+  If ((Get-ExecutionPolicy).ToString() -notin $allowedExecutionPolicy) {
+    throw @"
+Error: PowerShell requires an execution policy in [$($allowedExecutionPolicy -join ", ")] to run $app_name. For example, to set the execution policy to 'RemoteSigned' please run:
+
+    Set-ExecutionPolicy RemoteSigned -scope CurrentUser
+
+"@
+  }
+
+  # GitHub requires TLS 1.2
+  If ([System.Enum]::GetNames([System.Net.SecurityProtocolType]) -notcontains 'Tls12') {
+    throw @"
+Error: Installing $app_name requires at least .NET Framework 4.5
+Please download and install it first:
+
+    https://www.microsoft.com/net/download
+
+"@
+  }
+}
+
+function New-Temp-Dir() {
+  [CmdletBinding(SupportsShouldProcess)]
+  param()
+  $parent = [System.IO.Path]::GetTempPath()
+  [string] $name = [System.Guid]::NewGuid()
+  New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+# PSScriptAnalyzer doesn't like how we use our params as globals, this calms it
+$Null = $ArtifactDownloadUrl, $NoModifyPath, $Help
+# Make Write-Information statements be visible
+$InformationPreference = "Continue"
+
+# The default interactive handler
+try {
+  Install-Binary "$Args"
+} catch {
+  Write-Information $_
+  exit 1
+}
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
-  "announcement_tag": "v0.6.0",
+  "announcement_tag": "v0.10.2",
   "announcement_tag_is_implicit": true,
   "announcement_is_prerelease": false,
-  "announcement_title": "v0.6.0",
-  "announcement_github_body": "## Install axolotlsay-js 0.6.0\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\npowershell -c \"irm https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-installer.ps1 | iex\"\n```\n\n### Install prebuilt binaries via Homebrew\n\n```sh\nbrew install axodotdev/packages/axolotlsay-js\n```\n\n## Download axolotlsay-js 0.6.0\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-js-x86_64-apple-darwin.tar.xz](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-x86_64-apple-darwin.tar.xz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-x86_64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-js-x86_64-pc-windows-msvc.zip](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-x86_64-pc-windows-msvc.zip) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-x86_64-pc-windows-msvc.zip.sha256) |\n| [axolotlsay-js-x86_64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n\n",
+  "announcement_title": "v0.10.2",
+  "announcement_github_body": "# axolotlsay 0.10.2\n\n## Install axolotlsay 0.10.2\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\npowershell -c \"irm https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-installer.ps1 | iex\"\n```\n\n### Install prebuilt binaries via Homebrew\n\n```sh\nbrew install axodotdev/packages/axolotlsay\n```\n\n## Download axolotlsay 0.10.2\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.xz](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-aarch64-apple-darwin.tar.xz) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-aarch64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.xz](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-x86_64-apple-darwin.tar.xz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-x86_64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.zip](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-x86_64-pc-windows-msvc.zip) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-x86_64-pc-windows-msvc.zip.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n\n# axolotlsay-js 0.10.2\n\n## Install axolotlsay-js 0.10.2\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\npowershell -c \"irm https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-installer.ps1 | iex\"\n```\n\n### Install prebuilt binaries via Homebrew\n\n```sh\nbrew install axodotdev/packages/axolotlsay-js\n```\n\n## Download axolotlsay-js 0.10.2\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-js-aarch64-apple-darwin.tar.xz](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-aarch64-apple-darwin.tar.xz) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-aarch64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-js-x86_64-apple-darwin.tar.xz](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-x86_64-apple-darwin.tar.xz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-x86_64-apple-darwin.tar.xz.sha256) |\n| [axolotlsay-js-x86_64-pc-windows-msvc.zip](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-x86_64-pc-windows-msvc.zip) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-x86_64-pc-windows-msvc.zip.sha256) |\n| [axolotlsay-js-x86_64-unknown-linux-gnu.tar.xz](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n\n",
   "releases": [
     {
+      "app_name": "axolotlsay",
+      "app_version": "0.10.2",
+      "artifacts": [
+        "source.tar.gz",
+        "source.tar.gz.sha256",
+        "axolotlsay-installer.sh",
+        "axolotlsay-installer.ps1",
+        "axolotlsay.rb",
+        "axolotlsay-aarch64-apple-darwin.tar.xz",
+        "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-apple-darwin.tar.xz",
+        "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
+        "axolotlsay-x86_64-pc-windows-msvc.zip",
+        "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
+        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz",
+        "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256"
+      ],
+      "hosting": {
+        "github": {
+          "artifact_download_url": "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2",
+          "owner": "axodotdev",
+          "repo": "axolotlsay-hybrid"
+        }
+      }
+    },
+    {
       "app_name": "axolotlsay-js",
-      "app_version": "0.6.0",
+      "app_version": "0.10.2",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
         "axolotlsay-js-installer.sh",
         "axolotlsay-js-installer.ps1",
         "axolotlsay-js.rb",
+        "axolotlsay-js-aarch64-apple-darwin.tar.xz",
+        "axolotlsay-js-aarch64-apple-darwin.tar.xz.sha256",
         "axolotlsay-js-x86_64-apple-darwin.tar.xz",
         "axolotlsay-js-x86_64-apple-darwin.tar.xz.sha256",
         "axolotlsay-js-x86_64-pc-windows-msvc.zip",
@@ -1522,7 +3052,7 @@ try {
       ],
       "hosting": {
         "github": {
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0",
+          "artifact_download_url": "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2",
           "owner": "axodotdev",
           "repo": "axolotlsay-hybrid"
         }
@@ -1530,6 +3060,109 @@ try {
     }
   ],
   "artifacts": {
+    "axolotlsay-aarch64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "aarch64-apple-darwin"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256"
+    },
+    "axolotlsay-aarch64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "aarch64-apple-darwin"
+      ]
+    },
+    "axolotlsay-installer.ps1": {
+      "name": "axolotlsay-installer.ps1",
+      "kind": "installer",
+      "target_triples": [
+        "aarch64-pc-windows-msvc",
+        "x86_64-pc-windows-msvc"
+      ],
+      "install_hint": "powershell -c \"irm https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-installer.ps1 | iex\"",
+      "description": "Install prebuilt binaries via powershell script"
+    },
+    "axolotlsay-installer.sh": {
+      "name": "axolotlsay-installer.sh",
+      "kind": "installer",
+      "target_triples": [
+        "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-pc-windows-gnu",
+        "x86_64-unknown-linux-gnu"
+      ],
+      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-installer.sh | sh",
+      "description": "Install prebuilt binaries via shell script"
+    },
+    "axolotlsay-js-aarch64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-js-aarch64-apple-darwin.tar.xz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "aarch64-apple-darwin"
+      ],
+      "assets": [
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "axolotlsay-js-aarch64-apple-darwin-axolotlsay-js",
+          "name": "axolotlsay-js",
+          "path": "axolotlsay-js",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-js-aarch64-apple-darwin.tar.xz.sha256"
+    },
+    "axolotlsay-js-aarch64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-js-aarch64-apple-darwin.tar.xz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "aarch64-apple-darwin"
+      ]
+    },
     "axolotlsay-js-installer.ps1": {
       "name": "axolotlsay-js-installer.ps1",
       "kind": "installer",
@@ -1537,7 +3170,7 @@ try {
         "aarch64-pc-windows-msvc",
         "x86_64-pc-windows-msvc"
       ],
-      "install_hint": "powershell -c \"irm https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-installer.ps1 | iex\"",
+      "install_hint": "powershell -c \"irm https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-installer.ps1 | iex\"",
       "description": "Install prebuilt binaries via powershell script"
     },
     "axolotlsay-js-installer.sh": {
@@ -1549,7 +3182,7 @@ try {
         "x86_64-pc-windows-gnu",
         "x86_64-unknown-linux-gnu"
       ],
-      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.6.0/axolotlsay-js-installer.sh | sh",
+      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2/axolotlsay-js-installer.sh | sh",
       "description": "Install prebuilt binaries via shell script"
     },
     "axolotlsay-js-x86_64-apple-darwin.tar.xz": {
@@ -1678,6 +3311,147 @@ try {
       "install_hint": "brew install axodotdev/packages/axolotlsay-js",
       "description": "Install prebuilt binaries via Homebrew"
     },
+    "axolotlsay-x86_64-apple-darwin.tar.xz": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-apple-darwin"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256"
+    },
+    "axolotlsay-x86_64-apple-darwin.tar.xz.sha256": {
+      "name": "axolotlsay-x86_64-apple-darwin.tar.xz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-apple-darwin"
+      ]
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay.exe",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256"
+    },
+    "axolotlsay-x86_64-pc-windows-msvc.zip.sha256": {
+      "name": "axolotlsay-x86_64-pc-windows-msvc.zip.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ]
+    },
+    "axolotlsay-x86_64-unknown-linux-gnu.tar.xz": {
+      "name": "axolotlsay-x86_64-unknown-linux-gnu.tar.xz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-unknown-linux-gnu"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256"
+    },
+    "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256": {
+      "name": "axolotlsay-x86_64-unknown-linux-gnu.tar.xz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-unknown-linux-gnu"
+      ]
+    },
+    "axolotlsay.rb": {
+      "name": "axolotlsay.rb",
+      "kind": "installer",
+      "target_triples": [
+        "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-pc-windows-gnu",
+        "x86_64-unknown-linux-gnu"
+      ],
+      "install_hint": "brew install axodotdev/packages/axolotlsay",
+      "description": "Install prebuilt binaries via Homebrew"
+    },
     "source.tar.gz": {
       "name": "source.tar.gz",
       "kind": "source-tarball",
@@ -1700,6 +3474,15 @@ try {
     "github": {
       "artifacts_matrix": {
         "include": [
+          {
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
+            "runner": "macos-12",
+            "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
+            "cache_provider": "github"
+          },
           {
             "targets": [
               "x86_64-apple-darwin"
@@ -1729,7 +3512,7 @@ try {
           }
         ]
       },
-      "pr_run_mode": "plan"
+      "pr_run_mode": "upload"
     }
   },
   "linkage": []
@@ -1853,6 +3636,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
       - name: Install cargo-dist
         run: ${{ matrix.install_dist }}
       # Get the dist-manifest

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1036,11 +1036,11 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1081,7 +1081,7 @@ download_binary_and_run_installer "$@" || exit 1
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1284,7 +1284,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1311,7 +1311,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1337,7 +1337,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1480,7 +1480,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -1605,13 +1605,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2403,7 +2403,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2479,7 +2479,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1036,11 +1036,11 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1081,7 +1081,7 @@ download_binary_and_run_installer "$@" || exit 1
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1284,7 +1284,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1311,7 +1311,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1337,7 +1337,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1480,7 +1480,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -1605,13 +1605,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2403,7 +2403,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2479,7 +2479,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/coolbeans",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1028,7 +1028,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1088,7 +1088,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1514,11 +1514,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1559,7 +1559,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1762,7 +1762,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1789,7 +1789,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1815,7 +1815,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1958,7 +1958,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2083,13 +2083,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2883,7 +2883,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2968,7 +2968,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1508,11 +1508,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1553,7 +1553,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1756,7 +1756,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1783,7 +1783,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1809,7 +1809,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1952,7 +1952,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2077,13 +2077,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2875,7 +2875,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2958,7 +2958,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
@@ -1500,11 +1500,11 @@ try {
   exit 1
 }
 
-================ npm-package.tar.gz/package/.gitignore ================
+================ axolotlsay-npm-package.tar.gz/package/.gitignore ================
 /node_modules
 
 
-================ npm-package.tar.gz/package/CHANGELOG.md ================
+================ axolotlsay-npm-package.tar.gz/package/CHANGELOG.md ================
 # Version 0.2.2
 
 ```text
@@ -1545,7 +1545,7 @@ try {
 ≽(◕ ᴗ ◕)≼
 ```
 
-================ npm-package.tar.gz/package/LICENSE-APACHE ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-APACHE ================
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -1748,7 +1748,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-================ npm-package.tar.gz/package/LICENSE-MIT ================
+================ axolotlsay-npm-package.tar.gz/package/LICENSE-MIT ================
 Copyright (c) 2022-2024 Axo Developer Co.
 
 Permission is hereby granted, free of charge, to any
@@ -1775,7 +1775,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-================ npm-package.tar.gz/package/README.md ================
+================ axolotlsay-npm-package.tar.gz/package/README.md ================
 # axolotlsay
 > 💬 a CLI for learning to distribute CLIs in rust
 
@@ -1801,7 +1801,7 @@ Licensed under either of
 
 at your option.
 
-================ npm-package.tar.gz/package/binary-install.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
 const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
@@ -1944,7 +1944,7 @@ class Package {
 
 module.exports.Package = Package;
 
-================ npm-package.tar.gz/package/binary.js ================
+================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");
 const os = require("os");
 const cTable = require("console.table");
@@ -2069,13 +2069,13 @@ module.exports = {
   getPackage,
 };
 
-================ npm-package.tar.gz/package/install.js ================
+================ axolotlsay-npm-package.tar.gz/package/install.js ================
 #!/usr/bin/env node
 
 const { install } = require("./binary");
 install(false);
 
-================ npm-package.tar.gz/package/npm-shrinkwrap.json ================
+================ axolotlsay-npm-package.tar.gz/package/npm-shrinkwrap.json ================
 {
   "lockfileVersion": 3,
   "name": "@axodotdev/axolotlsay",
@@ -2867,7 +2867,7 @@ install(false);
   "requires": true,
   "version": "0.2.2"
 }
-================ npm-package.tar.gz/package/package.json ================
+================ axolotlsay-npm-package.tar.gz/package/package.json ================
 {
   "artifactDownloadUrl": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
   "author": "axodotdev <hello@axo.dev>",
@@ -2950,7 +2950,7 @@ install(false);
     "npm": "9.5.0"
   }
 }
-================ npm-package.tar.gz/package/run-axolotlsay.js ================
+================ axolotlsay-npm-package.tar.gz/package/run-axolotlsay.js ================
 #!/usr/bin/env node
 
 const { run } = require("./binary");

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1016,7 +1016,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1076,7 +1076,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -999,7 +999,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1059,7 +1059,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -999,7 +999,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1059,7 +1059,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -999,7 +999,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1059,7 +1059,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -999,7 +999,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1059,7 +1059,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1011,7 +1011,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1071,7 +1071,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -999,7 +999,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1059,7 +1059,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -999,7 +999,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1059,7 +1059,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -999,7 +999,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1059,7 +1059,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -999,7 +999,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1059,7 +1059,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -2,7 +2,7 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
-================ installer.sh ================
+================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
 #
@@ -1011,7 +1011,7 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ formula.rb ================
+================ axolotlsay.rb ================
 class Axolotlsay < Formula
   desc "💬 a CLI for learning to distribute CLIs in rust"
   homepage "https://github.com/axodotdev/axolotlsay"
@@ -1071,7 +1071,7 @@ class Axolotlsay < Formula
   end
 end
 
-================ installer.ps1 ================
+================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed


### PR DESCRIPTION
This introduces a new axoproject WorkspaceGraph abstraction that exists to replace the old Workspaces approach. The purpose of this new abstraction is that it supports nested workspaces, while still allowing you to work with all the packages uniformly.

Most code largely remains the same, as it looks up properties of packages by id, or queries a property of all workspaces/packages, where essentially nothing is changed.

Also all logic to inherit config from workspaces to packages is just changed to inherit from the *root* package, as we don't want to support multiple `[workspace.metadata.dist]` entries.

compute_build functions have been changed to take a workspace, so that we try to compute N cargo builds for N cargo workspaces (discarding them if unecessary).

The URL code has once again been refactored to be more of a chain instead of redoing the same work over and over.

The `package_info` subfield of a workspace has been deprecated in favour of Asking the WorkspaceGraph, as there are different tiers of childhood now.