### PR TITLE
chore: re-drop url in Cargo.toml

### DIFF
--- a/axoproject/Cargo.toml
+++ b/axoproject/Cargo.toml
@@ -34,5 +34,5 @@ oro-package-spec = { version = "0.3.34", optional = true }
 thiserror = "1.0.60"
 pathdiff = { version = "0.2.1", features = ["camino"] }
 itertools = "0.13.0"
-url = "2.5.2"
+url = "2.5.0"
 parse-changelog = "0.6.8"


### PR DESCRIPTION
I missed that axoproject's Cargo.toml had a dep version bumped; thought it was cargo-dist's, where we can be less careful about versioning.