### PR TITLE
fix: pass correct path to generic builds

### DIFF
--- a/cargo-dist/src/build/generic.rs
+++ b/cargo-dist/src/build/generic.rs
@@ -46,8 +46,8 @@ impl<'a> DistGraphBuilder<'a> {
                 builds.push(BuildStep::Generic(GenericBuildStep {
                     target_triple: target.clone(),
                     expected_binaries,
-                    working_dir: package.manifest_path.clone(),
-                    out_dir: package.manifest_path.clone(),
+                    working_dir: package.package_root.clone(),
+                    out_dir: package.package_root.clone(),
                     build_command: package
                         .build_command
                         .clone()


### PR DESCRIPTION
Prior to this, generic builds were being passed the manifest_path, which is the path to the *manifest file* - not the directory *containing*  the manifest. This caussed the `current_dir` part of the command to error out during the `chdir` that came before the actual command invocation.