### PR TITLE
Support cdylibs from Rust/generic projects

### DIFF
--- a/book/src/reference/concepts.md
+++ b/book/src/reference/concepts.md
@@ -22,6 +22,8 @@ First let's look at how cargo-dist computes the Universe.
 
 Each Cargo package in your workspace that has [binary targets][] is considered an App by cargo-dist. cargo-dist exists to build Apps, so making sure you and it agree on is important! (We prefer "App" over "package" because we want the freedom to one day decouple the two concepts -- for now they are strictly equivalent.)
 
+In addition to your executables cargo-dist can publish your [cdylibs][], including WASM bundles. Note that, for Rust specifically, there can be [messy issues around Cargo clobbering itself when you define two many things under one package][cargo-conflicts].
+
 Most invocations of cargo-dist will start by printing out a brief summary of the Apps that cargo-dist has found:
 
 ![screenshot of the debug log, described below][workspace-log]
@@ -33,8 +35,6 @@ In the above example the available Apps are "evil-workspace", "many-bin", and "t
 To match cargo-install's behaviour, if a package defines multiple binaries then they will be considered part of the same App and zips/[installers][] for it will contain/install all of them. We figure if you went out of your way to have multiple binaries under one package (as opposed to separate packages for each), you did that for a reason! If you don't want that, make separate packages. There is currently no way to group multiple packages into a single App, although there probably will be one day.
 
 If you don't want a package-with-binaries to be considered an App that cargo-dist should care about, you can use Cargo's own builtin [publish = false][publish-false]. You can also use `dist = false` or `dist = true` in [cargo-dist's own config][config-dist], which when defined will take priority over `publish`.
-
-Things like [cdylibs][] are not picked up by cargo-dist, even though they're similar to binaries. If anyone has a usecase for this we're happy to consider it ([although there's some messy issues around Cargo clobbering itself when you define two many things under one package][cargo-conflicts]).
 
 
 
@@ -259,4 +259,3 @@ CI will just invoke cargo-dist in the following sequence:
 [rust-platform]: https://doc.rust-lang.org/nightly/rustc/platform-support.html
 [cargo-metadata]: https://doc.rust-lang.org/cargo/commands/cargo-metadata.html
 [workspace]: https://doc.rust-lang.org/cargo/reference/workspaces.html
-

--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -602,6 +602,17 @@ This is a list of installers you want to be made for your application(s). In pri
 See "repository" for some discussion on the "Artifact Download URL".
 
 
+### install-cdylibs
+
+> since 0.19.0
+
+Example: `install-cdylibs = false`
+
+Whether to install C dynamic libraries using the Homebrew/shell/PowerShell installers. This is disabled by default. When enabled, C dynamic libraries will be installed alongside a package's binaries. Packaging libraries must first be enabled using the [package-cdylibs](#package-cdylibs) option.
+
+This feature is still experimental. The currently-supported install paths will place dynamic libraries alongside binaries. This means they may appear in the user's `$PATH`, which you may find undesirable.
+
+
 ### install-path
 
 > since 0.1.0
@@ -716,6 +727,19 @@ Example: `npm-scope = "@axodotdev"`
 Specifies that [npm installers][] should be published under the given [scope][]. The leading `@` is mandatory. If you newly enable the npm installer in `cargo dist init`'s interactive UI, then it will give you an opportunity to add the scope.
 
 If no scope is specified the package will be global.
+
+
+### package-cdylibs
+
+> since 0.19.0
+
+Example: `package-cdylibs = true`
+
+This is an experimental feature.
+
+Whether to include C dynamic libraries in release archives. This is disabled by default, which means C dynamic libraries will still be built but will be excluded from release artifacts.
+
+When enabled, C dynamic libraries will be included in release artifacts but won't be installed by default. That can be enabled using the [install-cdylibs](#install-cdylibs) setting.
 
 
 ### plan-jobs

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -339,6 +339,9 @@ pub enum AssetKind {
     /// An executable artifact
     #[serde(rename = "executable")]
     Executable(ExecutableAsset),
+    /// A C dynamic library
+    #[serde(rename = "c_dynamic_library")]
+    CDynamicLibrary(DynamicLibraryAsset),
     /// A README file
     #[serde(rename = "readme")]
     Readme,
@@ -394,6 +397,15 @@ pub enum ArtifactKind {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ExecutableAsset {
     /// The name of the Artifact containing symbols for this executable
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub symbols_artifact: Option<String>,
+}
+
+/// A C dynamic library artifact (so/dylib/dll)
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DynamicLibraryAsset {
+    /// The name of the Artifact containing symbols for this library
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub symbols_artifact: Option<String>,

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -385,6 +385,28 @@ expression: json_schema
           }
         },
         {
+          "description": "A C dynamic library",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "c_dynamic_library"
+              ]
+            },
+            "symbols_artifact": {
+              "description": "The name of the Artifact containing symbols for this library",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        {
           "description": "A README file",
           "type": "object",
           "required": [

--- a/cargo-dist/src/backend/installer/homebrew.rs
+++ b/cargo-dist/src/backend/installer/homebrew.rs
@@ -45,6 +45,8 @@ pub struct HomebrewInstallerInfo {
     pub inner: InstallerInfo,
     /// Additional packages to specify as dependencies
     pub dependencies: Vec<String>,
+    /// Whether to install packaged C dynamic libraries
+    pub install_cdylibs: bool,
 }
 
 pub(crate) fn write_homebrew_formula(

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -63,6 +63,8 @@ pub struct InstallerInfo {
     pub receipt: Option<InstallReceipt>,
     /// Aliases to install binaries under
     pub bin_aliases: BTreeMap<String, BTreeMap<String, Vec<String>>>,
+    /// Whether to install generated C dynamic libraries
+    pub install_cdylibs: bool,
 }
 
 /// A fake fragment of an ExecutableZip artifact for installers
@@ -72,8 +74,10 @@ pub struct ExecutableZipFragment {
     pub id: String,
     /// The target the artifact supports
     pub target_triple: TargetTriple,
-    /// The binaries the artifact contains (name, assumed at root)
-    pub binaries: Vec<String>,
+    /// The executables the artifact contains (name, assumed at root)
+    pub executables: Vec<String>,
+    /// The dynamic libraries the artifact contains (name, assumed at root)
+    pub cdylibs: Vec<String>,
     /// The style of zip this is
     pub zip_style: ZipStyle,
     /// The updater associated with this platform

--- a/cargo-dist/src/backend/installer/npm.rs
+++ b/cargo-dist/src/backend/installer/npm.rs
@@ -195,7 +195,7 @@ fn platforms(info: &NpmInstallerInfo) -> PlatformSummary {
         let target = archive.target_triple.clone();
 
         let mut bins = SortedMap::new();
-        for bin in &archive.binaries {
+        for bin in &archive.executables {
             // Add the binary
             let raw_name = bin.strip_suffix(".exe").unwrap_or(bin);
             bins.insert(raw_name.to_owned(), bin.to_owned());

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -201,11 +201,8 @@ pub fn build_cargo_target(
         };
         match message {
             cargo_metadata::Message::CompilerArtifact(artifact) => {
-                let Some(new_exe) = artifact.executable else {
-                    continue;
-                };
-                // Hey we got an executable, record that fact
-                expected.found_bin(artifact.package_id.to_string(), new_exe, artifact.filenames);
+                // Hey we got some files, record that fact
+                expected.found_bins(artifact.package_id.to_string(), artifact.filenames);
             }
             _ => {
                 // Nothing else interesting?

--- a/cargo-dist/src/build/fake.rs
+++ b/cargo-dist/src/build/fake.rs
@@ -50,7 +50,7 @@ fn build_fake_binaries(
         let real_fake_bin = tempdir.join(&binary.file_name);
         let package_id = super::package_id_string(binary.pkg_id.as_ref());
         LocalAsset::write_new_all("", &real_fake_bin)?;
-        expectations.found_bin(package_id, real_fake_bin, vec![]);
+        expectations.found_bins(package_id, vec![real_fake_bin]);
     }
 
     expectations.process_bins(dist, manifest)?;

--- a/cargo-dist/src/build/generic.rs
+++ b/cargo-dist/src/build/generic.rs
@@ -205,7 +205,7 @@ pub fn build_generic_target(
     for binary_idx in &target.expected_binaries {
         let binary = dist_graph.binary(*binary_idx);
         let src_path = target.out_dir.join(&binary.file_name);
-        expected.found_bin(package_id_string(binary.pkg_id.as_ref()), src_path, vec![]);
+        expected.found_bins(package_id_string(binary.pkg_id.as_ref()), vec![src_path]);
     }
 
     // Check and process the binaries

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -419,9 +419,18 @@ pub struct DistMetadata {
     /// Whether artifacts/installers for this app should be displayed in release bodies
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display: Option<bool>,
+
     /// How to refer to the app in release bodies
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+
+    /// Whether to include built C dynamic libraries in the release archive
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package_cdylibs: Option<bool>,
+
+    /// Whether installers should install cdylibs from the release archive
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install_cdylibs: Option<bool>,
 }
 
 /// values of the form `permission-name: read`
@@ -502,6 +511,8 @@ impl DistMetadata {
             github_releases_submodule_path: _,
             display: _,
             display_name: _,
+            package_cdylibs: _,
+            install_cdylibs: _,
         } = self;
         if let Some(include) = include {
             for include in include {
@@ -593,6 +604,8 @@ impl DistMetadata {
             github_releases_submodule_path,
             display,
             display_name,
+            package_cdylibs,
+            install_cdylibs,
         } = self;
 
         // Check for global settings on local packages
@@ -761,6 +774,12 @@ impl DistMetadata {
         }
         if display_name.is_none() {
             display_name.clone_from(&workspace_config.display_name);
+        }
+        if package_cdylibs.is_none() {
+            package_cdylibs.clone_from(&workspace_config.package_cdylibs);
+        }
+        if install_cdylibs.is_none() {
+            install_cdylibs.clone_from(&workspace_config.install_cdylibs);
         }
 
         // This was historically implemented as extend, but I'm not convinced the

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -383,6 +383,21 @@ pub enum DistError {
         /// The input
         levels: Vec<String>,
     },
+
+    /// An unknown target was found
+    #[error("Unrecognized target: {target}")]
+    #[diagnostic(help("The full list of supported targets can be found here: https://opensource.axo.dev/cargo-dist/book/reference/config.html#targets"))]
+    UnrecognizedTarget {
+        /// The target in question
+        target: String,
+    },
+
+    /// Installers requested despite having nothing to install
+    #[error("Installers were requested, but app contains no installable binaries")]
+    #[diagnostic(help(
+        "The only installable files are libraries, but `install-cdylibs` isn't enabled."
+    ))]
+    EmptyInstaller {},
 }
 
 /// Errors related to finding the project

--- a/cargo-dist/src/host.rs
+++ b/cargo-dist/src/host.rs
@@ -91,9 +91,9 @@ impl<'a> DistGraphBuilder<'a> {
         let releases_without_hosting = announcing
             .rust_releases
             .iter()
-            .filter_map(|(package, _)| {
+            .filter_map(|release| {
                 // Get the names of the apps we're releasing
-                let package = self.workspace.package(*package);
+                let package = self.workspace.package(release.package_idx);
                 let version = package
                     .version
                     .clone()
@@ -287,7 +287,7 @@ pub(crate) fn select_hosting(
     let package_list = announcing
         .rust_releases
         .iter()
-        .map(|(idx, _)| *idx)
+        .map(|release| release.package_idx)
         .collect::<Vec<_>>();
     // Either use the explicit one, or default to the CI provider's native solution
     let hosting_providers = hosting

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -275,6 +275,8 @@ fn get_new_dist_metadata(
             install_updater: None,
             display: None,
             display_name: None,
+            package_cdylibs: None,
+            install_cdylibs: None,
         }
     };
 
@@ -860,6 +862,8 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         display,
         display_name,
         github_release,
+        package_cdylibs,
+        install_cdylibs,
         // These settings are complex enough that we don't support editing them in init
         extra_artifacts: _,
         github_custom_runners: _,
@@ -1229,6 +1233,20 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "display-name",
         "# Custom display name to use for this app in release bodies\n",
         display_name.as_ref(),
+    );
+
+    apply_optional_value(
+        table,
+        "package-cdylibs",
+        "# Whether to include built C dynamic libraries in the final archives\n",
+        *package_cdylibs,
+    );
+
+    apply_optional_value(
+        table,
+        "install-cdylibs",
+        "# Whether to install packaged C dynamic libraries\n",
+        *install_cdylibs,
     );
 
     // Finalize the table

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -124,6 +124,12 @@ fn print_human(out: &mut Term, manifest: &DistManifest) -> Result<(), std::io::E
                             writeln!(out, "        (symbols artifact: {syms})")?;
                         }
                     }
+                    if let AssetKind::CDynamicLibrary(lib) = &asset.kind {
+                        writeln!(out, "      [cdylib] {}", path)?;
+                        if let Some(syms) = &lib.symbols_artifact {
+                            writeln!(out, "        (symbols artifact: {syms})")?;
+                        }
+                    }
                 }
             }
 
@@ -131,7 +137,10 @@ fn print_human(out: &mut Term, manifest: &DistManifest) -> Result<(), std::io::E
             // (We have more specific labels than "misc" here, but we don't care)
             let mut printed_asset = false;
             for asset in &artifact.assets {
-                if !matches!(&asset.kind, AssetKind::Executable(_)) {
+                if !matches!(
+                    &asset.kind,
+                    AssetKind::Executable(_) | AssetKind::CDynamicLibrary(_)
+                ) {
                     if let Some(path) = &asset.path {
                         if printed_asset {
                             write!(out, ", ")?;

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -1,7 +1,7 @@
 //! Mock testing utils, mostly you want the `workspace_*` functions,
 //! but other functions/consts will help you assert the results
 
-use crate::{CargoInfo, Tools};
+use crate::{announce::ReleaseArtifacts, CargoInfo, Tools};
 use axoproject::{AutoIncludes, PackageIdx, PackageInfo, WorkspaceInfo};
 use serde_json::json;
 
@@ -112,8 +112,12 @@ pub fn pkg_axo_bin_alpha() -> PackageInfo {
         ..mock_package(BIN_AXO_NAME, BIN_AXO_VER_ALPHA)
     }
 }
-pub fn entry_axo_bin() -> (PackageIdx, Vec<String>) {
-    (BIN_AXO_IDX, vec![BIN_AXO_NAME.to_owned()])
+pub fn entry_axo_bin() -> ReleaseArtifacts {
+    ReleaseArtifacts {
+        package_idx: BIN_AXO_IDX,
+        executables: vec![BIN_AXO_NAME.to_owned()],
+        cdylibs: vec![],
+    }
 }
 
 /// some-lib 1.0.0
@@ -122,8 +126,12 @@ pub fn pkg_some_lib() -> PackageInfo {
         ..mock_package(LIB_SOME_NAME, LIB_SOME_VER)
     }
 }
-pub fn entry_some_lib() -> (PackageIdx, Vec<String>) {
-    (LIB_SOME_IDX, vec![])
+pub fn entry_some_lib() -> ReleaseArtifacts {
+    ReleaseArtifacts {
+        package_idx: LIB_SOME_IDX,
+        executables: vec![],
+        cdylibs: vec![],
+    }
 }
 
 /// helper-bin 1.0.0 (has 2 binaries)
@@ -133,11 +141,12 @@ pub fn pkg_helper_bin() -> PackageInfo {
         ..mock_package(BIN_HELPER_NAME, BIN_HELPER_VER)
     }
 }
-pub fn entry_helper_bin() -> (PackageIdx, Vec<String>) {
-    (
-        BIN_HELPER_IDX,
-        vec![BIN_HELPER_NAME.to_owned(), BIN_HELPER_NAME2.to_owned()],
-    )
+pub fn entry_helper_bin() -> ReleaseArtifacts {
+    ReleaseArtifacts {
+        package_idx: BIN_HELPER_IDX,
+        executables: vec![BIN_HELPER_NAME.to_owned(), BIN_HELPER_NAME2.to_owned()],
+        cdylibs: vec![],
+    }
 }
 
 /// other-lib 0.5.0 (non-harmonious version)
@@ -146,8 +155,12 @@ pub fn pkg_other_lib() -> PackageInfo {
         ..mock_package(LIB_OTHER_NAME, LIB_OTHER_VER)
     }
 }
-pub fn entry_other_lib() -> (PackageIdx, Vec<String>) {
-    (LIB_OTHER_IDX, vec![])
+pub fn entry_other_lib() -> ReleaseArtifacts {
+    ReleaseArtifacts {
+        package_idx: LIB_OTHER_IDX,
+        executables: vec![],
+        cdylibs: vec![],
+    }
 }
 
 /// oddball-bin 0.1.0 (non-harmonious version)
@@ -157,8 +170,12 @@ pub fn pkg_oddball_bin() -> PackageInfo {
         ..mock_package(BIN_ODDBALL_NAME, BIN_ODDBALL_VER)
     }
 }
-pub fn entry_oddball_bin() -> (PackageIdx, Vec<String>) {
-    (BIN_ODDBALL_IDX, vec![BIN_ODDBALL_NAME.to_owned()])
+pub fn entry_oddball_bin() -> ReleaseArtifacts {
+    ReleaseArtifacts {
+        package_idx: BIN_ODDBALL_IDX,
+        executables: vec![BIN_ODDBALL_NAME.to_owned()],
+        cdylibs: vec![],
+    }
 }
 
 /// forced-bin 1.0.0
@@ -176,8 +193,12 @@ pub fn pkg_forced_bin() -> PackageInfo {
         ..mock_package(BIN_FORCED_NAME, BIN_FORCED_VER)
     }
 }
-pub fn entry_forced_bin() -> (PackageIdx, Vec<String>) {
-    (BIN_FORCED_IDX, vec![BIN_FORCED_NAME.to_owned()])
+pub fn entry_forced_bin() -> ReleaseArtifacts {
+    ReleaseArtifacts {
+        package_idx: BIN_FORCED_IDX,
+        executables: vec![BIN_FORCED_NAME.to_owned()],
+        cdylibs: vec![],
+    }
 }
 
 /// test-bin1 1.0.0

--- a/cargo-dist/templates/installer/homebrew.rb.j2
+++ b/cargo-dist/templates/installer/homebrew.rb.j2
@@ -84,24 +84,44 @@ class {{ formula_class }} < Formula
   end
 
   def install
-    {%- if arm64_macos.binaries %}
+    {%- if arm64_macos.executables or arm64_macos.cdylibs %}
     if OS.mac? && Hardware::CPU.arm?
-      bin.install {% for binary in arm64_macos.binaries %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- if arm64_macos.executables %}
+      bin.install {% for binary in arm64_macos.executables %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
+      {%- if arm64_macos.cdylibs and install_cdylibs %}
+      lib.install {% for library in arm64_macos.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
     end
     {%- endif %}
-    {%- if x86_64_macos.binaries %}
+    {%- if x86_64_macos.executables or x86_64_macos.cdylibs %}
     if OS.mac? && Hardware::CPU.intel?
-      bin.install {% for binary in x86_64_macos.binaries %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- if x86_64_macos.executables %}
+      bin.install {% for binary in x86_64_macos.executables %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
+      {%- if x86_64_macos.cdylibs and install_cdylibs %}
+      lib.install {% for library in x86_64_macos.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
     end
     {%- endif %}
-    {%- if arm64_linux.binaries %}
+    {%- if arm64_linux.executables or arm64_linux.cdylibs %}
     if OS.linux? && Hardware::CPU.arm?
-      bin.install {% for binary in arm64_linux.binaries %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- if arm64_linux.executables %}
+      bin.install {% for binary in arm64_linux.executables %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
+      {%- if arm64_linux.cdylibs and install_cdylibs %}
+      lib.install {% for library in arm64_linux.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
     end
     {%- endif %}
-    {%- if x86_64_linux.binaries %}
+    {%- if x86_64_linux.executables %}
     if OS.linux? && Hardware::CPU.intel?
-      bin.install {% for binary in x86_64_linux.binaries %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- if x86_64_linux.executables %}
+      bin.install {% for binary in x86_64_linux.executables %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
+      {%- if x86_64_linux.cdylibs and install_cdylibs %}
+      lib.install {% for library in x86_64_linux.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
     end
 {% endif %}
     install_binary_aliases!

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -68,9 +68,16 @@ function Install-Binary($install_args) {
   {%- for artifact in artifacts %}
     "{{ artifact.target_triple }}" = @{
       "artifact_name" = "{{ artifact.id }}"
-      "bins" = {% for bin in artifact.binaries -%}
+      "bins" = @({% for bin in artifact.executables -%}
         "{{ bin }}"{{ ", " if not loop.last else "" }}
-      {%- endfor %}
+      {%- endfor %})
+      {%- if install_cdylibs %}
+      "libs" = @({% for lib in artifact.cdylibs -%}
+        "{{ lib }}"{{ ", " if not loop.last else "" }}
+      {%- endfor %})
+      {%- else %}
+      "libs" = @()
+      {%- endif %}
       "zip_ext" = "{{ artifact.zip_style }}"
       "aliases" = @{
       {%- for source, dests in bin_aliases[artifact.target_triple] | items %}
@@ -93,7 +100,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -151,6 +158,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -192,6 +200,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -202,10 +215,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -218,6 +234,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -228,8 +245,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 {% if install_paths| selectattr("kind", "equalto", "CargoHome") %}
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
 {%- else -%}
     $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir_lib = $dest_dir
 {%- endif %}
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
@@ -247,18 +266,21 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
 {%- elif install_path.kind == "HomeSubdir" %}
     # Install to $HOME/{{ install_path.subdir }}
     $dest_dir = if (($base_dir = $HOME)) {
       Join-Path $base_dir "{{ install_path.subdir }}"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
 {%- elif install_path.kind == "EnvSubdir" %}
     # Install to $env:{{ install_path.env_key }}{% if install_path.subdir | length %}/{% endif %}{{ install_path.subdir }}
     $dest_dir = if (($base_dir = $env:{{ install_path.env_key }})) {
       Join-Path $base_dir "{{ install_path.subdir }}"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
 {%- else %}
     {{ error("unimplemented install_path format: " ~ install_path.kind) }}
@@ -275,9 +297,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -291,9 +314,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -145,8 +145,15 @@ download_binary_and_run_installer() {
         "{{ artifact.target_triple }}")
             _artifact_name="{{ artifact.id }}"
             _zip_ext="{{ artifact.zip_style }}"
-            _bins="{% for bin in artifact.binaries %}{{ bin }}{{ " " if not loop.last else "" }}{% endfor %}"
-            _bins_js_array='{% for bin in artifact.binaries %}"{{ bin }}"{{ "," if not loop.last else ""}}{% endfor %}'
+            _bins="{% for bin in artifact.executables %}{{ bin }}{{ " " if not loop.last else "" }}{% endfor %}"
+            _bins_js_array='{% for bin in artifact.executables %}"{{ bin }}"{{ "," if not loop.last else ""}}{% endfor %}'
+            {%- if install_cdylibs %}
+            _libs="{% for lib in artifact.cdylibs %}{{ lib }}{{ " " if not loop.last else "" }}{% endfor %}"
+            _libs_js_array='{% for lib in artifact.cdylibs %}"{{ lib }}"{{ "," if not loop.last else ""}}{% endfor %}'
+            {%- else %}
+            _libs=""
+            _libs_js_array=""
+            {%- endif %}
             {%- if artifact.updater %}
             _updater_name="{{ artifact.updater.id }}"
             _updater_bin="{{ artifact.updater.binary }}"
@@ -162,6 +169,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -220,7 +228,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -323,6 +331,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -340,12 +350,14 @@ install() {
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
     {%- if install_paths | selectattr("kind", "equalto", "CargoHome") %}
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
         _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
     {%- else %}
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _receipt_install_dir="$_install_dir"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
@@ -360,6 +372,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -376,6 +389,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -384,6 +398,7 @@ install() {
         # Install to $HOME/{{ install_path.subdir }}
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/{{ install_path.subdir }}"
+            _lib_install_dir="$HOME/{{ install_path.subdir }}"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$HOME/{{ install_path.subdir }}/env"
             _install_dir_expr='$HOME/{{ install_path.subdir }}'
@@ -393,6 +408,7 @@ install() {
         # Install to ${{ install_path.env_key }}{% if install_path.subdir | length %}/{% endif %}{{ install_path.subdir }}
         if [ -n "{{ "${" }}{{ install_path.env_key }}:-}" ]; then
             _install_dir="${{ install_path.env_key }}{% if install_path.subdir | length %}/{% endif %}{{ install_path.subdir }}"
+            _lib_install_dir="$_install_dir"
             _receipt_install_dir="$_install_dir"
             _env_script_path="${{ install_path.env_key }}{% if install_path.subdir | length %}/{% endif %}{{ install_path.subdir }}/env"
             _install_dir_expr="$(replace_home "$_install_dir")"
@@ -421,11 +437,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -435,6 +453,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "{{ install_success_msg }}"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".zip"
             _bins="akextract.exe akmetadata.exe akrepack.exe"
             _bins_js_array='"akextract.exe","akmetadata.exe","akrepack.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
-      "bins" = "akextract.exe", "akmetadata.exe", "akrepack.exe"
+      "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
+      "libs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
-      "bins" = "akextract.exe", "akmetadata.exe", "akrepack.exe"
+      "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
+      "libs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +183,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,6 +195,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -243,7 +254,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -381,6 +392,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -397,6 +410,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -407,6 +421,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -423,6 +438,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -446,11 +462,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -460,6 +478,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".zip"
             _bins="akextract.exe akmetadata.exe akrepack.exe"
             _bins_js_array='"akextract.exe","akmetadata.exe","akrepack.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -375,6 +384,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -391,6 +402,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -401,6 +413,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -417,6 +430,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -440,11 +454,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -454,6 +470,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1109,7 +1133,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1125,7 +1149,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
-      "bins" = "akextract.exe", "akmetadata.exe", "akrepack.exe"
+      "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
+      "libs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
         "akextract.exe" = "akextract-link.exe"
@@ -1134,7 +1159,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
-      "bins" = "akextract.exe", "akmetadata.exe", "akrepack.exe"
+      "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
+      "libs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
         "akextract.exe" = "akextract-link.exe"
@@ -1146,7 +1172,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1204,6 +1230,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1245,6 +1272,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1255,10 +1287,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1271,6 +1306,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1281,6 +1317,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1295,6 +1332,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1307,9 +1345,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1323,9 +1362,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".zip"
             _bins="akextract.exe akmetadata.exe akrepack.exe"
             _bins_js_array='"akextract.exe","akmetadata.exe","akrepack.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -387,6 +396,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -403,6 +414,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -413,6 +425,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -429,6 +442,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -452,11 +466,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -466,6 +482,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1121,7 +1145,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1137,7 +1161,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
-      "bins" = "akextract.exe", "akmetadata.exe", "akrepack.exe"
+      "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
+      "libs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
         "akextract.exe" = "akextract-link.exe"
@@ -1147,7 +1172,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
-      "bins" = "akextract.exe", "akmetadata.exe", "akrepack.exe"
+      "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
+      "libs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
         "akextract.exe" = "akextract-link.exe"
@@ -1160,7 +1186,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1218,6 +1244,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1259,6 +1286,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1269,10 +1301,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1285,6 +1320,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1295,6 +1331,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1309,6 +1346,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1321,9 +1359,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1337,9 +1376,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name="akaikatana-repack-aarch64-apple-darwin-update"
             _updater_bin="akaikatana-repack-aarch64-apple-darwin-update"
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name="akaikatana-repack-x86_64-apple-darwin-update"
             _updater_bin="akaikatana-repack-x86_64-apple-darwin-update"
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".zip"
             _bins="akextract.exe akmetadata.exe akrepack.exe"
             _bins_js_array='"akextract.exe","akmetadata.exe","akrepack.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name="akaikatana-repack-x86_64-pc-windows-msvc-update"
             _updater_bin="akaikatana-repack-x86_64-pc-windows-msvc-update"
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="akextract akmetadata akrepack"
             _bins_js_array='"akextract","akmetadata","akrepack"'
+            _libs=""
+            _libs_js_array=""
             _updater_name="akaikatana-repack-x86_64-unknown-linux-gnu-update"
             _updater_bin="akaikatana-repack-x86_64-unknown-linux-gnu-update"
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
-      "bins" = "akextract.exe", "akmetadata.exe", "akrepack.exe"
+      "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
+      "libs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1125,7 +1150,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
-      "bins" = "akextract.exe", "akmetadata.exe", "akrepack.exe"
+      "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
+      "libs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1140,7 +1166,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1198,6 +1224,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1239,6 +1266,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1249,10 +1281,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1265,6 +1300,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1275,6 +1311,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1289,6 +1326,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1301,9 +1339,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1317,9 +1356,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -375,6 +384,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -391,6 +402,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -401,6 +413,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -417,6 +430,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -440,11 +454,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -454,6 +470,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1109,7 +1133,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1125,7 +1149,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "axolotlsay.exe" = "axolotlsay-link.exe"
@@ -1134,7 +1159,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "axolotlsay.exe" = "axolotlsay-link.exe"
@@ -1146,7 +1172,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1204,6 +1230,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1245,6 +1272,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1255,10 +1287,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1271,6 +1306,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1281,6 +1317,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1295,6 +1332,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1307,9 +1345,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1323,9 +1362,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -375,6 +384,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -391,6 +402,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -401,6 +413,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -417,6 +430,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -440,11 +454,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -454,6 +470,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1109,7 +1133,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1125,7 +1149,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "nosuchbin.exe" = "axolotlsay-link1.exe", "axolotlsay-link2.exe"
@@ -1134,7 +1159,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "nosuchbin.exe" = "axolotlsay-link1.exe", "axolotlsay-link2.exe"
@@ -1146,7 +1172,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1204,6 +1230,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1245,6 +1272,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1255,10 +1287,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1271,6 +1306,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1281,6 +1317,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1295,6 +1332,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1307,9 +1345,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1323,9 +1362,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say ">o_o< everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1100,7 +1124,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1116,7 +1140,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1124,7 +1149,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1135,7 +1161,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1193,6 +1219,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1234,6 +1261,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1244,10 +1276,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1260,6 +1295,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1270,6 +1306,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1284,6 +1321,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1296,9 +1334,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1312,9 +1351,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay-js"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="axolotlsay-js"
             _bins_js_array='"axolotlsay-js"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="axolotlsay-js"
             _bins_js_array='"axolotlsay-js"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".zip"
             _bins="axolotlsay-js.exe"
             _bins_js_array='"axolotlsay-js.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.xz"
             _bins="axolotlsay-js"
             _bins_js_array='"axolotlsay-js"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say ">o_o< everything's installed!"
@@ -1092,7 +1116,7 @@ $app_name = 'axolotlsay-js'
 $app_version = '0.6.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay-js"
 
@@ -1108,7 +1132,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-js-x86_64-pc-windows-msvc.zip"
-      "bins" = "axolotlsay-js.exe"
+      "bins" = @("axolotlsay-js.exe")
+      "libs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1116,7 +1141,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-js-x86_64-pc-windows-msvc.zip"
-      "bins" = "axolotlsay-js.exe"
+      "bins" = @("axolotlsay-js.exe")
+      "libs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1127,7 +1153,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1185,6 +1211,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1226,6 +1253,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1236,10 +1268,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1252,6 +1287,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1262,6 +1298,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1276,6 +1313,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1288,9 +1326,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1304,9 +1343,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +183,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,6 +195,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -243,7 +254,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -381,6 +392,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -397,6 +410,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -407,6 +421,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -423,6 +438,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -446,11 +462,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -460,6 +478,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +183,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,6 +195,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -243,7 +254,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -381,6 +392,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -397,6 +410,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -407,6 +421,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -423,6 +438,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -446,11 +462,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -460,6 +478,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -375,6 +384,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -391,6 +402,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -401,6 +413,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -417,6 +430,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -440,11 +454,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -454,6 +470,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1109,7 +1133,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1125,7 +1149,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "axolotlsay.exe" = "axolotlsay-link1.exe", "axolotlsay-link2.exe"
@@ -1134,7 +1159,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "axolotlsay.exe" = "axolotlsay-link1.exe", "axolotlsay-link2.exe"
@@ -1146,7 +1172,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1204,6 +1230,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1245,6 +1272,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1255,10 +1287,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1271,6 +1306,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1281,6 +1317,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1295,6 +1332,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1307,9 +1345,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1323,9 +1362,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1037,7 +1061,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1053,7 +1077,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1061,7 +1086,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1072,7 +1098,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1130,6 +1156,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1171,6 +1198,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1181,10 +1213,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1197,6 +1232,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1207,6 +1243,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1221,6 +1258,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1233,9 +1271,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1249,9 +1288,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1037,7 +1061,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1053,7 +1077,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1061,7 +1086,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1072,7 +1098,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1130,6 +1156,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1171,6 +1198,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1181,10 +1213,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1197,6 +1232,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1207,6 +1243,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1221,6 +1258,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1233,9 +1271,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1249,9 +1288,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name="axolotlsay-aarch64-apple-darwin-update"
             _updater_bin="axolotlsay-aarch64-apple-darwin-update"
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name="axolotlsay-x86_64-apple-darwin-update"
             _updater_bin="axolotlsay-x86_64-apple-darwin-update"
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name="axolotlsay-x86_64-pc-windows-msvc-update"
             _updater_bin="axolotlsay-x86_64-pc-windows-msvc-update"
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name="axolotlsay-x86_64-unknown-linux-gnu-update"
             _updater_bin="axolotlsay-x86_64-unknown-linux-gnu-update"
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1125,7 +1150,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1140,7 +1166,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1198,6 +1224,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1239,6 +1266,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1249,10 +1281,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1265,6 +1300,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1275,6 +1311,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1289,6 +1326,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1301,9 +1339,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1317,9 +1356,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
         _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
@@ -389,6 +401,7 @@ install() {
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
             _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
             _env_script_path="$CARGO_HOME/env"
             # Initially make this early-bound to erase the potentially-temporary env-var
             _install_dir_expr="$_install_dir"
@@ -405,6 +418,7 @@ install() {
         elif [ -n "${HOME:-}" ]; then
             _receipt_install_dir="$HOME/.cargo"
             _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
             _env_script_path="$HOME/.cargo/env"
             _install_dir_expr='$HOME/.cargo/bin'
             _env_script_path_expr='$HOME/.cargo/env'
@@ -428,11 +442,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -442,6 +458,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1097,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1113,7 +1137,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1121,7 +1146,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1132,7 +1158,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1190,6 +1216,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1231,6 +1258,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1241,10 +1273,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1257,6 +1292,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1267,6 +1303,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 
     $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1281,6 +1318,7 @@ function Invoke-Installer($bin_paths, $platforms) {
     }
 
     $dest_dir = Join-Path $root "bin"
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
   }
 
@@ -1293,9 +1331,10 @@ function Invoke-Installer($bin_paths, $platforms) {
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1309,9 +1348,17 @@ function Invoke-Installer($bin_paths, $platforms) {
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _receipt_install_dir="$_install_dir"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
@@ -388,6 +400,7 @@ install() {
         # Install to $MY_ENV_VAR
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR"
+            _lib_install_dir="$_install_dir"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$MY_ENV_VAR/env"
             _install_dir_expr="$(replace_home "$_install_dir")"
@@ -412,11 +425,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -426,6 +441,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1081,7 +1104,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1097,7 +1120,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1105,7 +1129,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1116,7 +1141,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1174,6 +1199,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1215,6 +1241,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1225,10 +1256,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1241,6 +1275,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1250,6 +1285,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   # if we're overriding it.
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1257,6 +1293,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
       Join-Path $base_dir ""
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
 
@@ -1269,9 +1306,10 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1285,9 +1323,17 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _receipt_install_dir="$_install_dir"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
@@ -388,6 +400,7 @@ install() {
         # Install to $MY_ENV_VAR/bin
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR/bin"
+            _lib_install_dir="$_install_dir"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$MY_ENV_VAR/bin/env"
             _install_dir_expr="$(replace_home "$_install_dir")"
@@ -412,11 +425,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -426,6 +441,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1081,7 +1104,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1097,7 +1120,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1105,7 +1129,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1116,7 +1141,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1174,6 +1199,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1215,6 +1241,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1225,10 +1256,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1241,6 +1275,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1250,6 +1285,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   # if we're overriding it.
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1257,6 +1293,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
       Join-Path $base_dir "bin"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
 
@@ -1269,9 +1306,10 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1285,9 +1323,17 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _receipt_install_dir="$_install_dir"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
@@ -388,6 +400,7 @@ install() {
         # Install to $MY_ENV_VAR/My Axolotlsay Documents
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR/My Axolotlsay Documents"
+            _lib_install_dir="$_install_dir"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$MY_ENV_VAR/My Axolotlsay Documents/env"
             _install_dir_expr="$(replace_home "$_install_dir")"
@@ -412,11 +425,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -426,6 +441,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1081,7 +1104,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1097,7 +1120,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1105,7 +1129,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1116,7 +1141,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1174,6 +1199,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1215,6 +1241,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1225,10 +1256,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1241,6 +1275,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1250,6 +1285,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   # if we're overriding it.
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1257,6 +1293,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
       Join-Path $base_dir "My Axolotlsay Documents"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
 
@@ -1269,9 +1306,10 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1285,9 +1323,17 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _receipt_install_dir="$_install_dir"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
@@ -388,6 +400,7 @@ install() {
         # Install to $MY_ENV_VAR/My Axolotlsay Documents/bin
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR/My Axolotlsay Documents/bin"
+            _lib_install_dir="$_install_dir"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$MY_ENV_VAR/My Axolotlsay Documents/bin/env"
             _install_dir_expr="$(replace_home "$_install_dir")"
@@ -412,11 +425,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -426,6 +441,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1081,7 +1104,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1097,7 +1120,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1105,7 +1129,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1116,7 +1141,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1174,6 +1199,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1215,6 +1241,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1225,10 +1256,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1241,6 +1275,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1250,6 +1285,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   # if we're overriding it.
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1257,6 +1293,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
       Join-Path $base_dir "My Axolotlsay Documents/bin"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
 
@@ -1269,9 +1306,10 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1285,9 +1323,17 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -144,6 +144,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -152,6 +154,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -160,6 +164,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -168,6 +174,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -178,6 +186,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -236,7 +245,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -364,6 +373,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -380,6 +391,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _receipt_install_dir="$_install_dir"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
@@ -389,6 +401,7 @@ install() {
         # Install to $NO_SUCH_ENV_VAR/My Nonexistent Documents
         if [ -n "${NO_SUCH_ENV_VAR:-}" ]; then
             _install_dir="$NO_SUCH_ENV_VAR/My Nonexistent Documents"
+            _lib_install_dir="$_install_dir"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$NO_SUCH_ENV_VAR/My Nonexistent Documents/env"
             _install_dir_expr="$(replace_home "$_install_dir")"
@@ -399,6 +412,7 @@ install() {
         # Install to $MY_ENV_VAR/My Axolotlsay Documents
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR/My Axolotlsay Documents"
+            _lib_install_dir="$_install_dir"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$MY_ENV_VAR/My Axolotlsay Documents/env"
             _install_dir_expr="$(replace_home "$_install_dir")"
@@ -423,11 +437,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -437,6 +453,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1093,7 +1117,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1109,7 +1133,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1117,7 +1142,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1128,7 +1154,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1186,6 +1212,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1227,6 +1254,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1237,10 +1269,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1253,6 +1288,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1262,6 +1298,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   # if we're overriding it.
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1269,6 +1306,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $env:NO_SUCH_ENV_VAR)) {
       Join-Path $base_dir "My Nonexistent Documents"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
   if (-Not $dest_dir) {
@@ -1276,6 +1314,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
       Join-Path $base_dir "My Axolotlsay Documents"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
 
@@ -1288,9 +1327,10 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1304,9 +1344,17 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _receipt_install_dir="$_install_dir"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
@@ -388,6 +400,7 @@ install() {
         # Install to $HOME/.axolotlsay/bins
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/.axolotlsay/bins"
+            _lib_install_dir="$HOME/.axolotlsay/bins"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$HOME/.axolotlsay/bins/env"
             _install_dir_expr='$HOME/.axolotlsay/bins'
@@ -412,11 +425,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -426,6 +441,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1081,7 +1104,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1097,7 +1120,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1105,7 +1129,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1116,7 +1141,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1174,6 +1199,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1215,6 +1241,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1225,10 +1256,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1241,6 +1275,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1250,6 +1285,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   # if we're overriding it.
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1257,6 +1293,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $HOME)) {
       Join-Path $base_dir ".axolotlsay/bins"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
 
@@ -1269,9 +1306,10 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1285,9 +1323,17 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _receipt_install_dir="$_install_dir"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
@@ -388,6 +400,7 @@ install() {
         # Install to $HOME/.axolotlsay
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/.axolotlsay"
+            _lib_install_dir="$HOME/.axolotlsay"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$HOME/.axolotlsay/env"
             _install_dir_expr='$HOME/.axolotlsay'
@@ -412,11 +425,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -426,6 +441,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1081,7 +1104,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1097,7 +1120,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1105,7 +1129,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1116,7 +1141,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1174,6 +1199,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1215,6 +1241,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1225,10 +1256,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1241,6 +1275,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1250,6 +1285,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   # if we're overriding it.
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1257,6 +1293,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $HOME)) {
       Join-Path $base_dir ".axolotlsay"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
 
@@ -1269,9 +1306,10 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1285,9 +1323,17 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _receipt_install_dir="$_install_dir"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
@@ -388,6 +400,7 @@ install() {
         # Install to $HOME/My Axolotlsay Documents
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/My Axolotlsay Documents"
+            _lib_install_dir="$HOME/My Axolotlsay Documents"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$HOME/My Axolotlsay Documents/env"
             _install_dir_expr='$HOME/My Axolotlsay Documents'
@@ -412,11 +425,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -426,6 +441,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1081,7 +1104,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1097,7 +1120,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1105,7 +1129,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1116,7 +1141,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1174,6 +1199,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1215,6 +1241,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1225,10 +1256,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1241,6 +1275,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1250,6 +1285,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   # if we're overriding it.
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1257,6 +1293,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $HOME)) {
       Join-Path $base_dir "My Axolotlsay Documents"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
 
@@ -1269,9 +1306,10 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1285,9 +1323,17 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -143,6 +143,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -151,6 +153,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -159,6 +163,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -167,6 +173,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -177,6 +185,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -235,7 +244,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -363,6 +372,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -379,6 +390,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _receipt_install_dir="$_install_dir"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
@@ -388,6 +400,7 @@ install() {
         # Install to $HOME/My Axolotlsay Documents/bin
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/My Axolotlsay Documents/bin"
+            _lib_install_dir="$HOME/My Axolotlsay Documents/bin"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$HOME/My Axolotlsay Documents/bin/env"
             _install_dir_expr='$HOME/My Axolotlsay Documents/bin'
@@ -412,11 +425,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -426,6 +441,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1081,7 +1104,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1097,7 +1120,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1105,7 +1129,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1116,7 +1141,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1174,6 +1199,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1215,6 +1241,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1225,10 +1256,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1241,6 +1275,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1250,6 +1285,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   # if we're overriding it.
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1257,6 +1293,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $HOME)) {
       Join-Path $base_dir "My Axolotlsay Documents/bin"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
 
@@ -1269,9 +1306,10 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1285,9 +1323,17 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -144,6 +144,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -152,6 +154,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -160,6 +164,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay.exe"
             _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -168,6 +174,8 @@ download_binary_and_run_installer() {
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -178,6 +186,7 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -236,7 +245,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -364,6 +373,8 @@ install() {
 
     # The actual path we're going to install to
     local _install_dir
+    # The directory C dynamic/static libraries install to
+    local _lib_install_dir
     # The install prefix we write to the receipt.
     # For organized install methods like CargoHome, which have
     # subdirectories, this is the root without `/bin`. For other
@@ -380,6 +391,7 @@ install() {
     # if we're overriding it.
     if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
         _receipt_install_dir="$_install_dir"
         _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
         _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
@@ -389,6 +401,7 @@ install() {
         # Install to $HOME/.axolotlsay
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/.axolotlsay"
+            _lib_install_dir="$HOME/.axolotlsay"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$HOME/.axolotlsay/env"
             _install_dir_expr='$HOME/.axolotlsay'
@@ -399,6 +412,7 @@ install() {
         # Install to $MY_ENV_VAR/My Axolotlsay Documents/bin
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR/My Axolotlsay Documents/bin"
+            _lib_install_dir="$_install_dir"
             _receipt_install_dir="$_install_dir"
             _env_script_path="$MY_ENV_VAR/My Axolotlsay Documents/bin/env"
             _install_dir_expr="$(replace_home "$_install_dir")"
@@ -423,11 +437,13 @@ install() {
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
+    ensure mkdir -p "$_lib_install_dir"
 
     # copy all the binaries to the install dir
     local _src_dir="$1"
     local _bins="$2"
-    local _arch="$3"
+    local _libs="$3"
+    local _arch="$4"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -437,6 +453,14 @@ install() {
             ln -sf "$_install_dir/$_bin_name" "$_install_dir/$_dest"
         done
         say "  $_bin_name"
+    done
+    # Like the above, but no aliases
+    for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
     done
 
     say "everything's installed!"
@@ -1093,7 +1117,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1109,7 +1133,8 @@ function Install-Binary($install_args) {
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1117,7 +1142,8 @@ function Install-Binary($install_args) {
     }
     "x86_64-pc-windows-msvc" = @{
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = "axolotlsay.exe"
+      "bins" = @("axolotlsay.exe")
+      "libs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1128,7 +1154,7 @@ function Install-Binary($install_args) {
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
-    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
   } catch {
     throw @"
 We encountered an error trying to perform the installation;
@@ -1186,6 +1212,7 @@ function Download($download_url, $platforms) {
   $info = $platforms[$arch]
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
+  $lib_names = $info["libs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1227,6 +1254,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $bin_name"
     $bin_paths += "$tmp\$bin_name"
   }
+  $lib_paths = @()
+  foreach ($lib_name in $lib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $lib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1237,10 +1269,13 @@ function Download($download_url, $platforms) {
     $bin_paths += $out_name
   }
 
-  return $bin_paths
+  return @{
+    "bin_paths" = $bin_paths
+    "lib_paths" = $lib_paths
+  }
 }
 
-function Invoke-Installer($bin_paths, $platforms) {
+function Invoke-Installer($artifacts, $platforms) {
   # Replaces the placeholder binary entry with the actual list of binaries
   $arch = Get-TargetTriple
 
@@ -1253,6 +1288,7 @@ function Invoke-Installer($bin_paths, $platforms) {
 
   # The actual path we're going to install to
   $dest_dir = $null
+  $dest_dir_lib = $null
   # The install prefix we write to the receipt.
   # For organized install methods like CargoHome, which have
   # subdirectories, this is the root without `/bin`. For other
@@ -1262,6 +1298,7 @@ function Invoke-Installer($bin_paths, $platforms) {
   # if we're overriding it.
   if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
 $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
   if (-Not $dest_dir) {
@@ -1269,6 +1306,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $HOME)) {
       Join-Path $base_dir ".axolotlsay"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
   if (-Not $dest_dir) {
@@ -1276,6 +1314,7 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
       Join-Path $base_dir "My Axolotlsay Documents/bin"
     }
+    $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
   }
 
@@ -1288,9 +1327,10 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
+  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
   Write-Information "Installing to $dest_dir"
   # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $bin_paths) {
+  foreach ($bin_path in $artifacts["bin_paths"]) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
     Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
     Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
@@ -1304,9 +1344,17 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
       }
     }
   }
+  foreach ($lib_path in $artifacts["lib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
+  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 


### PR DESCRIPTION
This is the start of the branch for cdylib support - it doesn't fully work yet.

We had cdylibs available from axoproject/`cargo metadata` until now, but we ignored them. This pipes them into the buildsystem and treats them as binaries like any others. For most of the layers of cargo-dist, we have a single set of "binaries" but we now type them so that we can keep track of which are executables and which are libraries. We separate them back out at the time that we create installers to simplify the process of deciding where they get installed to.

Because we lean on axoproject to tell us about cdylibs, which already supported them in both rust and generic projects, users don't have to make any changes to their projects in order to use this feature. As long as a project declares cdylibs, we'll start installing them. (We always built them, we just didn't include them in our tarballs.)

Installer support:

* Homebrew is opinionated about where libraries go, so we use Homebrew's native features for this. Libraries are separated out via `lib.install` so they go in the right place.
* shell/powershell: For CARGO_HOME-style installs, we separate the libraries from the binaries in order to avoid putting them on the `PATH`. For example, if we install binaries to `~/.cargo/bin`, we place the libraries in `~/.cargo/lib`. For other installs, where everything is dumped in one directory, we place libs alongside binaries.
* npm: No change needed. We don't advertise them in npm packages, but they need to be there in case a binary depends on them. Luckily, since we already unpack the entire tarball instead of just the binaries, that's already done.