### PR TITLE
feat: inline default install-path

### DIFF
--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -1140,6 +1140,13 @@ pub enum InstallPathStrategy {
     },
 }
 
+impl InstallPathStrategy {
+    /// Returns the default set of install paths
+    pub fn default_list() -> Vec<Self> {
+        vec![InstallPathStrategy::CargoHome]
+    }
+}
+
 impl std::str::FromStr for InstallPathStrategy {
     type Err = DistError;
     fn from_str(path: &str) -> DistResult<Self> {

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1246,7 +1246,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let npm_scope = npm_scope.clone();
         let install_path = install_path
             .clone()
-            .unwrap_or(vec![InstallPathStrategy::CargoHome]);
+            .unwrap_or(InstallPathStrategy::default_list());
         let install_success_msg = install_success_msg
             .as_deref()
             .unwrap_or("everything's installed!")

--- a/cargo-dist/src/tests/config.rs
+++ b/cargo-dist/src/tests/config.rs
@@ -74,6 +74,8 @@ pr-run-mode = "plan"
 hosting = ["axodotdev", "github"]
 # Whether to install an updater program
 install-updater = false
+# Path that installers should place binaries in
+install-path = "CARGO_HOME"
 
 [[workspace.metadata.dist.extra-artifacts]]
 artifacts = ["dist-manifest-schema.json"]


### PR DESCRIPTION
This preps us for a future release where we change the default, making it easier for people using the previous default to keep it.

I considered migrating away from `Opt<Vec<_>>`, but this made it easier to keep `opt_string_or_vec`.

Fixes #1194.