### PR TITLE
fix: handle Invoke-Installer errors

### DIFF
--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -92,7 +92,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -270,15 +279,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1145,7 +1145,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1302,15 +1311,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1159,7 +1159,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1316,15 +1325,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1139,7 +1139,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1296,15 +1305,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1145,7 +1145,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1302,15 +1311,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1145,7 +1145,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1302,15 +1311,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1134,7 +1134,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1291,15 +1300,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1126,7 +1126,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1283,15 +1292,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1145,7 +1145,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1302,15 +1311,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1071,7 +1071,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1228,15 +1237,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1071,7 +1071,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1228,15 +1237,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1139,7 +1139,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1296,15 +1305,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1131,7 +1131,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1288,15 +1297,15 @@ function Invoke-Installer($bin_paths, $platforms) {
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1115,7 +1115,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1264,15 +1273,15 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1115,7 +1115,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1264,15 +1273,15 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1115,7 +1115,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1264,15 +1273,15 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1115,7 +1115,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1264,15 +1273,15 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1127,7 +1127,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1283,15 +1292,15 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1115,7 +1115,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1264,15 +1273,15 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1115,7 +1115,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1264,15 +1273,15 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1115,7 +1115,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1264,15 +1273,15 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1115,7 +1115,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1264,15 +1273,15 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1127,7 +1127,16 @@ function Install-Binary($install_args) {
 
   $fetched = Download "$ArtifactDownloadUrl" $platforms
   # FIXME: add a flag that lets the user not do this step
-  Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  try {
+    Invoke-Installer -bin_paths $fetched -platforms $platforms "$install_args"
+  } catch {
+    throw @"
+We encountered an error trying to perform the installation;
+please review the error messages below.
+
+$_
+"@
+  }
 }
 
 function Get-TargetTriple() {
@@ -1283,15 +1292,15 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   # Just copy the binaries from the temp location to the install dir
   foreach ($bin_path in $bin_paths) {
     $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir"
-    Remove-Item "$bin_path" -Recurse -Force
+    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
+    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
 
     if (($dests = $info["aliases"][$installed_file])) {
       $source = Join-Path "$dest_dir" "$installed_file"
       foreach ($dest_name in $dests) {
           $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force
+          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
       }
     }
   }


### PR DESCRIPTION
We hadn't set the error types we wanted from the core file management functions here, so they were continuing after an error instead of throwing so we could terminate early.

Prior to dec41f69c3b7fb64ea3f2cdba507709053d4d4f4 this was handled by explicitly setting `$ErrorActionPreference` before and after calling `Invoke-Installer`. We removed that when reworking some errors, but we didn't update individual calls within Invoke-Installer to ensure they still stopped on error.

Fixes #1183.