### PR TITLE
Track glibc versions and other runtime requirements

### DIFF
--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -799,6 +799,22 @@ impl Library {
             package_manager: None,
         }
     }
+
+    /// Attempts to guess whether this specific library is glibc or not
+    pub fn is_glibc(&self) -> bool {
+        // If we were able to parse the source, we can be pretty precise
+        if let Some(source) = &self.source {
+            source == "libc6"
+        } else {
+            // Both patterns seen on Ubuntu (on the same system!)
+            self.path.contains("libc.so.6") ||
+            // This one will also contain the series version but
+            // we don't want to be too precise here to avoid
+            // filtering out later OS releases
+            // Specifically we want to avoid `libc-musl` or `libc.musl`
+            self.path.contains("libc-2")
+        }
+    }
 }
 
 impl std::fmt::Display for Library {

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -116,6 +116,51 @@ pub struct DistManifest {
     pub github_attestations: bool,
 }
 
+/// Information about the build environment on this system
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub enum BuildEnvironment {
+    /// Linux-specific information
+    #[serde(rename = "linux")]
+    Linux {
+        /// The builder's glibc verison, relevant to glibc-based
+        /// builds.
+        glibc_version: Option<GlibcVersion>,
+    },
+    /// macOS-specific information
+    #[serde(rename = "macos")]
+    MacOS {
+        /// The version of macOS used by the builder
+        os_version: String,
+    },
+    /// Windows-specific information
+    #[serde(rename = "windows")]
+    Windows,
+    /// Unable to determine what the host OS was - error?
+    #[serde(rename = "indeterminate")]
+    Indeterminate,
+}
+
+/// Minimum glibc version required to run software
+#[derive(
+    Debug, Clone, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
+)]
+pub struct GlibcVersion {
+    /// Major version
+    pub major: u64,
+    /// Series (minor) version
+    pub series: u64,
+}
+
+impl Default for GlibcVersion {
+    fn default() -> Self {
+        Self {
+            // Values from the default Ubuntu runner
+            major: 2,
+            series: 31,
+        }
+    }
+}
+
 /// Info about an Asset (binary)
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AssetInfo {
@@ -234,6 +279,8 @@ pub struct SystemInfo {
     pub id: SystemId,
     /// The version of Cargo used (first line of cargo -vV)
     pub cargo_version_line: Option<String>,
+    /// Environment of the System
+    pub build_environment: BuildEnvironment,
 }
 
 /// A Release of an Application

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -555,6 +555,73 @@ expression: json_schema
         }
       }
     },
+    "BuildEnvironment": {
+      "description": "Information about the build environment on this system",
+      "oneOf": [
+        {
+          "description": "Linux-specific information",
+          "type": "object",
+          "required": [
+            "linux"
+          ],
+          "properties": {
+            "linux": {
+              "type": "object",
+              "properties": {
+                "glibc_version": {
+                  "description": "The builder's glibc verison, relevant to glibc-based builds.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/GlibcVersion"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "macOS-specific information",
+          "type": "object",
+          "required": [
+            "macos"
+          ],
+          "properties": {
+            "macos": {
+              "type": "object",
+              "required": [
+                "os_version"
+              ],
+              "properties": {
+                "os_version": {
+                  "description": "The version of macOS used by the builder",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Windows-specific information",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Unable to determine what the host OS was - error?",
+          "type": "string",
+          "enum": [
+            "indeterminate"
+          ]
+        }
+      ]
+    },
     "CiInfo": {
       "description": "CI backend info",
       "type": "object",
@@ -691,6 +758,28 @@ expression: json_schema
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "GlibcVersion": {
+      "description": "Minimum glibc version required to run software",
+      "type": "object",
+      "required": [
+        "major",
+        "series"
+      ],
+      "properties": {
+        "major": {
+          "description": "Major version",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "series": {
+          "description": "Series (minor) version",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         }
       }
     },
@@ -895,9 +984,18 @@ expression: json_schema
       "description": "Info about a system used to build this announcement.",
       "type": "object",
       "required": [
+        "build_environment",
         "id"
       ],
       "properties": {
+        "build_environment": {
+          "description": "Environment of the System",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BuildEnvironment"
+            }
+          ]
+        },
         "cargo_version_line": {
           "description": "The version of Cargo used (first line of cargo -vV)",
           "type": [

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -87,6 +87,8 @@ pub struct ExecutableZipFragment {
     pub zip_style: ZipStyle,
     /// The updater associated with this platform
     pub updater: Option<UpdaterFragment>,
+    /// Conditions the system being installed to should ideally satisfy to install this
+    pub runtime_conditions: RuntimeConditions,
 }
 
 /// A fake fragment of an Updater artifact for installers

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 
 use crate::{
     config::{JinjaInstallPathStrategy, LibraryStyle, ZipStyle},
+    platform::RuntimeConditions,
     InstallReceipt, TargetTriple,
 };
 
@@ -65,6 +66,8 @@ pub struct InstallerInfo {
     pub bin_aliases: BTreeMap<String, BTreeMap<String, Vec<String>>>,
     /// Whether to install generated C dynamic libraries
     pub install_libraries: Vec<LibraryStyle>,
+    /// Platform-specific runtime conditions
+    pub runtime_conditions: RuntimeConditions,
 }
 
 /// A fake fragment of an ExecutableZip artifact for installers

--- a/cargo-dist/src/backend/installer/npm.rs
+++ b/cargo-dist/src/backend/installer/npm.rs
@@ -2,12 +2,14 @@
 
 use axoasset::{LocalAsset, SourceFile};
 use camino::{Utf8Path, Utf8PathBuf};
+use cargo_dist_schema::GlibcVersion;
 use serde::Serialize;
 
 use super::InstallerInfo;
 use crate::{
     backend::templates::{Templates, TEMPLATE_INSTALLER_NPM, TEMPLATE_INSTALLER_NPM_RUN_JS},
     errors::DistResult,
+    platform::RuntimeCondition,
     DistGraph, SortedMap, SortedSet,
 };
 
@@ -182,11 +184,29 @@ fn mangle_package_json(
     package_json["artifactDownloadUrl"] = info.inner.base_url.clone().into();
     package_json["supportedPlatforms"] = platforms.platform_support_json();
 
+    match info.inner.runtime_conditions.linux.glibc {
+        Some(RuntimeCondition::MinGlibcVersion { major, series }) => {
+            package_json["glibcMinimum"] = glibc_json(major, series)
+        }
+        _ => {
+            let default = GlibcVersion::default();
+            package_json["glibcMinimum"] = glibc_json(default.major, default.series)
+        }
+    }
+
     // Commit the new package.json
     let new_package_json = serde_json::to_string_pretty(&package_json).expect("serde_json failed");
     files.insert(package_json_path.to_owned(), new_package_json);
 
     Ok(())
+}
+
+fn glibc_json(major: u64, series: u64) -> serde_json::Value {
+    let mut map = SortedMap::<&str, u64>::new();
+    map.insert("major", major);
+    map.insert("series", series);
+
+    serde_json::to_value(&map).expect("serde_json failed")
 }
 
 fn platforms(info: &NpmInstallerInfo) -> PlatformSummary {

--- a/cargo-dist/src/backend/installer/npm.rs
+++ b/cargo-dist/src/backend/installer/npm.rs
@@ -9,7 +9,7 @@ use super::InstallerInfo;
 use crate::{
     backend::templates::{Templates, TEMPLATE_INSTALLER_NPM, TEMPLATE_INSTALLER_NPM_RUN_JS},
     errors::DistResult,
-    platform::RuntimeCondition,
+    platform::LibcVersion,
     DistGraph, SortedMap, SortedSet,
 };
 
@@ -184,8 +184,8 @@ fn mangle_package_json(
     package_json["artifactDownloadUrl"] = info.inner.base_url.clone().into();
     package_json["supportedPlatforms"] = platforms.platform_support_json();
 
-    match info.inner.runtime_conditions.linux.glibc {
-        Some(RuntimeCondition::MinGlibcVersion { major, series }) => {
+    match info.inner.runtime_conditions.min_glibc_version {
+        Some(LibcVersion { major, series }) => {
             package_json["glibcMinimum"] = glibc_json(major, series)
         }
         _ => {

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -4,13 +4,12 @@ use std::env;
 
 use axoprocess::Cmd;
 use axoproject::WorkspaceIdx;
-use cargo_dist_schema::{BuildEnvironment, DistManifest};
+use cargo_dist_schema::DistManifest;
 use miette::{Context, IntoDiagnostic};
 use tracing::warn;
 
 use crate::build::BuildExpectations;
 use crate::env::{calculate_ldflags, fetch_brew_env, parse_env, select_brew_env};
-use crate::linkage::determine_build_environment;
 use crate::{errors::*, BinaryIdx, BuildStep, DistGraphBuilder, TargetTriple, PROFILE_DIST};
 use crate::{
     CargoBuildStep, CargoTargetFeatureList, CargoTargetPackages, DistGraph, RustupStep, SortedMap,
@@ -223,16 +222,6 @@ pub fn build_cargo_target(
 
     // Process all the resulting binaries
     expected.process_bins(dist_graph, manifest)?;
-
-    let system_id = format!("build:local:{}", target.target_triple);
-    // Record the build environment
-    if let Some(info) = manifest.systems.get_mut(&system_id) {
-        // Not yet set; do that now
-        if matches!(info.build_environment, BuildEnvironment::Indeterminate) {
-            let build_environment = determine_build_environment(&target.target_triple);
-            info.build_environment = build_environment;
-        }
-    };
 
     Ok(())
 }

--- a/cargo-dist/src/build/generic.rs
+++ b/cargo-dist/src/build/generic.rs
@@ -5,13 +5,12 @@ use std::{env, process::ExitStatus};
 use axoprocess::Cmd;
 use axoproject::WorkspaceIdx;
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_dist_schema::{BuildEnvironment, DistManifest};
+use cargo_dist_schema::DistManifest;
 
 use crate::{
     build::{package_id_string, BuildExpectations},
     copy_file,
     env::{calculate_cflags, calculate_ldflags, fetch_brew_env, parse_env, select_brew_env},
-    linkage::determine_build_environment,
     ArtifactKind, BinaryIdx, BuildStep, DistError, DistGraph, DistGraphBuilder, DistResult,
     ExtraBuildStep, GenericBuildStep, SortedMap, TargetTriple,
 };
@@ -216,16 +215,6 @@ pub fn build_generic_target(
 
     // Check and process the binaries
     expected.process_bins(dist_graph, manifest)?;
-
-    // Record the build environment
-    let system_id = format!("build:local:{}", target.target_triple);
-    if let Some(info) = manifest.systems.get_mut(&system_id) {
-        // Not yet set; do that now
-        if matches!(info.build_environment, BuildEnvironment::Indeterminate) {
-            let build_environment = determine_build_environment(&target.target_triple);
-            info.build_environment = build_environment;
-        }
-    };
 
     Ok(())
 }

--- a/cargo-dist/src/build/mod.rs
+++ b/cargo-dist/src/build/mod.rs
@@ -217,6 +217,7 @@ impl BuildExpectations {
         } else {
             determine_linkage(src_path, target)?
         };
+
         let bin = dist.binary(src.idx);
         manifest.assets.insert(
             bin.id.clone(),

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -65,6 +65,10 @@ pub enum DistError {
     #[error(transparent)]
     SerdeYml(#[from] serde_yml::Error),
 
+    /// random parseint error
+    #[error(transparent)]
+    ParseIntError(#[from] std::num::ParseIntError),
+
     /// A problem with a jinja template, which is always a cargo-dist bug
     #[error("Failed to render template")]
     #[diagnostic(help("this is a bug in cargo-dist, let us know and we'll fix it: https://github.com/axodotdev/cargo-dist/issues/new"))]

--- a/cargo-dist/src/platform.rs
+++ b/cargo-dist/src/platform.rs
@@ -2,7 +2,10 @@
 use axoproject::platforms::{
     TARGET_ARM64_MAC, TARGET_ARM64_WINDOWS, TARGET_X64_MAC, TARGET_X64_WINDOWS, TARGET_X86_WINDOWS,
 };
-use cargo_dist_schema::ArtifactId;
+
+use cargo_dist_schema::{
+    ArtifactId, AssetId, BuildEnvironment, DistManifest, GlibcVersion, Linkage, SystemInfo,
+};
 use serde::Serialize;
 
 use crate::{
@@ -59,44 +62,43 @@ pub enum SupportQuality {
     HighwayToHellmulated,
 }
 
-/// A condition that an installer should ideally check before using this an archive
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(untagged)]
-pub enum RuntimeCondition {
-    /// The system glibc must be at least this version
-    MinGlibcVersion {
-        /// Major version
-        major: u64,
-        /// Series (minor) version
-        series: u64,
-    },
-    /// The system musl libc must be at least this version
-    MinMuslVersion {
-        /// Major version
-        major: u64,
-        /// Series (minor) version
-        series: u64,
-    },
-    /// The system must have Rosetta2 installed
-    Rosetta2,
+/// A unixy libc version
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Serialize)]
+pub struct LibcVersion {
+    /// Major version
+    pub major: u64,
+    /// Series (minor) version
+    pub series: u64,
 }
 
-/// Runtime conditions specific to Linux
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
-pub struct LinuxRuntimeConditions {
-    /// The system glibc must be at least this version
-    pub glibc: Option<RuntimeCondition>,
-    /// The system musl libc must be at least this version
-    pub musl: Option<RuntimeCondition>,
+impl LibcVersion {
+    fn default_glibc() -> Self {
+        Self {
+            major: 2,
+            series: 31,
+        }
+    }
+
+    fn glibc_from_schema(schema: &GlibcVersion) -> Self {
+        Self {
+            major: schema.major,
+            series: schema.series,
+        }
+    }
 }
 
-/// Runtime conditions collected for every platform
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+/// Conditions that an installer should ideally check before using this an archive
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct RuntimeConditions {
-    /// Linux-specific conditions
-    pub linux: LinuxRuntimeConditions,
-    /// MacOS-specific conditions
-    pub macos: Option<RuntimeCondition>,
+    /// The system glibc should be at least this version
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_glibc_version: Option<LibcVersion>,
+    /// The system musl libc should be at least this version
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_musl_version: Option<LibcVersion>,
+    /// Rosetta2 should be installed
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub rosetta2: bool,
 }
 
 /// Computed platform support details for a Release
@@ -121,7 +123,7 @@ pub struct FetchableArchive {
     /// Runtime conditions that are native to this archive
     ///
     /// (You can largely ignore these in favour of the runtime_conditions in PlatformEntry)
-    pub native_runtime_conditions: Vec<RuntimeCondition>,
+    pub native_runtime_conditions: RuntimeConditions,
     /// What target triples does this archive natively support
     pub target_triples: Vec<TargetTriple>,
     /// The sha256sum of the archive
@@ -163,7 +165,7 @@ pub struct PlatformEntry {
     ///
     /// For instance if you have a linux-gnu build but the system glibc is too old to run it,
     /// you will want to skip it in favour of a more portable musl-static build.
-    pub runtime_conditions: Vec<RuntimeCondition>,
+    pub runtime_conditions: RuntimeConditions,
     /// The archive
     pub archive_idx: FetchableArchiveIdx,
 }
@@ -200,6 +202,9 @@ impl PlatformSupport {
             let (artifact, binaries) =
                 dist.make_executable_zip_for_variant(release_idx, variant_idx);
 
+            let native_runtime_conditions =
+                native_runtime_conditions_for_artifact(dist, &artifact.id);
+
             let executables = binaries
                 .iter()
                 .filter(|(idx, _)| dist.binary(*idx).kind == BinaryKind::Executable);
@@ -224,7 +229,7 @@ impl PlatformSupport {
                     .collect(),
                 zip_style: artifact.archive.as_ref().unwrap().zip_style,
                 sha256sum: None,
-                native_runtime_conditions: vec![],
+                native_runtime_conditions,
                 updater: updater_idx,
             };
             archives.push(archive);
@@ -281,11 +286,39 @@ impl PlatformSupport {
                 executables: archive.executables.clone(),
                 cdylibs: archive.cdylibs.clone(),
                 cstaticlibs: archive.cstaticlibs.clone(),
+                runtime_conditions: option.runtime_conditions.clone(),
                 updater,
             };
             fragments.push(fragment);
         }
         fragments
+    }
+
+    /// Conflate all the options that `fragments` suggests to create a single unified
+    /// RuntimeConditions that can be used in installers while we transition to implementations
+    /// that more granularly factor in these details.
+    pub fn conflated_runtime_conditions(&self) -> RuntimeConditions {
+        let mut runtime_conditions = RuntimeConditions::default();
+        for options in self.platforms.values() {
+            let Some(option) = options.first() else {
+                continue;
+            };
+            runtime_conditions.merge(&option.runtime_conditions);
+        }
+        runtime_conditions
+    }
+
+    /// Similar to conflated_runtime_conditions, but certain None values
+    /// are replaced by safe defaults.
+    /// Currently, a default value is provided for glibc; others may be
+    /// provided in the future.
+    pub fn safe_conflated_runtime_conditions(&self) -> RuntimeConditions {
+        let mut runtime_conditions = self.conflated_runtime_conditions();
+        if runtime_conditions.min_glibc_version.is_none() {
+            runtime_conditions.min_glibc_version = Some(LibcVersion::default_glibc());
+        }
+
+        runtime_conditions
     }
 }
 
@@ -380,12 +413,10 @@ fn supports(
         // and the auto-installer for it only applies to GUI apps, not CLI apps, so ideally
         // any installer that uses this fallback should check if Rosetta2 is installed!
         if target == TARGET_X64_MAC {
-            let runtime_conditions = archive
-                .native_runtime_conditions
-                .iter()
-                .cloned()
-                .chain(Some(RuntimeCondition::Rosetta2))
-                .collect();
+            let runtime_conditions = RuntimeConditions {
+                rosetta2: true,
+                ..archive.native_runtime_conditions.clone()
+            };
             res.push((
                 TARGET_ARM64_MAC.to_owned(),
                 PlatformEntry {
@@ -445,4 +476,107 @@ fn supports(
         }
     }
     res
+}
+
+impl RuntimeConditions {
+    fn merge(&mut self, other: &Self) {
+        let RuntimeConditions {
+            min_glibc_version,
+            min_musl_version,
+            rosetta2,
+        } = other;
+
+        self.min_glibc_version =
+            max_of_min_libc_versions(&self.min_glibc_version, min_glibc_version);
+        self.min_musl_version = max_of_min_libc_versions(&self.min_musl_version, min_musl_version);
+        self.rosetta2 |= rosetta2;
+    }
+}
+
+/// Combine two min_libc_versions to get a new min that satisfies both
+fn max_of_min_libc_versions(
+    lhs: &Option<LibcVersion>,
+    rhs: &Option<LibcVersion>,
+) -> Option<LibcVersion> {
+    match (*lhs, *rhs) {
+        (None, None) => None,
+        (Some(ver), None) | (None, Some(ver)) => Some(ver),
+        (Some(lhs), Some(rhs)) => Some(lhs.max(rhs)),
+    }
+}
+
+/// Compute the requirements for running the binaries of this release on its host platform
+fn native_runtime_conditions_for_artifact(
+    dist: &DistGraphBuilder,
+    artifact_id: &ArtifactId,
+) -> RuntimeConditions {
+    let manifest = &dist.manifest;
+    let Some(artifact) = manifest.artifacts.get(artifact_id) else {
+        return RuntimeConditions::default();
+    };
+
+    let mut runtime_conditions = RuntimeConditions::default();
+    for asset in &artifact.assets {
+        let asset_conditions = native_runtime_conditions_for_asset(manifest, &asset.id);
+        runtime_conditions.merge(&asset_conditions);
+    }
+
+    runtime_conditions
+}
+
+fn native_runtime_conditions_for_asset(
+    manifest: &DistManifest,
+    asset_id: &Option<AssetId>,
+) -> RuntimeConditions {
+    let Some(asset_id) = asset_id else {
+        return RuntimeConditions::default();
+    };
+    let Some(asset) = &manifest.assets.get(asset_id) else {
+        return RuntimeConditions::default();
+    };
+    let Some(linkage) = &asset.linkage else {
+        return RuntimeConditions::default();
+    };
+    // This one's actually infallible but better safe than sorry...
+    let Some(system) = manifest.systems.get(&asset.system) else {
+        return RuntimeConditions::default();
+    };
+
+    // Get various libc versions
+    let min_glibc_version = native_glibc_version(system, linkage);
+    let min_musl_version = native_musl_version(system, linkage);
+
+    // rosetta2 is never required to run a binary on its *host* platform
+    let rosetta2 = false;
+    RuntimeConditions {
+        min_glibc_version,
+        min_musl_version,
+        rosetta2,
+    }
+}
+
+/// Get the native glibc version this binary links against, to the best of our ability
+fn native_glibc_version(system: &SystemInfo, linkage: &Linkage) -> Option<LibcVersion> {
+    for lib in &linkage.system {
+        // If this links against glibc, then we need to require that
+        if lib.is_glibc() {
+            if let BuildEnvironment::Linux {
+                glibc_version: Some(system_glibc),
+            } = &system.build_environment
+            {
+                // If there's a system libc, assume that's what it was built against
+                return Some(LibcVersion::glibc_from_schema(system_glibc));
+            } else {
+                // If the system has no known libc version use Ubuntu 20.04's glibc as a guess
+                return Some(LibcVersion::default_glibc());
+            }
+        }
+    }
+    None
+}
+
+/// Get the native musl libc version this binary links against, to the best of our ability
+fn native_musl_version(_system: &SystemInfo, _linkage: &Linkage) -> Option<LibcVersion> {
+    // FIXME: this should be the same as glibc_version but we don't get this info yet!
+    None
 }

--- a/cargo-dist/src/platform.rs
+++ b/cargo-dist/src/platform.rs
@@ -3,6 +3,7 @@ use axoproject::platforms::{
     TARGET_ARM64_MAC, TARGET_ARM64_WINDOWS, TARGET_X64_MAC, TARGET_X64_WINDOWS, TARGET_X86_WINDOWS,
 };
 use cargo_dist_schema::ArtifactId;
+use serde::Serialize;
 
 use crate::{
     backend::installer::{ExecutableZipFragment, UpdaterFragment},
@@ -59,7 +60,8 @@ pub enum SupportQuality {
 }
 
 /// A condition that an installer should ideally check before using this an archive
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
 pub enum RuntimeCondition {
     /// The system glibc must be at least this version
     MinGlibcVersion {
@@ -77,6 +79,24 @@ pub enum RuntimeCondition {
     },
     /// The system must have Rosetta2 installed
     Rosetta2,
+}
+
+/// Runtime conditions specific to Linux
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+pub struct LinuxRuntimeConditions {
+    /// The system glibc must be at least this version
+    pub glibc: Option<RuntimeCondition>,
+    /// The system musl libc must be at least this version
+    pub musl: Option<RuntimeCondition>,
+}
+
+/// Runtime conditions collected for every platform
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+pub struct RuntimeConditions {
+    /// Linux-specific conditions
+    pub linux: LinuxRuntimeConditions,
+    /// MacOS-specific conditions
+    pub macos: Option<RuntimeCondition>,
 }
 
 /// Computed platform support details for a Release

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -69,6 +69,7 @@ use crate::config::{
     DependencyKind, DirtyMode, ExtraArtifact, GithubPermissionMap, GithubReleasePhase,
     LibraryStyle, ProductionMode, SystemDependencies,
 };
+use crate::linkage::determine_build_environment;
 use crate::net::ClientSettings;
 use crate::platform::{PlatformSupport, RuntimeConditions};
 use crate::sign::Signing;
@@ -1106,12 +1107,16 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             DirtyMode::AllowList(allow_dirty.clone().unwrap_or(vec![]))
         };
         let cargo_version_line = tools.cargo.version_line.clone();
+        let build_environment = if local_builds_are_lies {
+            BuildEnvironment::Indeterminate
+        } else {
+            determine_build_environment(&tools.cargo.host_target)
+        };
 
         let system = SystemInfo {
             id: system_id.clone(),
             cargo_version_line,
-            // Real value calculated during the build
-            build_environment: BuildEnvironment::Indeterminate,
+            build_environment,
         };
         let systems = SortedMap::from_iter([(system_id.clone(), system)]);
 

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -29,8 +29,8 @@ EORECEIPT
 RECEIPT_HOME="${HOME}/.config/{{ app_name }}"
 
 # glibc provided by the system(s) which built these binaries
-BUILDER_GLIBC_MAJOR="{{ runtime_conditions.linux.glibc.major }}"
-BUILDER_GLIBC_SERIES="{{ runtime_conditions.linux.glibc.series }}"
+BUILDER_GLIBC_MAJOR="{{ runtime_conditions.min_glibc_version.major }}"
+BUILDER_GLIBC_SERIES="{{ runtime_conditions.min_glibc_version.series }}"
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -28,11 +28,9 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/{{ app_name }}"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
-BUILDER_GLIBC_MAJOR="2"
-BUILDER_GLIBC_SERIES="31"
+# glibc provided by the system(s) which built these binaries
+BUILDER_GLIBC_MAJOR="{{ runtime_conditions.linux.glibc.major }}"
+BUILDER_GLIBC_SERIES="{{ runtime_conditions.linux.glibc.series }}"
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)

--- a/cargo-dist/templates/installer/npm/binary.js
+++ b/cargo-dist/templates/installer/npm/binary.js
@@ -13,10 +13,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();

--- a/cargo-dist/templates/installer/npm/package.json
+++ b/cargo-dist/templates/installer/npm/package.json
@@ -4,6 +4,10 @@
   "repository": "https://github.com/axodotdev/cargo-dist/",
   "preferUnplugged": true,
   "artifactDownloadUrl": "",
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "supportedPlatforms": {},
   "scripts": {
     "postinstall": "node ./install.js",
@@ -30,4 +34,3 @@
     "prettier": "^3.3.3"
   }
 }
-

--- a/cargo-dist/tests/gallery/dist/snapshot.rs
+++ b/cargo-dist/tests/gallery/dist/snapshot.rs
@@ -148,6 +148,18 @@ pub fn snapshot_settings_with_gallery_filter() -> insta::Settings {
     settings.add_filter(r#""sha256": .*"#, r#""sha256": "CENSORED""#);
     settings.add_filter(r#""sha512": .*"#, r#""sha512": "CENSORED""#);
     settings.add_filter(r#""version":"[a-zA-Z\.0-9\-]*""#, r#""version":"CENSORED""#);
+    settings.add_filter(
+        r#""build_environment": \{\n\s+"macos": \{\n\s+"os_version": ".+"\n\s+}\n\s+}"#,
+        r#""build_environment": "indeterminate""#,
+    );
+    settings.add_filter(
+        r#""build_environment": \{\n\s+"linux": \{\n\s+"glibc_version": \{\n\s+"major": .+\n\s+"series": .+\n\s+\}\n\s+}\n\s+}"#,
+        r#""build_environment": "indeterminate""#,
+    );
+    settings.add_filter(
+        r#""build_environment": "windows""#,
+        r#""build_environment": "indeterminate""#,
+    );
     settings
 }
 
@@ -183,6 +195,18 @@ pub fn snapshot_settings_with_dist_manifest_filter() -> insta::Settings {
     );
     settings.add_filter(r#""sha256": .*"#, r#""sha256": "CENSORED""#);
     settings.add_filter(r#""sha512": .*"#, r#""sha512": "CENSORED""#);
+    settings.add_filter(
+        r#""build_environment": \{\n\s+"macos": \{\n\s+"os_version": ".+"\n\s+}\n\s+}"#,
+        r#""build_environment": "indeterminate""#,
+    );
+    settings.add_filter(
+        r#""build_environment": \{\n\s+"linux": \{\n\s+"glibc_version": \{\n\s+"major": .+\n\s+"series": .+\n\s+\}\n\s+}\n\s+}"#,
+        r#""build_environment": "indeterminate""#,
+    );
+    settings.add_filter(
+        r#""build_environment": "windows""#,
+        r#""build_environment": "indeterminate""#,
+    );
 
     settings
 }

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1830,6 +1828,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1328,6 +1326,7 @@ download_binary_and_run_installer "$@" || exit 1
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1844,6 +1842,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1858,6 +1856,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1870,6 +1868,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3385,6 +3388,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3379,6 +3382,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2039,10 +2037,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2971,6 +2970,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3393,6 +3396,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2039,10 +2037,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2969,6 +2968,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3391,6 +3394,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3377,6 +3380,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2028,10 +2026,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2958,6 +2957,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3401,6 +3404,7 @@ run("axolotlsay");
     "build:lies:": {
       "id": "build:lies:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "assets": {

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -33,9 +33,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2024,10 +2022,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2954,6 +2953,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3376,6 +3379,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1298,6 +1296,7 @@ download_binary_and_run_installer "$@" || exit 1
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1298,6 +1296,7 @@ download_binary_and_run_installer "$@" || exit 1
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1298,6 +1296,7 @@ download_binary_and_run_installer "$@" || exit 1
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1298,6 +1296,7 @@ download_binary_and_run_installer "$@" || exit 1
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -296,6 +296,7 @@ end
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -223,6 +223,7 @@ expression: self.payload
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3366,6 +3369,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -223,6 +223,7 @@ expression: self.payload
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -231,6 +231,7 @@ expression: self.payload
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -225,6 +225,7 @@ expression: self.payload
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3351,6 +3354,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay-js"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1595,9 +1593,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -3595,6 +3591,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3377,6 +3380,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1546,10 +1544,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2476,6 +2475,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -2841,6 +2844,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1546,10 +1544,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2476,6 +2475,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -2796,6 +2799,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/coolbeans",
@@ -3351,6 +3354,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -223,6 +223,7 @@ expression: self.payload
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -223,6 +223,7 @@ expression: self.payload
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2039,10 +2037,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2973,6 +2972,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3395,6 +3398,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1776,6 +1774,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1776,6 +1774,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -223,6 +223,7 @@ expression: self.payload
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2033,10 +2031,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2963,6 +2962,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3417,6 +3420,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3351,6 +3354,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3351,6 +3354,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3351,6 +3354,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3351,6 +3354,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -2025,10 +2023,11 @@ const {
   name,
   artifactDownloadUrl,
   supportedPlatforms,
+  glibcMinimum,
 } = require("./package.json");
 
-const builderGlibcMajorVersion = 2;
-const builderGlibcMInorVersion = 31;
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMInorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2955,6 +2954,10 @@ install(false);
     "node": ">=14",
     "npm": ">=6"
   },
+  "glibcMinimum": {
+    "major": 2,
+    "series": 31
+  },
   "homepage": "https://github.com/axodotdev/axolotlsay",
   "license": "MIT OR Apache-2.0",
   "name": "@axodotdev/axolotlsay",
@@ -3351,6 +3354,7 @@ run("axolotlsay");
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1823,6 +1821,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1798,6 +1796,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1798,6 +1796,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1798,6 +1796,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1798,6 +1796,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1819,6 +1817,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1798,6 +1796,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1798,6 +1796,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1798,6 +1796,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1798,6 +1796,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -34,9 +34,7 @@ EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
 
-# glibc provided by our Ubuntu 20.04 runners;
-# in the future, we should actually record which glibc was on the runner,
-# and inject that into the script.
+# glibc provided by the system(s) which built these binaries
 BUILDER_GLIBC_MAJOR="2"
 BUILDER_GLIBC_SERIES="31"
 
@@ -1819,6 +1817,7 @@ try {
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -36,6 +36,7 @@ stdout:
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -36,6 +36,7 @@ stdout:
     "plan:all:": {
       "id": "plan:all:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -418,6 +418,7 @@ stdout:
     "plan:lies:": {
       "id": "plan:lies:",
       "cargo_version_line": "CENSORED"
+      "build_environment": "indeterminate"
     }
   },
   "publish_prereleases": false,


### PR DESCRIPTION
So far, we have one runtime requirement expressed directly in our installers: the glibc version used to build. At the moment, this is hardcoded based on the value in the default runner, but we'd like to have it be determined at buildtime and then used in the installer as appropriate.

This adds that tracking. At buildtime, we now add to the `SystemInfo` field to track system environment information specific to the build environment. We should expand this in time, but at the moment we track builder glibc version and macOS version. We then collate that information in the installer to calculate the safest minimum glibc version and inject that into the installers rather than hardcoding.

At the moment this reuses some platform information from the `platform` module, but not all of it - that module is focused on covering one platform at a time, while we're trying to collate information on every platform during install time. I'm not 100% sure if we want to be reusing these in this shape, or at least we may want to rethink the way `platform` is put together down the line if we want to be able to express more of this in the installers.

Some more thoughts on build info to track:

* musl version (on musl-based systems)
* Xcode/CLT version (on macOS)

We may also want to start using the macOS version to express a version minimum in the installers.