### PR TITLE
fix: restore proper diagnostics for repository url

### DIFF
--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -128,10 +128,22 @@ pub enum DistError {
         #[diagnostic_source]
         inner: AxoprojectError,
     },
+
     /// User tried to enable Github CI support but no url for the repo
     #[error("Github CI support requires you to specify the URL of your repository")]
-    #[diagnostic(help(r#"Set the repository = "https://github.com/..." key in your Cargo.toml"#))]
+    #[diagnostic(help(
+        r#"Set the repository = "https://github.com/..." key in the Cargo.toml of your app"#
+    ))]
     CantEnableGithubNoUrl,
+
+    /// We got a repository URL but couldn't interpret it as a GitHub repo
+    #[error("Github CI support requires your repository be hosted on Github")]
+    #[diagnostic(help(r#"You said your repository"#))]
+    CantEnableGithubUrlNotGithub {
+        /// inner error that caught this
+        #[diagnostic_source]
+        inner: AxoprojectError,
+    },
     /// User declined to force tar.gz with npm
     #[error("Cannot enable npm support without forcing artifacts to be .tar.gz")]
     MustEnableTarGz,

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -132,13 +132,15 @@ pub enum DistError {
     /// User tried to enable Github CI support but no url for the repo
     #[error("Github CI support requires you to specify the URL of your repository")]
     #[diagnostic(help(
-        r#"Set the repository = "https://github.com/..." key in the Cargo.toml of your app"#
+        r#"Set the repository = "https://github.com/..." key in these manifests: {manifest_list}"#
     ))]
-    CantEnableGithubNoUrl,
+    CantEnableGithubNoUrl {
+        /// List of manifests to change
+        manifest_list: String,
+    },
 
     /// We got a repository URL but couldn't interpret it as a GitHub repo
-    #[error("Github CI support requires your repository be hosted on Github")]
-    #[diagnostic(help(r#"You said your repository"#))]
+    #[error("GitHub CI support requires a GitHub repository")]
     CantEnableGithubUrlNotGithub {
         /// inner error that caught this
         #[diagnostic_source]

--- a/cargo-dist/src/host.rs
+++ b/cargo-dist/src/host.rs
@@ -305,7 +305,13 @@ pub(crate) fn select_hosting(
     let raw_repository_url = match workspaces.repository_url(Some(&package_list)) {
         Ok(Some(url)) => url,
         Ok(None) => {
-            return Err(DistError::CantEnableGithubNoUrl);
+            let mut manifest_list = String::new();
+            for pkg_idx in package_list {
+                let package = workspaces.package(pkg_idx);
+                manifest_list.push('\n');
+                manifest_list.push_str(package.manifest_path.as_str());
+            }
+            return Err(DistError::CantEnableGithubNoUrl { manifest_list });
         }
         Err(e) => {
             return Err(DistError::CantEnableGithubUrlInconsistent { inner: e });

--- a/cargo-dist/src/host.rs
+++ b/cargo-dist/src/host.rs
@@ -8,12 +8,11 @@ use crate::{
     gather_work,
     manifest::save_manifest,
     net::create_gazenot_client,
-    DistGraph, DistGraphBuilder, HostingInfo,
+    DistError, DistGraph, DistGraphBuilder, HostingInfo,
 };
 use axoproject::WorkspaceGraph;
 use cargo_dist_schema::{DistManifest, Hosting};
 use gazenot::{AnnouncementKey, Gazenot};
-use tracing::warn;
 
 /// Do hosting
 pub fn do_host(cfg: &Config, host_args: HostArgs) -> DistResult<DistManifest> {
@@ -79,7 +78,7 @@ impl<'a> DistGraphBuilder<'a> {
         hosting: Option<Vec<HostingStyle>>,
         ci: Option<Vec<CiStyle>>,
     ) -> DistResult<()> {
-        self.inner.hosting = select_hosting(self.workspaces, announcing, hosting, ci.as_deref());
+        self.inner.hosting = select_hosting(self.workspaces, announcing, hosting, ci.as_deref())?;
         // If we don't think we can host things, don't bother
         let Some(hosting) = &self.inner.hosting else {
             return Ok(());
@@ -283,39 +282,47 @@ pub(crate) fn select_hosting(
     announcing: &AnnouncementTag,
     hosting: Option<Vec<HostingStyle>>,
     ci: Option<&[CiStyle]>,
-) -> Option<HostingInfo> {
+) -> DistResult<Option<HostingInfo>> {
+    // Either use the explicit one, or default to the CI provider's native solution
+    let Some(hosting_providers) = hosting
+        .clone()
+        .or_else(|| Some(vec![ci.as_ref()?.first()?.native_hosting()?]))
+    else {
+        // This is the one case where we'll tolerate hosting not existing:
+        // * they don't have one set explicitly
+        // * and they haven't turned on a CI provider
+        // This implies early setup or using cargo-dist very "manually"
+        return Ok(None);
+    };
+
+    // Get the list of packages we actually care about
     let package_list = announcing
         .rust_releases
         .iter()
         .map(|release| release.package_idx)
         .collect::<Vec<_>>();
-    // Either use the explicit one, or default to the CI provider's native solution
-    let hosting_providers = hosting
-        .clone()
-        .or_else(|| Some(vec![ci.as_ref()?.first()?.native_hosting()?]))?;
 
-    let raw_repository_url = workspaces
-        .repository_url(Some(&package_list))
-        .map_err(|warning| {
-            let report = miette::Report::new(warning);
-            warn!("{:?}", report);
-        })
-        .ok()??;
+    let raw_repository_url = match workspaces.repository_url(Some(&package_list)) {
+        Ok(Some(url)) => url,
+        Ok(None) => {
+            return Err(DistError::CantEnableGithubNoUrl);
+        }
+        Err(e) => {
+            return Err(DistError::CantEnableGithubUrlInconsistent { inner: e });
+        }
+    };
+
     // Currently there's only one supported sourcehost provider
     let repo = raw_repository_url
         .github_repo()
-        .map_err(|warning| {
-            let report = miette::Report::new(warning);
-            warn!("{:?}", report);
-        })
-        .ok()?;
+        .map_err(|e| DistError::CantEnableGithubUrlNotGithub { inner: e })?;
     let repo_url = repo.web_url();
 
-    Some(HostingInfo {
+    Ok(Some(HostingInfo {
         hosts: hosting_providers,
         repo_url: repo_url.clone(),
         source_host: "github".to_owned(),
         owner: repo.owner,
         project: repo.name,
-    })
+    }))
 }

--- a/cargo-dist/src/tests/host.rs
+++ b/cargo-dist/src/tests/host.rs
@@ -1,0 +1,270 @@
+use super::mock::*;
+use crate::announce::{select_tag, AnnouncementTag, TagMode, TagSettings};
+use crate::config::{CiStyle, HostingStyle};
+use crate::host::select_hosting;
+use crate::DistError;
+use crate::{config::ArtifactMode, DistGraphBuilder};
+use axoproject::errors::AxoprojectError;
+use axoproject::{PackageIdx, WorkspaceGraph};
+use semver::Version;
+
+fn mock_announce(workspaces: &mut WorkspaceGraph) -> (DistGraphBuilder, AnnouncementTag) {
+    let version: Version = BIN_AXO_VER.parse().unwrap();
+    let tag = format!("{version}");
+
+    let tools = mock_tools();
+    let mut graph = DistGraphBuilder::new(
+        "a".to_owned(),
+        tools,
+        workspaces,
+        ArtifactMode::All,
+        true,
+        false,
+    )
+    .unwrap();
+    let settings = TagSettings {
+        needs_coherence: true,
+        tag: TagMode::Select(tag.clone()),
+    };
+    let announcing = select_tag(&mut graph, &settings).unwrap();
+    (graph, announcing)
+}
+
+#[test]
+fn github_simple() {
+    // ci = "github" and hosting = "github"
+    let mut workspaces = workspace_unified();
+    let hosting = Some(vec![HostingStyle::Github]);
+    let ci = Some(vec![CiStyle::Github]);
+
+    let (_graph, announcing) = mock_announce(&mut workspaces);
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+
+    let hosting = hosting.unwrap().unwrap();
+    assert_eq!(hosting.repo_url, REPO_URL);
+    assert_eq!(hosting.hosts, &[HostingStyle::Github]);
+    assert_eq!(hosting.owner, REPO_OWNER);
+    assert_eq!(hosting.project, REPO_PROJECT);
+    assert_eq!(hosting.source_host, "github");
+}
+
+#[test]
+fn github_and_axo_simple() {
+    // ci = "github" and hosting = ["github", "axodotdev"]
+    let mut workspaces = workspace_unified();
+    let hosting = Some(vec![HostingStyle::Github, HostingStyle::Axodotdev]);
+    let ci = Some(vec![CiStyle::Github]);
+
+    let (_graph, announcing) = mock_announce(&mut workspaces);
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+
+    let hosting = hosting.unwrap().unwrap();
+    assert_eq!(hosting.repo_url, REPO_URL);
+    assert_eq!(
+        hosting.hosts,
+        &[HostingStyle::Github, HostingStyle::Axodotdev]
+    );
+    assert_eq!(hosting.owner, REPO_OWNER);
+    assert_eq!(hosting.project, REPO_PROJECT);
+    assert_eq!(hosting.source_host, "github");
+}
+
+#[test]
+fn github_implicit() {
+    // ci = "github" and hosting = None
+    let mut workspaces = workspace_unified();
+    let hosting = None;
+    let ci = Some(vec![CiStyle::Github]);
+
+    let (_graph, announcing) = mock_announce(&mut workspaces);
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+
+    let hosting = hosting.unwrap().unwrap();
+    assert_eq!(hosting.repo_url, REPO_URL);
+    assert_eq!(hosting.hosts, &[HostingStyle::Github]);
+    assert_eq!(hosting.owner, REPO_OWNER);
+    assert_eq!(hosting.project, REPO_PROJECT);
+    assert_eq!(hosting.source_host, "github");
+}
+
+#[test]
+fn github_diff_repository_on_non_distables() {
+    // DIFFERENT repository keys for each non-distable package
+    const OTHER_REPO_URL: &str = "https://github.com/mycoolorg/radproj";
+    let mut workspaces = workspace_unified();
+    let num_packages = workspaces.all_packages().count();
+    for pkg_idx in 0..num_packages {
+        let package = workspaces.package_mut(PackageIdx(pkg_idx));
+        if package.binaries.is_empty() {
+            package.repository_url = Some(OTHER_REPO_URL.to_owned());
+        }
+    }
+    let hosting = None;
+    let ci = Some(vec![CiStyle::Github]);
+
+    let (_graph, announcing) = mock_announce(&mut workspaces);
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+
+    let hosting = hosting.unwrap().unwrap();
+    assert_eq!(hosting.repo_url, REPO_URL);
+    assert_eq!(hosting.hosts, &[HostingStyle::Github]);
+    assert_eq!(hosting.owner, REPO_OWNER);
+    assert_eq!(hosting.project, REPO_PROJECT);
+    assert_eq!(hosting.source_host, "github");
+}
+
+#[test]
+fn github_no_repository() {
+    // no repository key in any packages
+    let mut workspaces = workspace_unified();
+    let num_packages = workspaces.all_packages().count();
+    for pkg_idx in 0..num_packages {
+        let package = workspaces.package_mut(PackageIdx(pkg_idx));
+        package.repository_url = None;
+    }
+
+    let hosting = None;
+    let ci = Some(vec![CiStyle::Github]);
+
+    let (_graph, announcing) = mock_announce(&mut workspaces);
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+
+    if let Err(DistError::CantEnableGithubNoUrl { manifest_list }) = &hosting {
+        assert!(manifest_list.contains(".toml"));
+    } else {
+        panic!("unexpected result: {hosting:?}");
+    }
+}
+
+#[test]
+fn github_diff_repository() {
+    // DIFFERENT repository keys for each package
+    const OTHER_REPO_URL: &str = "https://github.com/mycoolorg/radproj";
+    let mut workspaces = workspace_unified();
+    let num_packages = workspaces.all_packages().count();
+    for pkg_idx in 0..num_packages {
+        let package = workspaces.package_mut(PackageIdx(pkg_idx));
+        if !package.binaries.is_empty() {
+            package.repository_url = Some(OTHER_REPO_URL.to_owned());
+            break;
+        }
+    }
+
+    let hosting = None;
+    let ci = Some(vec![CiStyle::Github]);
+
+    let (_graph, announcing) = mock_announce(&mut workspaces);
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+
+    if let Err(DistError::CantEnableGithubUrlInconsistent {
+        inner:
+            AxoprojectError::InconsistentRepositoryKey {
+                file1: _,
+                url1,
+                file2: _,
+                url2,
+            },
+    }) = &hosting
+    {
+        assert_eq!(url1, OTHER_REPO_URL);
+        assert_eq!(url2, REPO_URL);
+    } else {
+        panic!("unexpected result: {hosting:?}");
+    }
+}
+
+#[test]
+fn github_not_github_repository() {
+    // repo isn't github, but hosting enabled
+    const NOT_GH_REPO_URL: &str = "https://mysourcehost.com/mycoolorg/radproj";
+
+    let mut workspaces = workspace_unified();
+    let num_packages = workspaces.all_packages().count();
+    for pkg_idx in 0..num_packages {
+        let package = workspaces.package_mut(PackageIdx(pkg_idx));
+        package.repository_url = Some(NOT_GH_REPO_URL.to_owned());
+    }
+
+    let hosting = None;
+    let ci = Some(vec![CiStyle::Github]);
+
+    let (_graph, announcing) = mock_announce(&mut workspaces);
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+
+    if let Err(DistError::CantEnableGithubUrlNotGithub {
+        inner: AxoprojectError::NotGitHubError { url },
+    }) = &hosting
+    {
+        assert_eq!(url, NOT_GH_REPO_URL);
+    } else {
+        panic!("unexpected result: {hosting:?}");
+    }
+}
+
+#[test]
+fn no_ci_no_problem() {
+    // no repository key in any packages, but ci is disabled
+    let mut workspaces = workspace_unified();
+    let num_packages = workspaces.all_packages().count();
+    for pkg_idx in 0..num_packages {
+        let package = workspaces.package_mut(PackageIdx(pkg_idx));
+        package.repository_url = None;
+    }
+
+    let hosting = None;
+    let ci = None;
+
+    let (_graph, announcing) = mock_announce(&mut workspaces);
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci);
+
+    assert!(matches!(hosting, Ok(None)))
+}
+
+#[test]
+fn github_dot_git() {
+    // passed in a .git url
+    let mut workspaces = workspace_unified();
+    let num_packages = workspaces.all_packages().count();
+    for pkg_idx in 0..num_packages {
+        let package = workspaces.package_mut(PackageIdx(pkg_idx));
+        package.repository_url = Some(format!("{REPO_URL}.git"));
+    }
+    let hosting = Some(vec![HostingStyle::Github]);
+    let ci = Some(vec![CiStyle::Github]);
+
+    let (_graph, announcing) = mock_announce(&mut workspaces);
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+
+    let hosting = hosting.unwrap().unwrap();
+    assert_eq!(hosting.repo_url, REPO_URL);
+    assert_eq!(hosting.hosts, &[HostingStyle::Github]);
+    assert_eq!(hosting.owner, REPO_OWNER);
+    assert_eq!(hosting.project, REPO_PROJECT);
+    assert_eq!(hosting.source_host, "github");
+}
+
+#[test]
+fn github_trail_slash() {
+    // repo urls only differ by trailing slash
+    let mut workspaces = workspace_unified();
+    let num_packages = workspaces.all_packages().count();
+    for pkg_idx in 0..num_packages {
+        let package = workspaces.package_mut(PackageIdx(pkg_idx));
+        if !package.binaries.is_empty() {
+            package.repository_url = Some(format!("{REPO_URL}/"));
+            break;
+        }
+    }
+    let hosting = Some(vec![HostingStyle::Github]);
+    let ci = Some(vec![CiStyle::Github]);
+
+    let (_graph, announcing) = mock_announce(&mut workspaces);
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+
+    let hosting = hosting.unwrap().unwrap();
+    assert_eq!(hosting.repo_url, REPO_URL);
+    assert_eq!(hosting.hosts, &[HostingStyle::Github]);
+    assert_eq!(hosting.owner, REPO_OWNER);
+    assert_eq!(hosting.project, REPO_PROJECT);
+    assert_eq!(hosting.source_host, "github");
+}

--- a/cargo-dist/src/tests/mod.rs
+++ b/cargo-dist/src/tests/mod.rs
@@ -1,3 +1,4 @@
 mod config;
+mod host;
 mod mock;
 mod tag;


### PR DESCRIPTION
In various refactors this code got overly permissive, silently allowing 'no repository url set at all' in cases where it's invalid. Later code would then panic with an obtuse message about it being impossible (because it should be).