### PR TITLE
Build and install static libs

### DIFF
--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -602,15 +602,15 @@ This is a list of installers you want to be made for your application(s). In pri
 See "repository" for some discussion on the "Artifact Download URL".
 
 
-### install-cdylibs
+### install-libraries
 
 > since 0.19.0
 
-Example: `install-cdylibs = false`
+Example: `install-libraries = ["cdylib", "staticlib"]`
 
-Whether to install C dynamic libraries using the Homebrew/shell/PowerShell installers. This is disabled by default. When enabled, C dynamic libraries will be installed alongside a package's binaries. Packaging libraries must first be enabled using the [package-cdylibs](#package-cdylibs) option.
+Which kinds of libraries to install using the Homebrew/shell/PowerShell installers. By default, no kinds of libraries will be installed. When enabled, libraries will be installed alongside a package's binaries. Packaging libraries must first be enabled using the [package-libraries](#package-libraries) option.
 
-This feature is still experimental. The currently-supported install paths will place dynamic libraries alongside binaries. This means they may appear in the user's `$PATH`, which you may find undesirable.
+This feature is still experimental. The currently-supported install paths will place libraries alongside binaries. This means they may appear in the user's `$PATH`, which you may find undesirable.
 
 
 ### install-path
@@ -729,17 +729,17 @@ Specifies that [npm installers][] should be published under the given [scope][].
 If no scope is specified the package will be global.
 
 
-### package-cdylibs
+### package-libraries
 
 > since 0.19.0
 
-Example: `package-cdylibs = true`
+Example: `package-libraries = ["cdylib", "staticlib"]`
 
 This is an experimental feature.
 
-Whether to include C dynamic libraries in release archives. This is disabled by default, which means C dynamic libraries will still be built but will be excluded from release artifacts.
+Which kinds of libraries to include in release archives. This is disabled by default, which means libraries will still be built but will be excluded from release artifacts.
 
-When enabled, C dynamic libraries will be included in release artifacts but won't be installed by default. That can be enabled using the [install-cdylibs](#install-cdylibs) setting.
+When enabled, libraries will be included in release artifacts but won't be installed by default. That can be enabled using the [install-libraries](#install-libraries) setting.
 
 
 ### plan-jobs

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -342,6 +342,9 @@ pub enum AssetKind {
     /// A C dynamic library
     #[serde(rename = "c_dynamic_library")]
     CDynamicLibrary(DynamicLibraryAsset),
+    /// A C static library
+    #[serde(rename = "c_static_library")]
+    CStaticLibrary(StaticLibraryAsset),
     /// A README file
     #[serde(rename = "readme")]
     Readme,
@@ -405,6 +408,15 @@ pub struct ExecutableAsset {
 /// A C dynamic library artifact (so/dylib/dll)
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DynamicLibraryAsset {
+    /// The name of the Artifact containing symbols for this library
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub symbols_artifact: Option<String>,
+}
+
+/// A C static library artifact (a/lib)
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct StaticLibraryAsset {
     /// The name of the Artifact containing symbols for this library
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -407,6 +407,28 @@ expression: json_schema
           }
         },
         {
+          "description": "A C static library",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "c_static_library"
+              ]
+            },
+            "symbols_artifact": {
+              "description": "The name of the Artifact containing symbols for this library",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        {
           "description": "A README file",
           "type": "object",
           "required": [

--- a/cargo-dist/src/backend/installer/homebrew.rs
+++ b/cargo-dist/src/backend/installer/homebrew.rs
@@ -6,8 +6,11 @@ use serde::Serialize;
 
 use super::InstallerInfo;
 use crate::{
-    backend::templates::TEMPLATE_INSTALLER_RB, config::ChecksumStyle, errors::DistResult,
-    installer::ExecutableZipFragment, tasks::DistGraph,
+    backend::templates::TEMPLATE_INSTALLER_RB,
+    config::{ChecksumStyle, LibraryStyle},
+    errors::DistResult,
+    installer::ExecutableZipFragment,
+    tasks::DistGraph,
 };
 
 /// Info about a Homebrew formula
@@ -46,7 +49,7 @@ pub struct HomebrewInstallerInfo {
     /// Additional packages to specify as dependencies
     pub dependencies: Vec<String>,
     /// Whether to install packaged C dynamic libraries
-    pub install_cdylibs: bool,
+    pub install_libraries: Vec<LibraryStyle>,
 }
 
 pub(crate) fn write_homebrew_formula(

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -78,6 +78,8 @@ pub struct ExecutableZipFragment {
     pub executables: Vec<String>,
     /// The dynamic libraries the artifact contains (name, assumed at root)
     pub cdylibs: Vec<String>,
+    /// The static libraries the artifact contains (name, assumed at root)
+    pub cstaticlibs: Vec<String>,
     /// The style of zip this is
     pub zip_style: ZipStyle,
     /// The updater associated with this platform

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -8,7 +8,7 @@ use camino::Utf8PathBuf;
 use serde::Serialize;
 
 use crate::{
-    config::{JinjaInstallPathStrategy, ZipStyle},
+    config::{JinjaInstallPathStrategy, LibraryStyle, ZipStyle},
     InstallReceipt, TargetTriple,
 };
 
@@ -64,7 +64,7 @@ pub struct InstallerInfo {
     /// Aliases to install binaries under
     pub bin_aliases: BTreeMap<String, BTreeMap<String, Vec<String>>>,
     /// Whether to install generated C dynamic libraries
-    pub install_cdylibs: bool,
+    pub install_libraries: Vec<LibraryStyle>,
 }
 
 /// A fake fragment of an ExecutableZip artifact for installers

--- a/cargo-dist/src/build/mod.rs
+++ b/cargo-dist/src/build/mod.rs
@@ -258,14 +258,14 @@ fn bin_basename(src_path: &Utf8PathBuf) -> Option<String> {
             // the file extension *and* the lib prefix.
             // (Windows .dll libraries are missing the lib
             // prefix, so we don't need to handle those.)
-            "so" | "dylib" => {
+            "so" | "dylib" | "a" => {
                 return src_path
                     .file_stem()
                     .and_then(|stem| stem.strip_prefix("lib"))
                     .map(String::from);
             }
-            // If this is a .dll or .exe, strip just the extension
-            "dll" | "exe" => {
+            // If this is a .dll, .lib or .exe, strip just the extension
+            "dll" | "exe" | "lib" => {
                 return src_path.file_stem().map(String::from);
             }
             _ => {}

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -254,6 +254,12 @@ pub enum DistError {
         /// value provided
         style: String,
     },
+    /// unrecognized library style
+    #[error("{style} is not a recognized type of library")]
+    UnrecognizedLibraryStyle {
+        /// value provided
+        style: String,
+    },
     /// Linkage report can't be run for this combination of OS and target
     #[error("unable to run linkage report for {target} on {host}")]
     LinkageCheckInvalidOS {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -281,8 +281,8 @@ fn get_new_dist_metadata(
             install_updater: None,
             display: None,
             display_name: None,
-            package_cdylibs: None,
-            install_cdylibs: None,
+            package_libraries: None,
+            install_libraries: None,
         }
     };
 
@@ -878,8 +878,8 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         display,
         display_name,
         github_release,
-        package_cdylibs,
-        install_cdylibs,
+        package_libraries,
+        install_libraries,
         // These settings are complex enough that we don't support editing them in init
         extra_artifacts: _,
         github_custom_runners: _,
@@ -1251,18 +1251,18 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         display_name.as_ref(),
     );
 
-    apply_optional_value(
+    apply_string_or_list(
         table,
-        "package-cdylibs",
-        "# Whether to include built C dynamic libraries in the final archives\n",
-        *package_cdylibs,
+        "package-libraries",
+        "# Which kinds of built libraries to include in the final archives\n",
+        package_libraries.as_ref(),
     );
 
-    apply_optional_value(
+    apply_string_or_list(
         table,
-        "install-cdylibs",
-        "# Whether to install packaged C dynamic libraries\n",
-        *install_cdylibs,
+        "install-libraries",
+        "# Which kinds of packaged libraries to install\n",
+        install_libraries.as_ref(),
     );
 
     // Finalize the table

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -130,6 +130,12 @@ fn print_human(out: &mut Term, manifest: &DistManifest) -> Result<(), std::io::E
                             writeln!(out, "        (symbols artifact: {syms})")?;
                         }
                     }
+                    if let AssetKind::CStaticLibrary(lib) = &asset.kind {
+                        writeln!(out, "      [cstaticlib] {}", path)?;
+                        if let Some(syms) = &lib.symbols_artifact {
+                            writeln!(out, "        (symbols artifact: {syms})")?;
+                        }
+                    }
                 }
             }
 
@@ -139,7 +145,9 @@ fn print_human(out: &mut Term, manifest: &DistManifest) -> Result<(), std::io::E
             for asset in &artifact.assets {
                 if !matches!(
                     &asset.kind,
-                    AssetKind::Executable(_) | AssetKind::CDynamicLibrary(_)
+                    AssetKind::Executable(_)
+                        | AssetKind::CDynamicLibrary(_)
+                        | AssetKind::CStaticLibrary(_)
                 ) {
                     if let Some(path) = &asset.path {
                         if printed_asset {

--- a/cargo-dist/src/manifest.rs
+++ b/cargo-dist/src/manifest.rs
@@ -39,7 +39,7 @@ use std::collections::btree_map::Entry;
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_dist_schema::{
     Artifact, ArtifactId, Asset, AssetKind, DistManifest, DynamicLibraryAsset, ExecutableAsset,
-    Hosting,
+    Hosting, StaticLibraryAsset,
 };
 use tracing::warn;
 
@@ -249,6 +249,9 @@ fn add_manifest_artifact(
             let kind = match binary.kind {
                 crate::BinaryKind::DynamicLibrary => {
                     AssetKind::CDynamicLibrary(DynamicLibraryAsset { symbols_artifact })
+                }
+                crate::BinaryKind::StaticLibrary => {
+                    AssetKind::CStaticLibrary(StaticLibraryAsset { symbols_artifact })
                 }
                 crate::BinaryKind::Executable => {
                     AssetKind::Executable(ExecutableAsset { symbols_artifact })

--- a/cargo-dist/src/platform.rs
+++ b/cargo-dist/src/platform.rs
@@ -110,6 +110,8 @@ pub struct FetchableArchive {
     pub executables: Vec<String>,
     /// The dynamic libraries in the archive (assumed to be in root)
     pub cdylibs: Vec<String>,
+    /// The static libraries in the archive (assumed to be in root)
+    pub cstaticlibs: Vec<String>,
     /// The kind of compression the archive has
     pub zip_style: ZipStyle,
     /// The updater you should also fetch if you install this archive
@@ -181,9 +183,12 @@ impl PlatformSupport {
             let executables = binaries
                 .iter()
                 .filter(|(idx, _)| dist.binary(*idx).kind == BinaryKind::Executable);
-            let libraries = binaries
+            let cdylibs = binaries
                 .iter()
                 .filter(|(idx, _)| dist.binary(*idx).kind == BinaryKind::DynamicLibrary);
+            let cstaticlibs = binaries
+                .iter()
+                .filter(|(idx, _)| dist.binary(*idx).kind == BinaryKind::StaticLibrary);
 
             let archive = FetchableArchive {
                 id: artifact.id,
@@ -191,7 +196,10 @@ impl PlatformSupport {
                 executables: executables
                     .map(|(_, dest_path)| dest_path.file_name().unwrap().to_owned())
                     .collect(),
-                cdylibs: libraries
+                cdylibs: cdylibs
+                    .map(|(_, dest_path)| dest_path.file_name().unwrap().to_owned())
+                    .collect(),
+                cstaticlibs: cstaticlibs
                     .map(|(_, dest_path)| dest_path.file_name().unwrap().to_owned())
                     .collect(),
                 zip_style: artifact.archive.as_ref().unwrap().zip_style,
@@ -252,6 +260,7 @@ impl PlatformSupport {
                 zip_style: archive.zip_style,
                 executables: archive.executables.clone(),
                 cdylibs: archive.cdylibs.clone(),
+                cstaticlibs: archive.cstaticlibs.clone(),
                 updater,
             };
             fragments.push(fragment);

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1425,8 +1425,13 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             // referring to a package in your workspace that you want to build an app for.
             // If they do exist, that's deeply cursed and I want a user to tell me about it.
             let pkg_spec = package.true_name.clone();
+            let kind_label = match kind {
+                BinaryKind::Executable => "exe",
+                BinaryKind::DynamicLibrary => "cdylib",
+                BinaryKind::StaticLibrary => "cstaticlib",
+            };
             // FIXME: make this more of a GUID to allow variants to share binaries?
-            let bin_id = format!("{variant_id}-{binary_name}");
+            let bin_id = format!("{variant_id}-{kind_label}-{binary_name}");
 
             let idx = if let Some(&idx) = self.binaries_by_id.get(&bin_id) {
                 // If we already are building this binary we don't need to do it again!

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -3031,8 +3031,10 @@ pub struct InstallReceipt {
     pub install_prefix: String,
     /// A list of all binaries installed by this app
     pub binaries: Vec<String>,
-    /// A list of all libraries installed by this app
+    /// A list of all C dynamic libraries installed by this app
     pub cdylibs: Vec<String>,
+    /// A list of all C static libraries installed by this app
+    pub cstaticlibs: Vec<String>,
     /// Information about where to request information on new releases
     pub source: ReleaseSource,
     /// The version that was installed
@@ -3061,7 +3063,8 @@ impl InstallReceipt {
             // These first two are placeholder values which the installer will update
             install_prefix: "AXO_INSTALL_PREFIX".to_owned(),
             binaries: vec!["CARGO_DIST_BINS".to_owned()],
-            cdylibs: vec!["CARGO_DIST_LIBS".to_owned()],
+            cdylibs: vec!["CARGO_DIST_DYLIBS".to_owned()],
+            cstaticlibs: vec!["CARGO_DIST_STATICLIBS".to_owned()],
             version: release.version.to_string(),
             source: ReleaseSource {
                 release_type: source_type,

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -128,6 +128,7 @@ pub fn entry_axo_bin() -> ReleaseArtifacts {
         package_idx: BIN_AXO_IDX,
         executables: vec![BIN_AXO_NAME.to_owned()],
         cdylibs: vec![],
+        cstaticlibs: vec![],
     }
 }
 
@@ -142,6 +143,7 @@ pub fn entry_some_lib() -> ReleaseArtifacts {
         package_idx: LIB_SOME_IDX,
         executables: vec![],
         cdylibs: vec![],
+        cstaticlibs: vec![],
     }
 }
 
@@ -157,6 +159,7 @@ pub fn entry_helper_bin() -> ReleaseArtifacts {
         package_idx: BIN_HELPER_IDX,
         executables: vec![BIN_HELPER_NAME.to_owned(), BIN_HELPER_NAME2.to_owned()],
         cdylibs: vec![],
+        cstaticlibs: vec![],
     }
 }
 
@@ -171,6 +174,7 @@ pub fn entry_other_lib() -> ReleaseArtifacts {
         package_idx: LIB_OTHER_IDX,
         executables: vec![],
         cdylibs: vec![],
+        cstaticlibs: vec![],
     }
 }
 
@@ -186,6 +190,7 @@ pub fn entry_oddball_bin() -> ReleaseArtifacts {
         package_idx: BIN_ODDBALL_IDX,
         executables: vec![BIN_ODDBALL_NAME.to_owned()],
         cdylibs: vec![],
+        cstaticlibs: vec![],
     }
 }
 
@@ -209,6 +214,7 @@ pub fn entry_forced_bin() -> ReleaseArtifacts {
         package_idx: BIN_FORCED_IDX,
         executables: vec![BIN_FORCED_NAME.to_owned()],
         cdylibs: vec![],
+        cstaticlibs: vec![],
     }
 }
 

--- a/cargo-dist/templates/installer/homebrew.rb.j2
+++ b/cargo-dist/templates/installer/homebrew.rb.j2
@@ -89,7 +89,7 @@ class {{ formula_class }} < Formula
       {%- if arm64_macos.executables %}
       bin.install {% for binary in arm64_macos.executables %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
-      {%- if arm64_macos.cdylibs and install_cdylibs %}
+      {%- if arm64_macos.cdylibs and "cdylib" in install_libraries %}
       lib.install {% for library in arm64_macos.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
     end
@@ -99,7 +99,7 @@ class {{ formula_class }} < Formula
       {%- if x86_64_macos.executables %}
       bin.install {% for binary in x86_64_macos.executables %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
-      {%- if x86_64_macos.cdylibs and install_cdylibs %}
+      {%- if x86_64_macos.cdylibs and "cdylib" in install_libraries %}
       lib.install {% for library in x86_64_macos.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
     end
@@ -109,7 +109,7 @@ class {{ formula_class }} < Formula
       {%- if arm64_linux.executables %}
       bin.install {% for binary in arm64_linux.executables %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
-      {%- if arm64_linux.cdylibs and install_cdylibs %}
+      {%- if arm64_linux.cdylibs and "cdylib" in install_libraries %}
       lib.install {% for library in arm64_linux.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
     end
@@ -119,7 +119,7 @@ class {{ formula_class }} < Formula
       {%- if x86_64_linux.executables %}
       bin.install {% for binary in x86_64_linux.executables %}"{{ binary }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
-      {%- if x86_64_linux.cdylibs and install_cdylibs %}
+      {%- if x86_64_linux.cdylibs and "cdylib" in install_libraries %}
       lib.install {% for library in x86_64_linux.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
     end

--- a/cargo-dist/templates/installer/homebrew.rb.j2
+++ b/cargo-dist/templates/installer/homebrew.rb.j2
@@ -92,6 +92,9 @@ class {{ formula_class }} < Formula
       {%- if arm64_macos.cdylibs and "cdylib" in install_libraries %}
       lib.install {% for library in arm64_macos.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
+      {%- if arm64_macos.cstaticlibs and "cstaticlib" in install_libraries %}
+      lib.install {% for library in arm64_macos.cstaticlibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
     end
     {%- endif %}
     {%- if x86_64_macos.executables or x86_64_macos.cdylibs %}
@@ -101,6 +104,9 @@ class {{ formula_class }} < Formula
       {%- endif %}
       {%- if x86_64_macos.cdylibs and "cdylib" in install_libraries %}
       lib.install {% for library in x86_64_macos.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
+      {%- if x86_64_macos.cstaticlibs and "cstaticlib" in install_libraries %}
+      lib.install {% for library in x86_64_macos.cstaticlibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
     end
     {%- endif %}
@@ -112,6 +118,9 @@ class {{ formula_class }} < Formula
       {%- if arm64_linux.cdylibs and "cdylib" in install_libraries %}
       lib.install {% for library in arm64_linux.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
+      {%- if arm64_linux.cstaticlibs and "cstaticlib" in install_libraries %}
+      lib.install {% for library in arm64_linux.cstaticlibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
     end
     {%- endif %}
     {%- if x86_64_linux.executables %}
@@ -121,6 +130,9 @@ class {{ formula_class }} < Formula
       {%- endif %}
       {%- if x86_64_linux.cdylibs and "cdylib" in install_libraries %}
       lib.install {% for library in x86_64_linux.cdylibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
+      {%- endif %}
+      {%- if x86_64_linux.cstaticlibs and "cstaticlib" in install_libraries %}
+      lib.install {% for library in x86_64_linux.cstaticlibs %}"{{ library }}"{{ ", " if not loop.last else "" }}{% endfor %}
       {%- endif %}
     end
 {% endif %}

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -71,7 +71,7 @@ function Install-Binary($install_args) {
       "bins" = @({% for bin in artifact.executables -%}
         "{{ bin }}"{{ ", " if not loop.last else "" }}
       {%- endfor %})
-      {%- if install_cdylibs %}
+      {%- if "cdylib" in install_libraries %}
       "libs" = @({% for lib in artifact.cdylibs -%}
         "{{ lib }}"{{ ", " if not loop.last else "" }}
       {%- endfor %})

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -78,6 +78,13 @@ function Install-Binary($install_args) {
       {%- else %}
       "libs" = @()
       {%- endif %}
+      {%- if "cstaticlib" in install_libraries %}
+      "staticlibs" = @({% for lib in artifact.cstaticlibs -%}
+        "{{ lib }}"{{ ", " if not loop.last else "" }}
+      {%- endfor %})
+      {%- else %}
+      "staticlibs" = @()
+      {%- endif %}
       "zip_ext" = "{{ artifact.zip_style }}"
       "aliases" = @{
       {%- for source, dests in bin_aliases[artifact.target_triple] | items %}
@@ -159,6 +166,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -205,6 +213,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -218,6 +231,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -320,11 +334,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -147,7 +147,7 @@ download_binary_and_run_installer() {
             _zip_ext="{{ artifact.zip_style }}"
             _bins="{% for bin in artifact.executables %}{{ bin }}{{ " " if not loop.last else "" }}{% endfor %}"
             _bins_js_array='{% for bin in artifact.executables %}"{{ bin }}"{{ "," if not loop.last else ""}}{% endfor %}'
-            {%- if install_cdylibs %}
+            {%- if "cdylib" in install_libraries %}
             _libs="{% for lib in artifact.cdylibs %}{{ lib }}{{ " " if not loop.last else "" }}{% endfor %}"
             _libs_js_array='{% for lib in artifact.cdylibs %}"{{ lib }}"{{ "," if not loop.last else ""}}{% endfor %}'
             {%- else %}

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -154,6 +154,13 @@ download_binary_and_run_installer() {
             _libs=""
             _libs_js_array=""
             {%- endif %}
+            {%- if "cstaticlib" in install_libraries %}
+            _staticlibs="{% for lib in artifact.cstaticlibs %}{{ lib }}{{ " " if not loop.last else "" }}{% endfor %}"
+            _staticlibs_js_array='{% for lib in artifact.cstaticlibs %}"{{ lib }}"{{ "," if not loop.last else ""}}{% endfor %}'
+            {%- else %}
+            _staticlibs=""
+            _staticlibs_js_array=""
+            {%- endif %}
             {%- if artifact.updater %}
             _updater_name="{{ artifact.updater.id }}"
             _updater_bin="{{ artifact.updater.binary }}"
@@ -169,7 +176,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -228,7 +236,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -443,7 +451,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -456,6 +465,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1555,19 +1555,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akextract",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akmetadata",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akrepack",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"
@@ -1622,19 +1622,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akextract",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akmetadata",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akrepack",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"
@@ -1667,19 +1667,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akextract",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akextract",
           "name": "akextract",
           "path": "akextract.exe",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akmetadata",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata.exe",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akrepack",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack.exe",
           "kind": "executable"
@@ -1712,19 +1712,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akextract",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akmetadata",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akrepack",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract.exe","akmetadata.exe","akrepack.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
       "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
       "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1089,19 +1089,19 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akextract",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akmetadata",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akrepack",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"
@@ -1147,19 +1147,19 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akextract",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akmetadata",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akrepack",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"
@@ -1192,19 +1192,19 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akextract",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akmetadata",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akrepack",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"
@@ -1237,19 +1237,19 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-musl-akextract",
+          "id": "akaikatana-repack-x86_64-unknown-linux-musl-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-musl-akmetadata",
+          "id": "akaikatana-repack-x86_64-unknown-linux-musl-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-musl-akrepack",
+          "id": "akaikatana-repack-x86_64-unknown-linux-musl-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,6 +193,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -195,7 +205,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -254,7 +265,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -468,7 +479,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -481,6 +493,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1569,19 +1569,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akextract",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akmetadata",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akrepack",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"
@@ -1636,19 +1636,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akextract",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akmetadata",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akrepack",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"
@@ -1681,19 +1681,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akextract",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akextract",
           "name": "akextract",
           "path": "akextract.exe",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akmetadata",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata.exe",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akrepack",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack.exe",
           "kind": "executable"
@@ -1726,19 +1726,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akextract",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akmetadata",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akrepack",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract.exe","akmetadata.exe","akrepack.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -460,7 +469,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -473,6 +483,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1133,7 +1150,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1151,6 +1168,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
       "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
         "akextract.exe" = "akextract-link.exe"
@@ -1161,6 +1179,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
       "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
         "akextract.exe" = "akextract-link.exe"
@@ -1231,6 +1250,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1277,6 +1297,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1290,6 +1315,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1368,11 +1394,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1583,19 +1583,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akextract",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akmetadata",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akrepack",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"
@@ -1650,19 +1650,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akextract",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akmetadata",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akrepack",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"
@@ -1695,19 +1695,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akextract",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akextract",
           "name": "akextract",
           "path": "akextract.exe",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akmetadata",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata.exe",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akrepack",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack.exe",
           "kind": "executable"
@@ -1740,19 +1740,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akextract",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akmetadata",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akrepack",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract.exe","akmetadata.exe","akrepack.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -472,7 +481,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -485,6 +495,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1145,7 +1162,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1163,6 +1180,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
       "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
         "akextract.exe" = "akextract-link.exe"
@@ -1174,6 +1192,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
       "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
         "akextract.exe" = "akextract-link.exe"
@@ -1245,6 +1264,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1291,6 +1311,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1304,6 +1329,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1382,11 +1408,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name="akaikatana-repack-aarch64-apple-darwin-update"
             _updater_bin="akaikatana-repack-aarch64-apple-darwin-update"
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name="akaikatana-repack-x86_64-apple-darwin-update"
             _updater_bin="akaikatana-repack-x86_64-apple-darwin-update"
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract.exe","akmetadata.exe","akrepack.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name="akaikatana-repack-x86_64-pc-windows-msvc-update"
             _updater_bin="akaikatana-repack-x86_64-pc-windows-msvc-update"
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"akextract","akmetadata","akrepack"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name="akaikatana-repack-x86_64-unknown-linux-gnu-update"
             _updater_bin="akaikatana-repack-x86_64-unknown-linux-gnu-update"
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
       "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1152,6 +1170,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "akaikatana-repack-x86_64-pc-windows-msvc.zip"
       "bins" = @("akextract.exe", "akmetadata.exe", "akrepack.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1225,6 +1244,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1271,6 +1291,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1284,6 +1309,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1362,11 +1388,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1574,19 +1574,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akextract",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akmetadata",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-aarch64-apple-darwin-akrepack",
+          "id": "akaikatana-repack-aarch64-apple-darwin-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"
@@ -1648,19 +1648,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akextract",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akmetadata",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-apple-darwin-akrepack",
+          "id": "akaikatana-repack-x86_64-apple-darwin-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"
@@ -1700,19 +1700,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akextract",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akextract",
           "name": "akextract",
           "path": "akextract.exe",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akmetadata",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata.exe",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-pc-windows-msvc-akrepack",
+          "id": "akaikatana-repack-x86_64-pc-windows-msvc-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack.exe",
           "kind": "executable"
@@ -1752,19 +1752,19 @@ try {
           "kind": "readme"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akextract",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akextract",
           "name": "akextract",
           "path": "akextract",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akmetadata",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akmetadata",
           "name": "akmetadata",
           "path": "akmetadata",
           "kind": "executable"
         },
         {
-          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-akrepack",
+          "id": "akaikatana-repack-x86_64-unknown-linux-gnu-exe-akrepack",
           "name": "akrepack",
           "path": "akrepack",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3033,7 +3033,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3169,7 +3169,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3192,7 +3192,7 @@ run("axolotlsay");
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3236,7 +3236,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3279,7 +3279,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3027,7 +3027,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3163,7 +3163,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3186,7 +3186,7 @@ run("axolotlsay");
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3230,7 +3230,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3273,7 +3273,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -460,7 +469,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -473,6 +483,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1133,7 +1150,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1151,6 +1168,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "axolotlsay.exe" = "axolotlsay-link.exe"
@@ -1161,6 +1179,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "axolotlsay.exe" = "axolotlsay-link.exe"
@@ -1231,6 +1250,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1277,6 +1297,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1290,6 +1315,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1368,11 +1394,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3041,7 +3041,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3177,7 +3177,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3200,7 +3200,7 @@ run("axolotlsay");
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3244,7 +3244,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3287,7 +3287,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3039,7 +3039,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3175,7 +3175,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3198,7 +3198,7 @@ run("axolotlsay");
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3242,7 +3242,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3285,7 +3285,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -460,7 +469,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -473,6 +483,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1133,7 +1150,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1151,6 +1168,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "nosuchbin.exe" = "axolotlsay-link1.exe", "axolotlsay-link2.exe"
@@ -1161,6 +1179,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "nosuchbin.exe" = "axolotlsay-link1.exe", "axolotlsay-link2.exe"
@@ -1231,6 +1250,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1277,6 +1297,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1290,6 +1315,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1368,11 +1394,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3025,7 +3025,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3161,7 +3161,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3184,7 +3184,7 @@ run("axolotlsay");
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3228,7 +3228,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3271,7 +3271,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3028,7 +3028,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3170,7 +3170,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3196,7 +3196,7 @@ run("axolotlsay");
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3243,7 +3243,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3289,7 +3289,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3339,8 +3339,8 @@ run("axolotlsay");
     }
   },
   "assets": {
-    "axolotlsay-aarch64-apple-darwin-axolotlsay": {
-      "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+    "axolotlsay-aarch64-apple-darwin-exe-axolotlsay": {
+      "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
       "name": "axolotlsay",
       "system": "build:lies:",
       "target_triples": [
@@ -3355,8 +3355,8 @@ run("axolotlsay");
         ]
       }
     },
-    "axolotlsay-x86_64-apple-darwin-axolotlsay": {
-      "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+    "axolotlsay-x86_64-apple-darwin-exe-axolotlsay": {
+      "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
       "name": "axolotlsay",
       "system": "build:lies:",
       "target_triples": [
@@ -3371,8 +3371,8 @@ run("axolotlsay");
         ]
       }
     },
-    "axolotlsay-x86_64-pc-windows-msvc-axolotlsay": {
-      "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+    "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay": {
+      "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
       "name": "axolotlsay",
       "system": "build:lies:",
       "target_triples": [
@@ -3387,8 +3387,8 @@ run("axolotlsay");
         ]
       }
     },
-    "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay": {
-      "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+    "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay": {
+      "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
       "name": "axolotlsay",
       "system": "build:lies:",
       "target_triples": [

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1124,7 +1141,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1142,6 +1159,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1151,6 +1169,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1220,6 +1239,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1266,6 +1286,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1279,6 +1304,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1357,11 +1383,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1080,7 +1080,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1135,7 +1135,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1178,7 +1178,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1221,7 +1221,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1080,7 +1080,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1135,7 +1135,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1178,7 +1178,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1221,7 +1221,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1080,7 +1080,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1135,7 +1135,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1178,7 +1178,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1221,7 +1221,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1080,7 +1080,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1135,7 +1135,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1178,7 +1178,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1221,7 +1221,7 @@ download_binary_and_run_installer "$@" || exit 1
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -138,7 +138,7 @@ end
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -181,7 +181,7 @@ end
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -224,7 +224,7 @@ end
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -267,7 +267,7 @@ end
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -65,7 +65,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-aarch64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -108,7 +108,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-unknown-linux-musl-axolotlsay",
+          "id": "axolotlsay-aarch64-unknown-linux-musl-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -151,7 +151,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -194,7 +194,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-musl-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-musl-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3023,7 +3023,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3159,7 +3159,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3182,7 +3182,7 @@ run("axolotlsay");
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3226,7 +3226,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3269,7 +3269,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -65,7 +65,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -108,7 +108,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -151,7 +151,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -194,7 +194,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -73,7 +73,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -116,7 +116,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -159,7 +159,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -202,7 +202,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -67,7 +67,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -110,7 +110,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -153,7 +153,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -196,7 +196,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3023,7 +3023,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3159,7 +3159,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3202,7 +3202,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3245,7 +3245,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -3088,7 +3088,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3148,7 +3148,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-js-aarch64-apple-darwin-axolotlsay-js",
+          "id": "axolotlsay-js-aarch64-apple-darwin-exe-axolotlsay-js",
           "name": "axolotlsay-js",
           "path": "axolotlsay-js",
           "kind": "executable"
@@ -3208,7 +3208,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-js-x86_64-apple-darwin-axolotlsay-js",
+          "id": "axolotlsay-js-x86_64-apple-darwin-exe-axolotlsay-js",
           "name": "axolotlsay-js",
           "path": "axolotlsay-js",
           "kind": "executable"
@@ -3246,7 +3246,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-js-x86_64-pc-windows-msvc-axolotlsay-js",
+          "id": "axolotlsay-js-x86_64-pc-windows-msvc-exe-axolotlsay-js",
           "name": "axolotlsay-js",
           "path": "axolotlsay-js.exe",
           "kind": "executable"
@@ -3284,7 +3284,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-js-x86_64-unknown-linux-gnu-axolotlsay-js",
+          "id": "axolotlsay-js-x86_64-unknown-linux-gnu-exe-axolotlsay-js",
           "name": "axolotlsay-js",
           "path": "axolotlsay-js",
           "kind": "executable"
@@ -3339,7 +3339,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3382,7 +3382,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3425,7 +3425,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay-js"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay-js"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay-js"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay-js.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay-js"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1120,7 +1137,7 @@ $app_name = 'axolotlsay-js'
 $app_version = '0.10.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay-js"
 
@@ -1138,6 +1155,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-js-x86_64-pc-windows-msvc.zip"
       "bins" = @("axolotlsay-js.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1147,6 +1165,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-js-x86_64-pc-windows-msvc.zip"
       "bins" = @("axolotlsay-js.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -1216,6 +1235,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1262,6 +1282,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1275,6 +1300,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1353,11 +1379,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
@@ -1525,7 +1559,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -1642,6 +1676,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -1652,6 +1688,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -1662,6 +1700,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -1672,6 +1712,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -1682,7 +1724,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -1741,7 +1784,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -1945,7 +1988,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -1958,6 +2002,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -2618,7 +2669,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.10.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -2636,6 +2687,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.zip"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -2645,6 +2697,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.zip"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".zip"
       "aliases" = @{
       }
@@ -2714,6 +2767,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -2760,6 +2814,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -2773,6 +2832,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -2851,11 +2911,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3025,7 +3025,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3161,7 +3161,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3184,7 +3184,7 @@ run("axolotlsay");
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3228,7 +3228,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3271,7 +3271,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,6 +193,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -195,7 +205,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -254,7 +265,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -468,7 +479,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -481,6 +493,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2550,7 +2550,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -2676,7 +2676,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -2719,7 +2719,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -2762,7 +2762,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-musl-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-musl-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2548,7 +2548,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -2674,7 +2674,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -2717,7 +2717,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-musl-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-musl-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,6 +193,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -195,7 +205,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -254,7 +265,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -468,7 +479,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -481,6 +493,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3023,7 +3023,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3159,7 +3159,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3202,7 +3202,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3245,7 +3245,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -65,7 +65,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -108,7 +108,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -151,7 +151,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -194,7 +194,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -65,7 +65,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -108,7 +108,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -151,7 +151,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -194,7 +194,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3043,7 +3043,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3179,7 +3179,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3202,7 +3202,7 @@ run("axolotlsay");
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3246,7 +3246,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3289,7 +3289,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -460,7 +469,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -473,6 +483,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1133,7 +1150,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1151,6 +1168,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "axolotlsay.exe" = "axolotlsay-link1.exe", "axolotlsay-link2.exe"
@@ -1161,6 +1179,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
         "axolotlsay.exe" = "axolotlsay-link1.exe", "axolotlsay-link2.exe"
@@ -1231,6 +1250,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1277,6 +1297,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1290,6 +1315,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1368,11 +1394,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1507,7 +1507,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1572,7 +1572,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1595,7 +1595,7 @@ try {
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1639,7 +1639,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1682,7 +1682,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1061,7 +1078,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1079,6 +1096,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1088,6 +1106,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1157,6 +1176,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1203,6 +1223,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1216,6 +1241,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1294,11 +1320,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1507,7 +1507,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1572,7 +1572,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1595,7 +1595,7 @@ try {
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1639,7 +1639,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1682,7 +1682,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1061,7 +1078,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1079,6 +1096,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1088,6 +1106,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1157,6 +1176,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1203,6 +1223,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1216,6 +1241,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1294,11 +1320,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -65,7 +65,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -108,7 +108,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -151,7 +151,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -194,7 +194,7 @@ expression: self.payload
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3044,7 +3044,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3187,7 +3187,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3217,7 +3217,7 @@ run("axolotlsay");
       ],
       "assets": [
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3261,7 +3261,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3311,7 +3311,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name="axolotlsay-aarch64-apple-darwin-update"
             _updater_bin="axolotlsay-aarch64-apple-darwin-update"
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name="axolotlsay-x86_64-apple-darwin-update"
             _updater_bin="axolotlsay-x86_64-apple-darwin-update"
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name="axolotlsay-x86_64-pc-windows-msvc-update"
             _updater_bin="axolotlsay-x86_64-pc-windows-msvc-update"
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name="axolotlsay-x86_64-unknown-linux-gnu-update"
             _updater_bin="axolotlsay-x86_64-unknown-linux-gnu-update"
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1152,6 +1170,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1225,6 +1244,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1271,6 +1291,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1284,6 +1309,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1362,11 +1388,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3023,7 +3023,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3159,7 +3159,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3202,7 +3202,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3245,7 +3245,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3023,7 +3023,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3159,7 +3159,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3202,7 +3202,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3245,7 +3245,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3023,7 +3023,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3159,7 +3159,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3202,7 +3202,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3245,7 +3245,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3023,7 +3023,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3159,7 +3159,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3202,7 +3202,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3245,7 +3245,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3023,7 +3023,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3159,7 +3159,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -3202,7 +3202,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -3245,7 +3245,7 @@ run("axolotlsay");
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -448,7 +457,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -461,6 +471,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1121,7 +1138,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1139,6 +1156,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1148,6 +1166,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1217,6 +1236,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1263,6 +1283,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1276,6 +1301,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1354,11 +1380,19 @@ function Invoke-Installer($artifacts, $platforms) {
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1566,7 +1566,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1631,7 +1631,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1674,7 +1674,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1717,7 +1717,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1541,7 +1541,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1606,7 +1606,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1649,7 +1649,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1692,7 +1692,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -431,7 +440,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -444,6 +454,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1104,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1122,6 +1139,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1131,6 +1149,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1200,6 +1219,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1246,6 +1266,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1259,6 +1284,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1329,11 +1355,19 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1541,7 +1541,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1606,7 +1606,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1649,7 +1649,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1692,7 +1692,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -431,7 +440,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -444,6 +454,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1104,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1122,6 +1139,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1131,6 +1149,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1200,6 +1219,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1246,6 +1266,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1259,6 +1284,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1329,11 +1355,19 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1541,7 +1541,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1606,7 +1606,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1649,7 +1649,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1692,7 +1692,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -431,7 +440,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -444,6 +454,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1104,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1122,6 +1139,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1131,6 +1149,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1200,6 +1219,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1246,6 +1266,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1259,6 +1284,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1329,11 +1355,19 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1541,7 +1541,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1606,7 +1606,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1649,7 +1649,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1692,7 +1692,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -431,7 +440,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -444,6 +454,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1104,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1122,6 +1139,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1131,6 +1149,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1200,6 +1219,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1246,6 +1266,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1259,6 +1284,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1329,11 +1355,19 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1562,7 +1562,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1627,7 +1627,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1670,7 +1670,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1713,7 +1713,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -146,6 +146,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -156,6 +158,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -166,6 +170,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -176,6 +182,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -186,7 +194,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -245,7 +254,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -443,7 +452,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -456,6 +466,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1117,7 +1134,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1135,6 +1152,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1144,6 +1162,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1213,6 +1232,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1259,6 +1279,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1272,6 +1297,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1350,11 +1376,19 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1541,7 +1541,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1606,7 +1606,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1649,7 +1649,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1692,7 +1692,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -431,7 +440,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -444,6 +454,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1104,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1122,6 +1139,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1131,6 +1149,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1200,6 +1219,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1246,6 +1266,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1259,6 +1284,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1329,11 +1355,19 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1541,7 +1541,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1606,7 +1606,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1649,7 +1649,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1692,7 +1692,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -431,7 +440,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -444,6 +454,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1104,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1122,6 +1139,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1131,6 +1149,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1200,6 +1219,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1246,6 +1266,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1259,6 +1284,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1329,11 +1355,19 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1541,7 +1541,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1606,7 +1606,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1649,7 +1649,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1692,7 +1692,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -431,7 +440,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -444,6 +454,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1104,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1122,6 +1139,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1131,6 +1149,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1200,6 +1219,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1246,6 +1266,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1259,6 +1284,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1329,11 +1355,19 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1541,7 +1541,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1606,7 +1606,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1649,7 +1649,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1692,7 +1692,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -145,6 +145,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -155,6 +157,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -165,6 +169,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -175,6 +181,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -185,7 +193,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -244,7 +253,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -431,7 +440,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -444,6 +454,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1104,7 +1121,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1122,6 +1139,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1131,6 +1149,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1200,6 +1219,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1246,6 +1266,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1259,6 +1284,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1329,11 +1355,19 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1562,7 +1562,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1627,7 +1627,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-apple-darwin-axolotlsay",
+          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
@@ -1670,7 +1670,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-axolotlsay",
+          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay.exe",
           "kind": "executable"
@@ -1713,7 +1713,7 @@ try {
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-axolotlsay",
+          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -28,7 +28,7 @@ PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -146,6 +146,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -156,6 +158,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -166,6 +170,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay.exe"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -176,6 +182,8 @@ download_binary_and_run_installer() {
             _bins_js_array='"axolotlsay"'
             _libs=""
             _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
             _updater_name=""
             _updater_bin=""
             ;;
@@ -186,7 +194,8 @@ download_binary_and_run_installer() {
 
     # Replace the placeholder binaries with the calculated array from above
     RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_BINS"'/"$_bins_js_array"/)"
-    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_LIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_DYLIBS"'/"$_libs_js_array"/)"
+    RECEIPT="$(echo "$RECEIPT" | sed s/'"CARGO_DIST_STATICLIBS"'/"$_staticlibs_js_array"/)"
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
@@ -245,7 +254,7 @@ download_binary_and_run_installer() {
             ;;
     esac
 
-    install "$_dir" "$_bins" "$_libs" "$_arch" "$@"
+    install "$_dir" "$_bins" "$_libs" "$_staticlibs" "$_arch" "$@"
     local _retval=$?
     if [ "$_retval" != 0 ]; then
         return "$_retval"
@@ -443,7 +452,8 @@ install() {
     local _src_dir="$1"
     local _bins="$2"
     local _libs="$3"
-    local _arch="$4"
+    local _staticlibs="$4"
+    local _arch="$5"
     for _bin_name in $_bins; do
         local _bin="$_src_dir/$_bin_name"
         ensure mv "$_bin" "$_install_dir"
@@ -456,6 +466,13 @@ install() {
     done
     # Like the above, but no aliases
     for _lib_name in $_libs; do
+        local _lib="$_src_dir/$_lib_name"
+        ensure mv "$_lib" "$_lib_install_dir"
+        # unzip seems to need this chmod
+        ensure chmod +x "$_lib_install_dir/$_lib_name"
+        say "  $_lib_name"
+    done
+    for _lib_name in $_staticlibs; do
         local _lib="$_src_dir/$_lib_name"
         ensure mv "$_lib" "$_lib_install_dir"
         # unzip seems to need this chmod
@@ -1117,7 +1134,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_LIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1135,6 +1152,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1144,6 +1162,7 @@ function Install-Binary($install_args) {
       "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
+      "staticlibs" = @()
       "zip_ext" = ".tar.gz"
       "aliases" = @{
       }
@@ -1213,6 +1232,7 @@ function Download($download_url, $platforms) {
   $zip_ext = $info["zip_ext"]
   $bin_names = $info["bins"]
   $lib_names = $info["libs"]
+  $staticlib_names = $info["staticlibs"]
   $artifact_name = $info["artifact_name"]
 
   # Make a new temp dir to unpack things to
@@ -1259,6 +1279,11 @@ function Download($download_url, $platforms) {
     Write-Verbose "  Unpacked $lib_name"
     $lib_paths += "$tmp\$lib_name"
   }
+  $staticlib_paths = @()
+  foreach ($lib_name in $staticlib_names) {
+    Write-Verbose "  Unpacked $lib_name"
+    $staticlib_paths += "$tmp\$lib_name"
+  }
 
   if ($null -ne $info["updater"]) {
     $updater_id = $info["updater"]["artifact_name"]
@@ -1272,6 +1297,7 @@ function Download($download_url, $platforms) {
   return @{
     "bin_paths" = $bin_paths
     "lib_paths" = $lib_paths
+    "staticlib_paths" = $staticlib_paths
   }
 }
 
@@ -1350,11 +1376,19 @@ $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
     Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
     Write-Information "  $installed_file"
   }
+  foreach ($lib_path in $artifacts["staticlib_paths"]) {
+    $installed_file = Split-Path -Path "$lib_path" -Leaf
+    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
+    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
+    Write-Information "  $installed_file"
+  }
 
   $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
   $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
   $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_LIBS"', $formatted_libs)
+  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
+  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
+  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
   # Also replace the aliases with the arch-specific one
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -83,7 +83,7 @@ stdout:
           "kind": "readme"
         },
         {
-          "id": "cargo-dist-aarch64-apple-darwin-cargo-dist",
+          "id": "cargo-dist-aarch64-apple-darwin-exe-cargo-dist",
           "name": "cargo-dist",
           "path": "cargo-dist",
           "kind": "executable"
@@ -126,7 +126,7 @@ stdout:
           "kind": "readme"
         },
         {
-          "id": "cargo-dist-aarch64-unknown-linux-gnu-cargo-dist",
+          "id": "cargo-dist-aarch64-unknown-linux-gnu-exe-cargo-dist",
           "name": "cargo-dist",
           "path": "cargo-dist",
           "kind": "executable"
@@ -169,7 +169,7 @@ stdout:
           "kind": "readme"
         },
         {
-          "id": "cargo-dist-aarch64-unknown-linux-musl-cargo-dist",
+          "id": "cargo-dist-aarch64-unknown-linux-musl-exe-cargo-dist",
           "name": "cargo-dist",
           "path": "cargo-dist",
           "kind": "executable"
@@ -239,7 +239,7 @@ stdout:
           "kind": "readme"
         },
         {
-          "id": "cargo-dist-x86_64-apple-darwin-cargo-dist",
+          "id": "cargo-dist-x86_64-apple-darwin-exe-cargo-dist",
           "name": "cargo-dist",
           "path": "cargo-dist",
           "kind": "executable"
@@ -282,7 +282,7 @@ stdout:
           "kind": "readme"
         },
         {
-          "id": "cargo-dist-x86_64-pc-windows-msvc-cargo-dist",
+          "id": "cargo-dist-x86_64-pc-windows-msvc-exe-cargo-dist",
           "name": "cargo-dist",
           "path": "cargo-dist.exe",
           "kind": "executable"
@@ -325,7 +325,7 @@ stdout:
           "kind": "readme"
         },
         {
-          "id": "cargo-dist-x86_64-unknown-linux-gnu-cargo-dist",
+          "id": "cargo-dist-x86_64-unknown-linux-gnu-exe-cargo-dist",
           "name": "cargo-dist",
           "path": "cargo-dist",
           "kind": "executable"
@@ -368,7 +368,7 @@ stdout:
           "kind": "readme"
         },
         {
-          "id": "cargo-dist-x86_64-unknown-linux-musl-cargo-dist",
+          "id": "cargo-dist-x86_64-unknown-linux-musl-exe-cargo-dist",
           "name": "cargo-dist",
           "path": "cargo-dist",
           "kind": "executable"


### PR DESCRIPTION
This is similar to #1182, extending that feature to support static libraries as well. It also contains a few other changes/improvements:

* The syntax for `package_cdylibs` and `install_cdylibs` has changed; this is now `package_libraries` and `install_libraries`, and it accepts arrays of strings in order to be able to specify `cdylib` and `cstaticlib` independently of each other.
* Two separate bugs have been fixed which prevented us from being able to reason about two binaries with overlapping names. That bug previously meant that a binary named `foo.exe` and a library named `libfoo.dylib` would be mistaken for each other, with one definition overwriting the other one internally. I caught it when I discovered that `libfoo.a` and `libfoo.dylib` couldn't be packaged at the same time, but it also affected executables and cdylibs.

I intentionally allowed some duplication in the installer code with how it handles staticlibs to leave ourselves open to install them to a separate path from dylibs at some point, if that's ever wanted.

Note that while Rust uses `cdylib` and `staticlib`, inconsistently prefixing with `c` or not, we use `cdylib` and `cstaticlib` to be more precise. This is true both internally and in the public-facing terminology.

Covers https://github.com/axodotdev/cargo-dist/issues/179#issuecomment-2232464351.