### PR TITLE
feat: add Repo struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ name = "axoproject"
 version = "0.20.0-prerelease.3"
 dependencies = [
  "axoasset",
+ "axoprocess",
  "camino",
  "guppy",
  "itertools 0.13.0",

--- a/axoproject/Cargo.toml
+++ b/axoproject/Cargo.toml
@@ -30,6 +30,7 @@ oro-package-spec = { version = "0.3.34", optional = true }
 node-semver = { version = "2.1.0", optional = true }
 
 axoasset.workspace = true
+axoprocess.workspace = true
 
 camino.workspace = true
 miette.workspace = true

--- a/axoproject/src/errors.rs
+++ b/axoproject/src/errors.rs
@@ -1,5 +1,7 @@
 //! Errors!
 
+use std::string::FromUtf8Error;
+
 use camino::Utf8PathBuf;
 use miette::Diagnostic;
 use thiserror::Error;
@@ -18,6 +20,11 @@ pub enum AxoprojectError {
     #[diagnostic(transparent)]
     Axoasset(#[from] axoasset::AxoassetError),
 
+    /// Axoprocess returned an error (I/O error)
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Axoprocess(#[from] axoprocess::AxoprocessError),
+
     /// An error occured in guppy/cargo-metadata when trying to find a cargo project
     #[cfg(feature = "cargo-projects")]
     #[error(transparent)]
@@ -31,6 +38,10 @@ pub enum AxoprojectError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Generic(#[from] GenericManifestParseError),
+
+    /// An error producing a string
+    #[error(transparent)]
+    FromUtf8(#[from] FromUtf8Error),
 
     /// An error parsing a Cargo.toml
     #[cfg(feature = "cargo-projects")]

--- a/axoproject/src/local_repo.rs
+++ b/axoproject/src/local_repo.rs
@@ -1,0 +1,61 @@
+//! Details for git repository
+
+use axoprocess::Cmd;
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::errors::Result;
+
+/// Information about a git repo
+#[derive(Clone, Debug)]
+pub struct LocalRepo {
+    /// The repository's absolute path on disk
+    pub path: Utf8PathBuf,
+    /// The repository's current HEAD
+    /// This can be None in the case that a git repository
+    /// has been `init`ted, but no commits have been made yet.
+    pub head: Option<String>,
+}
+
+impl LocalRepo {
+    /// Returns a Repo for the git repository at `working_dir`.
+    /// If git returns an error, for example if `working_dir`
+    /// isn't a git repository, this will return an `Err`.
+    /// The `git` param is the path to the `git` executable to use.
+    pub fn new(git: &str, working_dir: &Utf8Path) -> Result<Self> {
+        let root = get_root(git, working_dir)?;
+        let path = Utf8PathBuf::from(root);
+        let head = get_head_commit(git, working_dir).ok();
+
+        Ok(Self { path, head })
+    }
+}
+
+fn get_root(git: &str, working_dir: &Utf8Path) -> Result<String> {
+    let mut cmd = Cmd::new(git, "detect a git repo");
+    cmd.arg("rev-parse")
+        .arg("--show-toplevel")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .check(false)
+        .current_dir(working_dir);
+
+    let result = cmd.output()?;
+
+    let root = String::from_utf8(result.stdout)?;
+    Ok(root.trim_end().to_owned())
+}
+
+fn get_head_commit(git: &str, working_dir: &Utf8Path) -> Result<String> {
+    let mut cmd = Cmd::new(git, "check for HEAD commit");
+    cmd.arg("rev-parse")
+        .arg("HEAD")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .check(false)
+        .current_dir(working_dir);
+
+    let result = cmd.output()?;
+
+    let commit = String::from_utf8(result.stdout)?;
+    Ok(commit.trim_end().to_owned())
+}

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use axoasset::{toml_edit, SourceFile};
-use axoprocess::Cmd;
+use axoproject::local_repo::LocalRepo;
 use axoproject::WorkspaceKind;
 use camino::{Utf8Path, Utf8PathBuf};
 use semver::Version;
@@ -1704,27 +1704,12 @@ pub(crate) fn parse_metadata_table(
         .unwrap_or_default())
 }
 
-fn get_git_repo_root(run_in: &Utf8PathBuf) -> DistResult<Utf8PathBuf> {
-    let mut command = Cmd::new("git", "get git repo root");
-    command
-        .arg("-C")
-        .arg(run_in)
-        .arg("rev-parse")
-        .arg("--show-toplevel");
-
-    let string = String::from_utf8(command.output()?.stdout)?
-        .trim_end()
-        .to_owned();
-
-    Ok(Utf8PathBuf::from(string))
-}
-
 /// Find the dist workspaces relative to the current directory
 pub fn get_project() -> Result<axoproject::WorkspaceGraph, axoproject::errors::ProjectError> {
     let start_dir = std::env::current_dir().expect("couldn't get current working dir!?");
     let start_dir = Utf8PathBuf::from_path_buf(start_dir).expect("project path isn't utf8!?");
-    let clamp_to_dir = get_git_repo_root(&start_dir).ok();
-    let workspaces = axoproject::WorkspaceGraph::find(&start_dir, clamp_to_dir.as_deref())?;
+    let repo = LocalRepo::new("git", &start_dir).ok();
+    let workspaces = axoproject::WorkspaceGraph::find_from_git(&start_dir, repo)?;
     Ok(workspaces)
 }
 

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -847,10 +847,12 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let root_workspace = workspaces.workspace(root_workspace_idx);
         let target_dir = root_workspace.target_dir.clone();
         let workspace_dir = root_workspace.workspace_dir.clone();
-        // FIXME: factor out the git repo detection code in source_tarball so that this
-        // is computed properly -- for now this is the value that's just been assumed
-        // already but at least code is clear about which it's referring to.
-        let repo_dir = workspace_dir.clone();
+        let repo_dir = if let Some(repo) = &workspaces.repo {
+            repo.path.to_owned()
+        } else {
+            // Fallback if we're not building in a git repo
+            workspace_dir.clone()
+        };
         let dist_dir = target_dir.join(TARGET_DIST);
 
         let mut workspace_metadata =


### PR DESCRIPTION
This captures information about the git repository we're running builds in, including its absolute path on disk and its current git HEAD.

We already used the side effects of capturing this information in the past; this lets us capture and hold on to it.