### PR TITLE
docs: document native runner for arm64 libraries

### DIFF
--- a/book/src/ci/customizing.md
+++ b/book/src/ci/customizing.md
@@ -13,6 +13,8 @@ In the past, you may have customized cargo-dist's generated CI configuration and
 
 Sometimes, you may need extra packages from the system package manager to be installed before in the builder before cargo-dist begins building your software. Cargo-dist can do this for you by adding the `dependencies` setting to your `Cargo.toml`. When set, the packages you request will be fetched and installed in the step before `build`. Additionally, on macOS, the `cargo build` process will be wrapped in `brew bundle exec` to ensure that your dependencies can be found no matter where Homebrew placed them.
 
+By default, we run Apple silicon (aarch64) builds for macOS on the `macos-12` runner, which is Intel-based. If your build process needs to link against C libraries from Homebrew using the `dependencies` feature, you will need to switch to an Apple silicon-native runner to ensure that you have access to Apple silicon-native dependencies from Homebrew. You can do this using the [custom runners][custom-runners] feature. Currently, `macos-14` is the oldest (and only) GitHub-provided runner for Apple silicon.
+
 Sometimes, you may want to make sure your users also have these dependencies available when they install your software. If you use a package manager-based installer, cargo-dist has the ability to specify these dependencies. By default, cargo-dist will examine your program to try to detect which dependencies it thinks will be necessary. At the moment, [Homebrew][homebrew] is the only supported package manager installer. You can also specify these dependencies manually.
 
 For more information, see the [configuration syntax][config-dependencies].
@@ -111,6 +113,8 @@ aarch64-apple-darwin = "macos-14"
 
 You can change which repository a GitHub Release gets published to with the [github-releases-repo setting][config-github-releases-repo].
 
+
+[custom-runners]: #custom-runners
 
 [config-dependencies]: ../reference/config.md#dependencies
 [config-plan]: ../reference/config.md#plan-jobs


### PR DESCRIPTION
Although we indirectly documented this later in the page, we didn't properly document this in the place it's most relevant.

Closes #1244.