### PR TITLE
init: ensure terminal is restored when interrupted

### DIFF
--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -67,7 +67,12 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
 
         // Immediately re-exit the process with the same
         // exit code the unhandled ctrl-c would have used
-        std::process::exit(130);
+        let exitstatus = if cfg!(windows) {
+            0xc000013a_u32 as i32
+        } else {
+            130
+        };
+        std::process::exit(exitstatus);
     });
 
     let workspaces = config::get_project()?;

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -54,6 +54,22 @@ fn theme() -> dialoguer::theme::ColorfulTheme {
 
 /// Run 'cargo dist init'
 pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
+    // on ctrl-c,  dialoguer/console will clean up the rest of its
+    // formatting, but the cursor will remain hidden unless we
+    // explicitly go in and show it again
+    // See: https://github.com/console-rs/dialoguer/issues/294
+    let ctrlc_handler = tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.unwrap();
+
+        let term = console::Term::stdout();
+        // Ignore the error here if there is any, this is best effort
+        let _ = term.show_cursor();
+
+        // Immediately re-exit the process with the same
+        // exit code the unhandled ctrl-c would have used
+        std::process::exit(130);
+    });
+
     let workspaces = config::get_project()?;
     let root_workspace = workspaces.root_workspace();
     let check = console::style("✔".to_string()).for_stderr().green();
@@ -127,6 +143,10 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
             packages: SortedMap::new(),
         }
     };
+
+    // We're past the final dialoguer call; we can remove the
+    // ctrl-c handler.
+    ctrlc_handler.abort();
 
     // If we're migrating, the configuration will be missing the
     // generic workspace specification, and will have some


### PR DESCRIPTION
If we receive ctrl-c during `init`, dialoguer leaves the cursor hidden and the user may not understand why that's happened. We need to make sure we restore the cursor before terminating the application.

While this may be handled by dialoguer/console at some point, this would make for a nicer user experience today.