### PR TITLE
release: 0.20.0-prerelease.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "0.20.0-prerelease.6"
+version = "0.20.0-prerelease.7"
 dependencies = [
  "axoasset",
  "camino",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.20.0-prerelease.6"
+version = "0.20.0-prerelease.7"
 dependencies = [
  "axoasset",
  "axocli",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.20.0-prerelease.6"
+version = "0.20.0-prerelease.7"
 dependencies = [
  "camino",
  "gazenot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
 homepage = "https://opensource.axo.dev/cargo-dist/"
-version = "0.20.0-prerelease.6"
+version = "0.20.0-prerelease.7"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!
-cargo-dist-schema = { version = "=0.20.0-prerelease.6", path = "cargo-dist-schema" }
-axoproject = { version = "=0.20.0-prerelease.6", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
+cargo-dist-schema = { version = "=0.20.0-prerelease.7", path = "cargo-dist-schema" }
+axoproject = { version = "=0.20.0-prerelease.7", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
 
 # first-party deps
 axocli = { version = "0.2.0" }


### PR DESCRIPTION
Incorporates the two most recent improvements to `cargo dist init` migration.