### PR TITLE
feat: guard new config format behind hidden flag

### DIFF
--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -275,6 +275,9 @@ pub struct InitArgs {
     /// `cargo dist init` will persist the values you pass to that location.
     #[clap(long, value_delimiter(','))]
     pub hosting: Vec<HostingStyle>,
+    /// Opts into the new configuration format
+    #[clap(long, hide = true)]
+    pub opt_in_migrate: bool,
 }
 
 /// Which style(s) of configuration to generate
@@ -377,6 +380,9 @@ pub struct UpdateArgs {
     /// `cargo dist init` will persist the values you pass to that location.
     #[clap(long, value_delimiter(','))]
     pub hosting: Vec<HostingStyle>,
+    /// Opts into the new configuration format
+    #[clap(long, hide = true)]
+    pub opt_in_migrate: bool,
 }
 
 /// A style of CI to generate

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -303,6 +303,7 @@ fn cmd_init(cli: &Cli, args: &InitArgs) -> Result<(), miette::Report> {
         no_generate: args.skip_generate,
         with_json_config: args.with_json_config.clone(),
         host: args.hosting.iter().map(|host| host.to_lib()).collect(),
+        migrate_to_new_config: args.opt_in_migrate,
     };
     do_init(&config, &args)?;
     Ok(())


### PR DESCRIPTION
We now opt into the new configuration format via `cargo dist init --opt-in-migrate`. Users who don't pass this flag won't have the new format offered to them. Users with an already-initted project will be asked if they want to opt in, while users with a Cargo.toml project will be automatically given the new format.

(Best viewed with `?w=1`)