### PR TITLE
chore: bump min macos version to 13

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -495,9 +495,9 @@ type GithubRunner = String;
 /// The Github Runner to use for Linux
 const GITHUB_LINUX_RUNNER: &str = "ubuntu-20.04";
 /// The Github Runner to use for Intel macos
-const GITHUB_MACOS_INTEL_RUNNER: &str = "macos-12";
+const GITHUB_MACOS_INTEL_RUNNER: &str = "macos-13";
 /// The Github Runner to use for Apple Silicon macos
-const GITHUB_MACOS_ARM64_RUNNER: &str = "macos-12";
+const GITHUB_MACOS_ARM64_RUNNER: &str = "macos-13";
 /// The Github Runner to use for windows
 const GITHUB_WINDOWS_RUNNER: &str = "windows-2019";
 

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ akaikatana-repack-installer.sh ================
@@ -1841,7 +1840,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1850,7 +1849,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ akaikatana-repack-installer.sh ================
@@ -1339,7 +1338,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1348,7 +1347,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ akaikatana-repack-installer.sh ================
@@ -1855,7 +1854,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1864,7 +1863,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ akaikatana-repack-installer.sh ================
@@ -1869,7 +1868,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1878,7 +1877,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ akaikatana-repack-installer.sh ================
@@ -1881,7 +1880,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1890,7 +1889,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3400,7 +3400,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3409,7 +3409,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3394,7 +3394,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3403,7 +3403,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3408,7 +3408,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3417,7 +3417,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3406,7 +3406,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3415,7 +3415,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3392,7 +3392,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3401,7 +3401,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3482,7 +3482,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3491,7 +3491,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -3392,7 +3392,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3401,7 +3401,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1309,7 +1308,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1318,7 +1317,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1309,7 +1308,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1318,7 +1317,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1309,7 +1308,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1318,7 +1317,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1309,7 +1308,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1318,7 +1317,7 @@ download_binary_and_run_installer "$@" || exit 1
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -309,7 +309,7 @@ end
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -318,7 +318,7 @@ end
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3381,7 +3381,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3390,7 +3390,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -236,7 +236,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -245,7 +245,7 @@ expression: self.payload
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -244,7 +244,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -253,7 +253,7 @@ expression: self.payload
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -238,7 +238,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -247,7 +247,7 @@ expression: self.payload
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3366,7 +3366,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3375,7 +3375,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 106
 expression: self.payload
 ---
 ================ axolotlsay-js-installer.sh ================
@@ -3604,7 +3603,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3613,7 +3612,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3392,7 +3392,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "packages_install": "cat << EOF >Brewfile\ncask \"homebrew/cask/macfuse\"\nbrew \"libcue\"\nEOF\n\nbrew bundle install",
@@ -3402,7 +3402,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "packages_install": "cat << EOF >Brewfile\ncask \"homebrew/cask/macfuse\"\nbrew \"libcue\"\nEOF\n\nbrew bundle install",

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2856,7 +2856,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -2865,7 +2865,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2811,7 +2811,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -2820,7 +2820,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3366,7 +3366,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3375,7 +3375,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -236,7 +236,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -245,7 +245,7 @@ expression: self.payload
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -236,7 +236,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -245,7 +245,7 @@ expression: self.payload
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3410,7 +3410,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3419,7 +3419,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1787,7 +1786,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1796,7 +1795,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1787,7 +1786,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1796,7 +1795,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -236,7 +236,7 @@ expression: self.payload
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -245,7 +245,7 @@ expression: self.payload
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3432,7 +3432,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3441,7 +3441,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3366,7 +3366,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3375,7 +3375,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3366,7 +3366,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3375,7 +3375,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3366,7 +3366,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3375,7 +3375,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3366,7 +3366,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3375,7 +3375,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3366,7 +3366,7 @@ run("axolotlsay");
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -3375,7 +3375,7 @@ run("axolotlsay");
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1834,7 +1833,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1843,7 +1842,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1809,7 +1808,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1818,7 +1817,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1809,7 +1808,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1818,7 +1817,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1809,7 +1808,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1818,7 +1817,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1809,7 +1808,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1818,7 +1817,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1830,7 +1829,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1839,7 +1838,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1809,7 +1808,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1818,7 +1817,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1809,7 +1808,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1818,7 +1817,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1809,7 +1808,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1818,7 +1817,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1809,7 +1808,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1818,7 +1817,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1,6 +1,5 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
-assertion_line: 92
 expression: self.payload
 ---
 ================ axolotlsay-installer.sh ================
@@ -1830,7 +1829,7 @@ try {
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -1839,7 +1838,7 @@ try {
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -431,7 +431,7 @@ stdout:
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
@@ -459,7 +459,7 @@ stdout:
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-12",
+            "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"


### PR DESCRIPTION
12 is now deprecated and slated to be removed in winter