### PR TITLE
docs: restore linkcheck

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -10,9 +10,8 @@ git-repository-url = "https://github.com/axodotdev/cargo-dist"
 edit-url-template = "https://github.com/axodotdev/cargo-dist/edit/main/book/{path}"
 search.use-boolean-and = true
 
-# disabled due to bugginess (#337)
-# [output.linkcheck]
-# warning-policy = "error"
+[output.linkcheck]
+warning-policy = "error"
 
 [preprocessor.toc]
 command = "mdbook-toc"


### PR DESCRIPTION
This works again as of oranda 0.6.5.