### PR TITLE
Add initial appimage support

### DIFF
--- a/cargo-dist/src/backend/installer/appimage.rs
+++ b/cargo-dist/src/backend/installer/appimage.rs
@@ -1,0 +1,110 @@
+//! Appimage installer
+
+use std::{fs::Permissions, io::BufRead, os::unix::fs::PermissionsExt};
+
+use axoproject::Version;
+use camino::Utf8PathBuf;
+use itertools::Itertools;
+use serde::Serialize;
+
+use crate::{backend::templates::TEMPLATE_LINUX_DESKTOP, DistGraph, DistResult};
+
+#[derive(Debug, Clone)]
+/// Info needed to build an Appimage
+pub struct AppImageInfo {
+    /// An ideally unambiguous way to refer to a package for the purpose of cargo -p flags.
+    pub pkg_spec: String,
+    /// Final file path of the msi
+    pub file_path: Utf8PathBuf,
+    /// Dir stuff goes to
+    pub package_dir: Utf8PathBuf,
+    /// Binaries we'll be baking into the msi
+    pub target: String,
+    /// Path to the package Cargo.toml associated with this msi
+    pub version: Version,
+}
+
+#[derive(Serialize)]
+struct DesktopEntry {
+    pub pkg: String,
+    pub version: String,
+}
+
+impl AppImageInfo {
+    /// Build the appimage installer
+    pub fn build(&self, dist: &DistGraph) -> DistResult<()> {
+        let bin_path = self.package_dir.join("usr").join("bin");
+        std::fs::create_dir_all(&bin_path)?;
+        let app_bin_path = bin_path.join(&self.pkg_spec);
+
+        std::fs::rename(self.package_dir.join(&self.pkg_spec), &app_bin_path)?;
+
+        let output = std::process::Command::new("ldd")
+            .arg(app_bin_path)
+            .output()?;
+
+        assert!(output.status.success());
+
+        let lib_path = self.package_dir.join("lib");
+        let lib64_path = self.package_dir.join("lib64");
+        std::fs::create_dir_all(&lib_path)?;
+        std::fs::create_dir_all(&lib64_path)?;
+
+        for dep in output.stdout.lines() {
+            let dep = dep.unwrap();
+            let temp = dep.trim().split_whitespace().collect_vec();
+            let lib = match temp.len() {
+                2 => temp[0],
+                4 => temp[2],
+                _ => unreachable!(),
+            };
+
+            if lib.starts_with("/lib64/") {
+                let fname = lib.strip_prefix("/lib64/").unwrap();
+                std::fs::copy(lib, lib64_path.join(fname))?;
+            } else if lib.starts_with("/lib/") {
+                let fname = lib.strip_prefix("/lib/").unwrap();
+                std::fs::copy(lib, lib_path.join(fname))?;
+            }
+        }
+
+        let desktop_vals = DesktopEntry {
+            pkg: self.pkg_spec.clone(),
+            version: self.version.to_string(),
+        };
+
+        let desktop_entry = dist
+            .templates
+            .render_file_to_clean_string(TEMPLATE_LINUX_DESKTOP, &desktop_vals)?;
+
+        std::fs::write(
+            self.package_dir.join(format!("{}.desktop", self.pkg_spec)),
+            desktop_entry,
+        )?;
+
+        // TODO: Add actual icon
+        let icon_path = self.package_dir.join("icon.png");
+        std::fs::write(icon_path, [])?;
+
+        // TODO: Maybe generate our own AppRun
+        let app_run_path = self.package_dir.join("AppRun");
+        let handle = tokio::runtime::Handle::current();
+        handle.block_on(async {
+            dist.axoclient.load_and_write_to_file(
+                "https://raw.githubusercontent.com/AppImage/AppImageKit/master/resources/AppRun",
+                &app_run_path
+            ).await
+        })?;
+        std::fs::set_permissions(app_run_path, Permissions::from_mode(0777))?;
+
+        let output = std::process::Command::new("appimagetool")
+            .args([&self.package_dir, &self.file_path])
+            .output()?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(crate::DistError::MissingAppImageTool)
+        }
+    }
+}

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -16,12 +16,14 @@ use crate::{
 use self::homebrew::HomebrewInstallerInfo;
 use self::msi::MsiInstallerInfo;
 use self::npm::NpmInstallerInfo;
+use self::appimage::AppImageInfo;
 
 pub mod homebrew;
 pub mod msi;
 pub mod npm;
 pub mod powershell;
 pub mod shell;
+pub mod appimage;
 
 /// A kind of an installer
 #[derive(Debug, Clone)]
@@ -37,6 +39,8 @@ pub enum InstallerImpl {
     Homebrew(HomebrewInstallerInfo),
     /// Windows msi installer
     Msi(MsiInstallerInfo),
+    /// Linux Appimage
+    AppImage(AppImageInfo),
 }
 
 /// Generic info about an installer

--- a/cargo-dist/src/backend/templates.rs
+++ b/cargo-dist/src/backend/templates.rs
@@ -23,6 +23,8 @@ pub const TEMPLATE_INSTALLER_NPM: TemplateId = "installer/npm";
 pub const TEMPLATE_INSTALLER_NPM_RUN_JS: TemplateId = "installer/npm/run.js";
 /// Template key for the github ci.yml
 pub const TEMPLATE_CI_GITHUB: TemplateId = "ci/github/release.yml";
+/// Template key for linux desktop entry
+pub const TEMPLATE_LINUX_DESKTOP: TemplateId = "installer/linux.desktop";
 
 /// ID used to look up an environment in [`Templates::envs`][]
 type EnvId = &'static str;

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -948,6 +948,8 @@ pub enum InstallerStyle {
     Homebrew,
     /// Generate an msi installer that embeds the binary
     Msi,
+    /// Generate an Appimage installer
+    AppImage
 }
 
 impl std::fmt::Display for InstallerStyle {
@@ -958,6 +960,7 @@ impl std::fmt::Display for InstallerStyle {
             InstallerStyle::Npm => "npm",
             InstallerStyle::Homebrew => "homebrew",
             InstallerStyle::Msi => "msi",
+            InstallerStyle::AppImage => "app-image"
         };
         string.fmt(f)
     }

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -263,6 +263,23 @@ pub enum DistError {
         keys: &'static [&'static str],
     },
 
+    /// appimage with too many packages
+    #[error("{artifact_name} depends on multiple packages, which isn't yet supported")]
+    #[diagnostic(help("depends on {spec1} and {spec2}"))]
+    MultiPackageAppImage {
+        /// Name of the appimage
+        artifact_name: String,
+        /// One of the pacakges
+        spec1: String,
+        /// A different package
+        spec2: String,
+    },
+
+    /// appimagetool missing
+    #[error("appimagetool not found")]
+    #[diagnostic(help("install appimagetool"))]
+    MissingAppImageTool,
+
     /// unrecognized job style
     #[error("{style} is not a recognized job value")]
     #[diagnostic(help("Jobs that do not come with cargo-dist should be prefixed with ./"))]

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -684,10 +684,11 @@ fn get_new_dist_metadata(
                 InstallerStyle::Npm,
                 InstallerStyle::Homebrew,
                 InstallerStyle::Msi,
+                InstallerStyle::AppImage
             ]
         } else {
             eprintln!("{notice} no CI backends enabled, most installers have been hidden");
-            &[InstallerStyle::Msi]
+            &[InstallerStyle::Msi, InstallerStyle::AppImage]
         };
         let mut defaults = vec![];
         let mut keys = vec![];
@@ -712,6 +713,7 @@ fn get_new_dist_metadata(
                 InstallerStyle::Npm => "npm",
                 InstallerStyle::Homebrew => "homebrew",
                 InstallerStyle::Msi => "msi",
+                InstallerStyle::AppImage => "app-image"
             });
         }
 

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -725,6 +725,7 @@ fn generate_installer(
             installer::homebrew::write_homebrew_formula(dist, info, manifest)?
         }
         InstallerImpl::Msi(info) => info.build(dist)?,
+        InstallerImpl::AppImage(info) => info.build(dist)?,
     }
     Ok(())
 }

--- a/cargo-dist/src/manifest.rs
+++ b/cargo-dist/src/manifest.rs
@@ -355,6 +355,11 @@ fn add_manifest_artifact(
             description = Some("install via msi".to_owned());
             kind = cargo_dist_schema::ArtifactKind::Installer;
         }
+        ArtifactKind::Installer(InstallerImpl::AppImage(..)) => {
+            install_hint = None;
+            description = Some("install via appimage".to_owned());
+            kind = cargo_dist_schema::ArtifactKind::Installer;
+        }
         ArtifactKind::Checksum(_) => {
             install_hint = None;
             description = None;

--- a/cargo-dist/templates/installer/linux.desktop.j2
+++ b/cargo-dist/templates/installer/linux.desktop.j2
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name={{ pkg }}
+Exec={{ pkg }}
+Icon=icon
+Type=Application
+Categories=Utility;
+X-AppImage-Version={{ version }}


### PR DESCRIPTION
- Uses appimagetool to create the appimage from AppDir folder
- Generte destkop entry file on the fly.
- Use AppRun from AppImageKit
- Use empty icon.

This is basically a MVP implementation. Some things that need discussion:
1. How to handle linux desktop entries since they will be used in most other linux formats.
2. How to handle icons. Appimage only seems to support PNG icons, while Windows uses ICO, so we need to decide on something cross-platform.
3. How to handle bundling platform deps. Basically needs an exclude list of some kind.

Fixes: https://github.com/axodotdev/cargo-dist/issues/1297