### PR TITLE
Fix generated comment describing `pr-run-mode`

### DIFF
--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1285,7 +1285,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
     apply_optional_value(
         table,
         "pr-run-mode",
-        "# Publish jobs to run in CI\n",
+        "# Which actions to run on pull requests\n",
         pr_run_mode.as_ref().map(|m| m.to_string()),
     );
 

--- a/cargo-dist/src/tests/config.rs
+++ b/cargo-dist/src/tests/config.rs
@@ -72,7 +72,7 @@ tap = "axodotdev/homebrew-tap"
 publish-jobs = ["homebrew", "./publish-crates"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
-# Publish jobs to run in CI
+# Which actions to run on pull requests
 pr-run-mode = "plan"
 # Where to host releases
 hosting = ["axodotdev", "github"]


### PR DESCRIPTION
e.g., the following is incorrect https://github.com/axodotdev/cargo-dist/blob/39abb63c095a8bf9559bf45ab339cf821d15148d/Cargo.toml#L88-L89