### PR TITLE
fix: javascript workspace bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "0.20.0"
+version = "0.21.0-prerelease.1"
 dependencies = [
  "axoasset",
  "axoprocess",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.20.0"
+version = "0.21.0-prerelease.1"
 dependencies = [
  "axoasset",
  "axocli",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.20.0"
+version = "0.21.0-prerelease.1"
 dependencies = [
  "camino",
  "gazenot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
 homepage = "https://opensource.axo.dev/cargo-dist/"
-version = "0.20.0"
+version = "0.21.0-prerelease.1"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!
-cargo-dist-schema = { version = "=0.20.0", path = "cargo-dist-schema" }
-axoproject = { version = "=0.20.0", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
+cargo-dist-schema = { version = "=0.21.0-prerelease.1", path = "cargo-dist-schema" }
+axoproject = { version = "=0.21.0-prerelease.1", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
 
 # first-party deps
 axocli = { version = "0.2.0" }

--- a/axoproject/src/errors.rs
+++ b/axoproject/src/errors.rs
@@ -60,7 +60,7 @@ pub enum AxoprojectError {
 
     /// We found a package.json but it didn't have "name" set
     #[cfg(feature = "npm-projects")]
-    #[error("your package doesn't have a name: {manifest}")]
+    #[error("your package doesn't have a name:\n{manifest}")]
     #[diagnostic(help("is it a workspace? We don't support that yet."))]
     NamelessNpmPackage {
         /// path to the package.json
@@ -69,7 +69,7 @@ pub enum AxoprojectError {
 
     /// We tried to get the bins from a package.json but something went wrong
     #[cfg(feature = "npm-projects")]
-    #[error("Failed to read the binaries from your package.json: {manifest_path}")]
+    #[error("Failed to read the binaries from your package.json:\n{manifest_path}")]
     BuildInfoParse {
         /// Path to the package.json
         manifest_path: Utf8PathBuf,
@@ -79,7 +79,7 @@ pub enum AxoprojectError {
     },
 
     /// Your workspace gave several different values for "repository"
-    #[error("your workspace has inconsistent values for 'repository', refusing to select one:\n  {file1}: {url1}\n  {file2}: {url2}")]
+    #[error("your workspace has inconsistent values for 'repository', refusing to select one:\n  {file1}:\n    {url1}\n  {file2}:\n    {url2}")]
     #[diagnostic(severity("warning"))]
     InconsistentRepositoryKey {
         /// Path to the first manifest
@@ -93,7 +93,7 @@ pub enum AxoprojectError {
     },
 
     /// An error that occured while trying to find READMEs and whatnot in your project dir
-    #[error("couldn't search for files in {dir}")]
+    #[error("couldn't search for files in\n{dir}")]
     AutoIncludeSearch {
         /// path to the dir we were searching
         dir: Utf8PathBuf,

--- a/axoproject/src/generic.rs
+++ b/axoproject/src/generic.rs
@@ -301,6 +301,7 @@ fn package_from(manifest_path: &Utf8Path) -> Result<PackageInfo> {
         cargo_metadata_table: None,
         #[cfg(feature = "cargo-projects")]
         cargo_package_id: None,
+        npm_scope: None,
     };
 
     // Load and apply auto-includes

--- a/axoproject/src/generic.rs
+++ b/axoproject/src/generic.rs
@@ -328,7 +328,7 @@ fn load_package_dist_toml(manifest_path: &Utf8Path) -> Result<PackageManifest> {
 fn merge_package_with_raw_generic(
     package: &mut PackageInfo,
     generic: Package,
-    generic_path: Utf8PathBuf,
+    generic_manifest_path: Utf8PathBuf,
 ) {
     let Package {
         name,
@@ -348,7 +348,7 @@ fn merge_package_with_raw_generic(
         version,
     } = generic;
 
-    package.dist_manifest_path = Some(generic_path);
+    package.dist_manifest_path = Some(generic_manifest_path);
 
     if let Some(val) = name {
         package.name = val;

--- a/axoproject/src/generic.rs
+++ b/axoproject/src/generic.rs
@@ -195,7 +195,7 @@ fn workspace_from(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
             let paired_manifest = package.package_root.join(DIST_PACKAGE_TOML);
             if paired_manifest.exists() {
                 let generic = raw_package_from(&paired_manifest)?;
-                merge_package_with_raw_generic(package, generic);
+                merge_package_with_raw_generic(package, generic, paired_manifest);
             }
 
             crate::merge_auto_includes(package, &root_auto_includes);
@@ -210,6 +210,7 @@ fn workspace_from(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
             target_dir: workspace_dir.join(DIST_TARGET_DIR),
             workspace_dir,
             manifest_path: manifest_path.to_owned(),
+            dist_manifest_path: Some(manifest_path.to_owned()),
             root_auto_includes,
             #[cfg(feature = "cargo-projects")]
             cargo_metadata_table: None,
@@ -229,6 +230,7 @@ fn single_package_workspace_from(manifest_path: &Utf8Path) -> Result<WorkspaceSt
             target_dir: package.package_root.join(DIST_TARGET_DIR),
             workspace_dir: package.package_root.clone(),
             manifest_path: package.manifest_path.clone(),
+            dist_manifest_path: Some(package.manifest_path.clone()),
             root_auto_includes,
 
             #[cfg(feature = "cargo-projects")]
@@ -276,6 +278,7 @@ fn package_from(manifest_path: &Utf8Path) -> Result<PackageInfo> {
         true_name: name.clone(),
         true_version: version.clone(),
         manifest_path: manifest_path.clone(),
+        dist_manifest_path: Some(manifest_path.clone()),
         package_root: manifest_path.parent().unwrap().to_owned(),
         name,
         version,
@@ -321,7 +324,11 @@ fn load_package_dist_toml(manifest_path: &Utf8Path) -> Result<PackageManifest> {
     Ok(manifest)
 }
 
-fn merge_package_with_raw_generic(package: &mut PackageInfo, generic: Package) {
+fn merge_package_with_raw_generic(
+    package: &mut PackageInfo,
+    generic: Package,
+    generic_path: Utf8PathBuf,
+) {
     let Package {
         name,
         repository,
@@ -339,6 +346,9 @@ fn merge_package_with_raw_generic(package: &mut PackageInfo, generic: Package) {
         build_command,
         version,
     } = generic;
+
+    package.dist_manifest_path = Some(generic_path);
+
     if let Some(val) = name {
         package.name = val;
     }

--- a/axoproject/src/javascript.rs
+++ b/axoproject/src/javascript.rs
@@ -123,6 +123,7 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
         name: package_name,
         version,
         manifest_path: manifest_path.to_owned(),
+        dist_manifest_path: None,
         package_root: root.clone(),
         description: manifest.description,
         authors,
@@ -164,6 +165,7 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
             workspace_dir: root,
 
             manifest_path: manifest_path.to_owned(),
+            dist_manifest_path: None,
             root_auto_includes,
             #[cfg(feature = "cargo-projects")]
             cargo_metadata_table: None,

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -558,6 +558,8 @@ pub struct PackageInfo {
     /// A unique id used by Cargo to refer to the package
     #[cfg(feature = "cargo-projects")]
     pub cargo_package_id: Option<PackageId>,
+    /// npm scope (with the @, like "@axodotdev")
+    pub npm_scope: Option<String>,
     /// Command to run to build this package
     pub build_command: Option<Vec<String>>,
 }

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -412,6 +412,8 @@ impl RepositoryUrl {
                 if let Some(cur_url) = &repo_url {
                     if &normalized_new_url == cur_url {
                         // great! consensus!
+                    } else if cur_url.github_repo().ok() == normalized_new_url.github_repo().ok() {
+                        // good enough! consensus on the github repo!
                     } else {
                         return Err(AxoprojectError::InconsistentRepositoryKey {
                             file1: repo_url_origin.as_ref().unwrap().to_owned(),

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -355,10 +355,16 @@ pub struct WorkspaceInfo {
     pub workspace_dir: Utf8PathBuf,
     /// Path to the root manifest of the workspace
     ///
-    /// This can be either a Cargo.toml or package.json. In either case this manifest
-    /// may or may not represent a "real" package. Both systems have some notion of
-    /// "virtual" manifest which exists only to list the actual packages in the workspace.
+    /// This can be either a Cargo.toml, package.json, dist.toml, or dist-workspace.toml.
+    ///
+    /// In most cases this manifest may or may not represent a "real" package. Many systems
+    /// have some notion of "virtual" manifest which exists only to list the actual packages
+    /// in the workspace.
     pub manifest_path: Utf8PathBuf,
+    /// Path to the dist.toml or dist-workspace.toml for the workspace
+    ///
+    /// If this is ever set, then this will be the same as manifest_path.
+    pub dist_manifest_path: Option<Utf8PathBuf>,
     /// If the workspace root has some auto-includeable files, here they are!
     ///
     /// This is currently what is use for top-level Announcement contents.
@@ -443,8 +449,13 @@ pub struct PackageInfo {
     ///
     /// This may be needed when e.g. talking to cargo about the package.
     pub true_version: Option<Version>,
-    /// Path to the manifest for this package
+    /// Path to the primary manifest for this package
     pub manifest_path: Utf8PathBuf,
+    /// Path to a dist.toml overriding this package's contents
+    ///
+    /// NOTE: this WILL be the same path as the manifest_path for a pure dist.toml
+    /// package. Don't assume these are disjoint!
+    pub dist_manifest_path: Option<Utf8PathBuf>,
     /// Path to the root dir for this package
     pub package_root: Utf8PathBuf,
     /// Name of the package

--- a/axoproject/src/repo.rs
+++ b/axoproject/src/repo.rs
@@ -11,7 +11,7 @@ pub enum GithubRepoInput {
 }
 
 /// Represents a GitHub repository that we can query things about.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GithubRepo {
     /// The repository owner.
     pub owner: String,

--- a/axoproject/src/rust.rs
+++ b/axoproject/src/rust.rs
@@ -226,6 +226,7 @@ fn package_info(_workspace_root: &Utf8Path, package: &PackageMetadata) -> Result
         cstaticlibs,
         cargo_metadata_table,
         cargo_package_id,
+        npm_scope: None,
         build_command: None,
     };
 

--- a/axoproject/src/rust.rs
+++ b/axoproject/src/rust.rs
@@ -95,6 +95,7 @@ fn workspace_info(pkg_graph: &PackageGraph) -> Result<WorkspaceStructure> {
             workspace_dir,
 
             manifest_path,
+            dist_manifest_path: None,
             root_auto_includes,
             cargo_metadata_table,
             cargo_profiles,
@@ -203,6 +204,7 @@ fn package_info(_workspace_root: &Utf8Path, package: &PackageMetadata) -> Result
         name: package.name().to_owned(),
         version,
         manifest_path,
+        dist_manifest_path: None,
         package_root: package_root.clone(),
         description: package.description().map(ToOwned::to_owned),
         authors: package.authors().to_vec(),

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -4,7 +4,6 @@ use std::collections::BTreeMap;
 
 use axoasset::{toml_edit, SourceFile};
 use axoproject::local_repo::LocalRepo;
-use axoproject::WorkspaceKind;
 use camino::{Utf8Path, Utf8PathBuf};
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -21,7 +20,7 @@ use crate::{
 #[derive(Debug, Deserialize)]
 struct GenericConfig {
     /// The dist field within dist.toml
-    dist: DistMetadata,
+    dist: Option<DistMetadata>,
 }
 
 /// Contents of METADATA_DIST in Cargo.toml files
@@ -1668,25 +1667,40 @@ impl std::fmt::Display for ProductionMode {
 }
 
 pub(crate) fn parse_metadata_table_or_manifest(
-    workspace_type: WorkspaceKind,
     manifest_path: &Utf8Path,
+    dist_manifest_path: Option<&Utf8Path>,
     metadata_table: Option<&serde_json::Value>,
 ) -> DistResult<DistMetadata> {
-    match workspace_type {
-        WorkspaceKind::Javascript => unimplemented!("npm packages not yet supported here"),
-        // Pre-parsed Rust metadata table
-        WorkspaceKind::Rust => parse_metadata_table(manifest_path, metadata_table),
+    if let Some(dist_manifest_path) = dist_manifest_path {
+        reject_metadata_table(manifest_path, dist_manifest_path, metadata_table)?;
         // Generic dist.toml
-        WorkspaceKind::Generic => {
-            let src = SourceFile::load_local(manifest_path)?;
-            parse_generic_config(src)
-        }
+        let src = SourceFile::load_local(dist_manifest_path)?;
+        parse_generic_config(src)
+    } else {
+        // Pre-parsed Rust metadata table
+        parse_metadata_table(manifest_path, metadata_table)
     }
 }
 
 pub(crate) fn parse_generic_config(src: SourceFile) -> DistResult<DistMetadata> {
     let config: GenericConfig = src.deserialize_toml()?;
-    Ok(config.dist)
+    Ok(config.dist.unwrap_or_default())
+}
+
+pub(crate) fn reject_metadata_table(
+    manifest_path: &Utf8Path,
+    dist_manifest_path: &Utf8Path,
+    metadata_table: Option<&serde_json::Value>,
+) -> DistResult<()> {
+    let has_dist_metadata = metadata_table.and_then(|t| t.get(METADATA_DIST)).is_some();
+    if has_dist_metadata {
+        Err(DistError::UnusedMetadata {
+            manifest_path: manifest_path.to_owned(),
+            dist_manifest_path: dist_manifest_path.to_owned(),
+        })
+    } else {
+        Ok(())
+    }
 }
 
 pub(crate) fn parse_metadata_table(

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -465,6 +465,18 @@ pub enum DistError {
         /// Error messsage details
         message: String,
     },
+
+    /// Something has metadata.dist but shouldn't
+    #[error("The metadata.dist entry in this Cargo.toml isn't being used: {manifest_path}")]
+    #[diagnostic(help(
+        "You probably want to move them to the [dist] section in {dist_manifest_path}"
+    ))]
+    UnusedMetadata {
+        /// The manifest that had the metadata.dist
+        manifest_path: Utf8PathBuf,
+        /// The dist.toml/dist-workspace.toml that means it's ignored
+        dist_manifest_path: Utf8PathBuf,
+    },
 }
 
 /// This error indicates we tried to deserialize some YAML with serde_yml

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -105,7 +105,7 @@ pub enum DistError {
     },
 
     /// Error parsing metadata in Cargo.toml (json because it's from cargo-metadata)
-    #[error("Malformed metadata.dist in {manifest_path}")]
+    #[error("Malformed metadata.dist in\n{manifest_path}")]
     #[diagnostic(help("you can find a reference for the configuration schema at https://opensource.axo.dev/cargo-dist/book/reference/config.html"))]
     CargoTomlParse {
         /// path to file
@@ -320,7 +320,7 @@ pub enum DistError {
     GitArchiveError {},
 
     /// An error running `git -C path rev-parse HEAD`
-    #[error("We failed to query information about the git submodule at {path}")]
+    #[error("We failed to query information about the git submodule at\n{path}")]
     #[diagnostic(help("Does a submodule exist at that path? Has it been fetched with `git submodule update --init`?"))]
     GitSubmoduleCommitError {
         /// The path we failed to fetch
@@ -467,9 +467,9 @@ pub enum DistError {
     },
 
     /// Something has metadata.dist but shouldn't
-    #[error("The metadata.dist entry in this Cargo.toml isn't being used: {manifest_path}")]
+    #[error("The metadata.dist entry in this Cargo.toml isn't being used:\n{manifest_path}")]
     #[diagnostic(help(
-        "You probably want to move them to the [dist] section in {dist_manifest_path}"
+        "You probably want to move them to the [dist] section in\n{dist_manifest_path}"
     ))]
     UnusedMetadata {
         /// The manifest that had the metadata.dist

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -387,8 +387,8 @@ fn has_metadata_table(workspace_info: &WorkspaceInfo) -> bool {
             .unwrap_or(false)
     } else {
         config::parse_metadata_table_or_manifest(
-            workspace_info.kind,
             &workspace_info.manifest_path,
+            workspace_info.dist_manifest_path.as_deref(),
             workspace_info.cargo_metadata_table.as_ref(),
         )
         .is_ok()
@@ -410,8 +410,8 @@ fn get_new_dist_metadata(
 
     let mut meta = if has_config {
         config::parse_metadata_table_or_manifest(
-            root_workspace.kind,
             &root_workspace.manifest_path,
+            root_workspace.dist_manifest_path.as_deref(),
             root_workspace.cargo_metadata_table.as_ref(),
         )?
     } else {

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1313,7 +1313,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let app_homepage_url = package_info.homepage_url.clone();
         let app_keywords = package_info.keywords.clone();
         let npm_package = npm_package.clone();
-        let npm_scope = npm_scope.clone();
+        let npm_scope = npm_scope.clone().or_else(|| package_info.npm_scope.clone());
         let install_path = install_path
             .clone()
             .unwrap_or(InstallPathStrategy::default_list());

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -846,6 +846,22 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
     ) -> DistResult<Self> {
         let root_workspace_idx = workspaces.root_workspace_idx();
         let root_workspace = workspaces.workspace(root_workspace_idx);
+
+        // Complain if someone still has [workspace.metadata.dist] in a dist-workspace.toml scenario
+        if let Some(dist_manifest_path) = root_workspace.dist_manifest_path.as_deref() {
+            for workspace_idx in workspaces.all_workspace_indices() {
+                if workspace_idx == root_workspace_idx {
+                    continue;
+                }
+                let workspace = workspaces.workspace(workspace_idx);
+                config::reject_metadata_table(
+                    &workspace.manifest_path,
+                    dist_manifest_path,
+                    workspace.cargo_metadata_table.as_ref(),
+                )?;
+            }
+        }
+
         let target_dir = root_workspace.target_dir.clone();
         let workspace_dir = root_workspace.workspace_dir.clone();
         let repo_dir = if let Some(repo) = &workspaces.repo {
@@ -859,8 +875,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let mut workspace_metadata =
             // Read the global config
             config::parse_metadata_table_or_manifest(
-                root_workspace.kind,
                 &root_workspace.manifest_path,
+                root_workspace.dist_manifest_path.as_deref(),
                 root_workspace.cargo_metadata_table.as_ref(),
             )?;
 
@@ -979,8 +995,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         // Compute/merge package configs
         let mut package_metadata = vec![];
         for (_idx, package) in workspaces.all_packages() {
-            let mut package_config = config::parse_metadata_table(
+            let mut package_config = config::parse_metadata_table_or_manifest(
                 &package.manifest_path,
+                package.dist_manifest_path.as_deref(),
                 package.cargo_metadata_table.as_ref(),
             )?;
             package_config.make_relative_to(&package.package_root);

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -111,6 +111,7 @@ pub fn mock_package(name: &str, ver: &str) -> PackageInfo {
         cdylibs: vec![],
         cargo_metadata_table: None,
         cargo_package_id: None,
+        npm_scope: None,
         build_command: None,
     }
 }

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -93,6 +93,7 @@ pub fn mock_package(name: &str, ver: &str) -> PackageInfo {
         name: name.to_owned(),
         version,
         manifest_path,
+        dist_manifest_path: None,
         package_root,
         description: Some(REPO_DESC.to_owned()),
         authors: vec![],
@@ -129,6 +130,7 @@ pub fn mock_workspace(packages: Vec<PackageInfo>) -> WorkspaceGraph {
             target_dir,
             workspace_dir,
             manifest_path,
+            dist_manifest_path: None,
             root_auto_includes: AutoIncludes {
                 readme: None,
                 licenses: vec![],

--- a/cargo-dist/tests/gallery/dist.rs
+++ b/cargo-dist/tests/gallery/dist.rs
@@ -77,7 +77,7 @@ pub static AXOLOTLSAY_HYBRID: TestContextLock<Tools> = TestContextLock::new(
     &Repo {
         repo_owner: "axodotdev",
         repo_name: "axolotlsay-hybrid",
-        commit_sha: "b29f382a67409c10c055501d920175285d12098c",
+        commit_sha: "bf2bab37685af43ca58e7ee3683dd59db0b7b645",
         apps: &[
             App {
                 name: "axolotlsay-js",


### PR DESCRIPTION
Use the [dist] section package dist.tomls, and add errors for cases where a metadata.dist exists but is being ignored.

Also handles npm package scopes better.

Also handles url equality checks better.

fixes #1308 
fixes #1307 