### PR TITLE
chore(deps): bump axios in /cargo-dist/templates/installer/npm

### DIFF
--- a/cargo-dist/templates/installer/npm/npm-shrinkwrap.json
+++ b/cargo-dist/templates/installer/npm/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -94,10 +94,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/cargo-dist/templates/installer/npm/package.json
+++ b/cargo-dist/templates/installer/npm/package.json
@@ -19,7 +19,7 @@
     "npm": "9.5.0"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -2165,7 +2165,7 @@ install(false);
         "axolotlsay-link": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2259,10 +2259,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2956,7 +2955,7 @@ install(false);
     "axolotlsay-link": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -2164,7 +2164,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2258,10 +2258,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2954,7 +2953,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -2153,7 +2153,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2247,10 +2247,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2943,7 +2942,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -2149,7 +2149,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2243,10 +2243,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2939,7 +2938,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1671,7 +1671,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -1765,10 +1765,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2461,7 +2460,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1671,7 +1671,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -1765,10 +1765,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2461,7 +2460,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -2166,7 +2166,7 @@ install(false);
         "axolotlsay-link2": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2260,10 +2260,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2958,7 +2957,7 @@ install(false);
     "axolotlsay-link2": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -2158,7 +2158,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2252,10 +2252,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2948,7 +2947,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -2150,7 +2150,7 @@ install(false);
         "axolotlsay": "run-axolotlsay.js"
       },
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
@@ -2244,10 +2244,9 @@ install(false);
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "version": "1.7.2"
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "version": "1.7.3"
     },
     "node_modules/axios-proxy-builder": {
       "dependencies": {
@@ -2940,7 +2939,7 @@ install(false);
     "axolotlsay": "run-axolotlsay.js"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",


### PR DESCRIPTION
Backported copy of #1274 for the 0.20.x series branch.

Bumps [axios](https://github.com/axios/axios) from 1.7.2 to 1.7.3.
- [Release notes](https://github.com/axios/axios/releases)
- [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
- [Commits](https://github.com/axios/axios/compare/v1.7.2...v1.7.3)

---
updated-dependencies:
- dependency-name: axios dependency-type: direct:production update-type: version-update:semver-patch ...