### PR TITLE
docs: add two more redirects

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -14,6 +14,8 @@ search.use-boolean-and = true
 warning-policy = "error"
 
 [output.html.redirect]
+"/ci/github.html" = "./index.html"
+"/generic-builds.html" = "./custom-builds.html"
 "/way-too-quickstart.html" = "./quickstart/rust.html"
 
 [preprocessor.toc]


### PR DESCRIPTION
These pages were deleted/moved in the recent docs rewrite. While they were less popular than the previous one we've redirected, it's still worth adding redirects to new homes for them just in case any links or search results were pointing to them.