### PR TITLE
fix: remove last vestiges of version::cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "0.21.0"
+version = "0.21.1-prerelease.1"
 dependencies = [
  "axoasset",
  "axoprocess",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.21.0"
+version = "0.21.1-prerelease.1"
 dependencies = [
  "axoasset",
  "axocli",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.21.0"
+version = "0.21.1-prerelease.1"
 dependencies = [
  "camino",
  "gazenot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
 homepage = "https://opensource.axo.dev/cargo-dist/"
-version = "0.21.0"
+version = "0.21.1-prerelease.1"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!
-cargo-dist-schema = { version = "=0.21.0", path = "cargo-dist-schema" }
-axoproject = { version = "=0.21.0", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
+cargo-dist-schema = { version = "=0.21.1-prerelease.1", path = "cargo-dist-schema" }
+axoproject = { version = "=0.21.1-prerelease.1", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
 
 # first-party deps
 axocli = { version = "0.2.0" }

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -618,17 +618,6 @@ impl Display for Version {
 }
 
 impl Version {
-    /// Assume it's a cargo Version
-    #[cfg(feature = "cargo-projects")]
-    pub fn cargo(&self) -> &semver::Version {
-        #[allow(irrefutable_let_patterns)]
-        if let Version::Cargo(v) = self {
-            v
-        } else {
-            panic!("Version wasn't in the cargo format")
-        }
-    }
-
     /// Returns a semver-based Version
     #[cfg(any(feature = "generic-projects", feature = "cargo-projects"))]
     pub fn semver(&self) -> semver::Version {

--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -591,9 +591,9 @@ fn maximum_version(
     packages
         .into_iter()
         .filter_map(|pkg_idx| graph.workspaces.package(pkg_idx).version.as_ref())
-        .map(|v| v.cargo())
+        .map(|v| v.semver())
         .max()
-        .cloned()
+        .clone()
 }
 
 /// Overwrite the versions of the given packages


### PR DESCRIPTION
Every user of this was removed except for a use in the --tag=timestamp path, which meant that adding a javascript/generic project to it would needlessly panic and crash without actually checking if the version was semver compatible