### PR TITLE
fix(redirect): quickstart -> quickstart index

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -16,7 +16,7 @@ warning-policy = "error"
 [output.html.redirect]
 "/ci/github.html" = "./index.html"
 "/generic-builds.html" = "./custom-builds.html"
-"/way-too-quickstart.html" = "./quickstart/rust.html"
+"/way-too-quickstart.html" = "./quickstart/index.html"
 
 [preprocessor.toc]
 command = "mdbook-toc"


### PR DESCRIPTION
when i originally made this redirect i was focused on doing a best-effort match to the previous content. however, i didn't realize the quickstart was showing up for generic "cargo-dist" searches (see below, makes a lot of sense). i think putting the redirect at the index page makes more sense here. we *may* want to soup up that page so it's a little nicer than it is currently, but i think the best redirect goes to the index, souped up or not :)

<img width="1525" alt="Screenshot 2024-08-18 at 5 54 41 PM" src="https://github.com/user-attachments/assets/a40df1ac-d759-4541-b8b8-08091a927362">
