### PR TITLE
docs: add notes to two SPDX tests

### DIFF
--- a/cargo-dist/src/backend/installer/homebrew.rs
+++ b/cargo-dist/src/backend/installer/homebrew.rs
@@ -369,6 +369,9 @@ mod tests {
     fn spdx_three_licenses_or_and() {
         run_spdx_comparison(
             "MIT OR Apache-2.0 AND CC-BY-4.0",
+            // NOTE: Homebrew parses this as {:all_of=>[{:any_of=>["MIT", "Apache-2.0"]}, "CC-BY-4.0"]}
+            // According to the spec, this seems to be wrong -
+            // the result produced here is correct.
             r#"any_of: ["MIT", { all_of: ["Apache-2.0", "CC-BY-4.0"] }]"#,
         );
     }
@@ -377,6 +380,8 @@ mod tests {
     fn spdx_three_licenses_and_or() {
         run_spdx_comparison(
             "MIT AND Apache-2.0 OR CC-BY-4.0",
+            // Likewise, Homebrew parses this as {:all_of=>["MIT", {:any_of=>["Apache-2.0", "CC-BY-4.0"]}]}
+            // Which appears to be incorrect.
             r#"any_of: [{ all_of: ["MIT", "Apache-2.0"] }, "CC-BY-4.0"]"#,
         );
     }

--- a/cargo-dist/src/backend/installer/homebrew.rs
+++ b/cargo-dist/src/backend/installer/homebrew.rs
@@ -370,8 +370,11 @@ mod tests {
         run_spdx_comparison(
             "MIT OR Apache-2.0 AND CC-BY-4.0",
             // NOTE: Homebrew parses this as {:all_of=>[{:any_of=>["MIT", "Apache-2.0"]}, "CC-BY-4.0"]}
-            // According to the spec, this seems to be wrong -
-            // the result produced here is correct.
+            // According to the SPDX v3 spec, this seems to be wrong, as operator precedence is specified
+            // as WITH > AND > OR (while Homebrew evaluates OR operators, then AND operators).
+            // The result produced in this test is correct.
+            //
+            // https://spdx.github.io/spdx-spec/v3.0/annexes/SPDX-license-expressions/#d45-order-of-precedence-and-parentheses
             r#"any_of: ["MIT", { all_of: ["Apache-2.0", "CC-BY-4.0"] }]"#,
         );
     }


### PR DESCRIPTION
These two tests produce different results in Homebrew's SPDX parser, but that appears to be a bug in Homebrew's parser rather than this one. Added notes to both tests so that we expect the results to be different from what Homebrew returns.

refs https://github.com/axodotdev/cargo-dist/pull/1345#discussion_r1723932405.

cc @cxreiff 