### PR TITLE
fix: Make RECEIPT_HOME variable XDG compliant

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -26,7 +26,7 @@ read -r RECEIPT <<EORECEIPT
 {{ receipt | tojson }}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
-RECEIPT_HOME="${HOME}/.config/{{ app_name }}"
+RECEIPT_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/{{ app_name }}"
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)


### PR DESCRIPTION
The setting of RECEIPT_HOME using "${HOME}/.config" will fail for users who move their config folder elsewhere using XDG_CONFIG_HOME. Both dash and bash (the usual interpreters for /bin/sh) both support parameter substitution.