### PR TITLE
feat: improve staticlib handling, errors

### DIFF
--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -302,8 +302,11 @@ pub enum DistError {
     },
 
     /// Linkage report can't be run for this target
-    #[error("unable to run linkage report for this type of binary")]
-    LinkageCheckUnsupportedBinary {},
+    #[error("unable to run linkage report for this type of binary; file was: {file_name:?}")]
+    LinkageCheckUnsupportedBinary {
+        /// The object's file name
+        file_name: Option<String>,
+    },
 
     /// Error parsing a string containing an environment variable
     /// in VAR=value syntax


### PR DESCRIPTION
* Windows staticlibs are `ar` archives, not PE executables. Make sure we handle those in the Windows object parsing case.
* Make unsupported binary checks nonfatal. In this case we can simply return a default instead of failing the build.
* Provide the filename in the LinkageCheckUnsupportedBinary error, making it more informative in the cases it does end up getting printed.

Fixes #1356.