### PR TITLE
feat: macOS codesigning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ dependencies = [
  "axoproject",
  "axotag",
  "axoupdater",
+ "base64",
  "blake2",
  "camino",
  "cargo-dist-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ parse-changelog = "0.6.8"
 schemars = "0.8.21"
 serde_yml = "0.0.10"
 spdx = "0.10.6"
+base64 = "0.22.1"
 
 [workspace.metadata.release]
 shared-version = true

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -66,6 +66,7 @@ sha3.workspace = true
 blake2.workspace = true
 serde_yml.workspace = true
 spdx.workspace = true
+base64.workspace = true
 
 [dev-dependencies]
 homedir.workspace = true

--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -73,6 +73,8 @@ pub struct GithubCiInfo {
     pub github_releases_repo: Option<JinjaGithubRepoPair>,
     /// \[unstable\] whether to add ssl.com windows binary signing
     pub ssldotcom_windows_sign: Option<ProductionMode>,
+    /// Whether to enable macOS codesigning
+    pub macos_sign: bool,
     /// Whether to enable GitHub Attestations
     pub github_attestations: bool,
     /// what hosting provider we're using
@@ -177,6 +179,7 @@ impl GithubCiInfo {
         let create_release = dist.create_release;
         let github_releases_repo = dist.github_releases_repo.clone().map(|r| r.into_jinja());
         let ssldotcom_windows_sign = dist.ssldotcom_windows_sign.clone();
+        let macos_sign = dist.macos_sign;
         let github_attestations = dist.github_attestations;
         let tag_namespace = dist.tag_namespace.clone();
         let mut dependencies = SystemDependencies::default();
@@ -362,6 +365,7 @@ impl GithubCiInfo {
             create_release,
             github_releases_repo,
             ssldotcom_windows_sign,
+            macos_sign,
             github_attestations,
             hosting_providers,
             release_command,

--- a/cargo-dist/src/config.rs
+++ b/cargo-dist/src/config.rs
@@ -380,6 +380,10 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ssldotcom_windows_sign: Option<ProductionMode>,
 
+    /// Whether we should sign Mac binaries
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub macos_sign: Option<bool>,
+
     /// Whether GitHub Attestations is enabled (default false)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub github_attestations: Option<bool>,
@@ -503,6 +507,7 @@ impl DistMetadata {
             allow_dirty: _,
             github_release: _,
             ssldotcom_windows_sign: _,
+            macos_sign: _,
             github_attestations: _,
             msvc_crt_static: _,
             hosting: _,
@@ -596,6 +601,7 @@ impl DistMetadata {
             allow_dirty,
             github_release,
             ssldotcom_windows_sign,
+            macos_sign,
             github_attestations,
             msvc_crt_static,
             hosting,
@@ -670,6 +676,9 @@ impl DistMetadata {
         }
         if ssldotcom_windows_sign.is_some() {
             warn!("package.metadata.dist.ssldotcom-windows-sign is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
+        }
+        if macos_sign.is_some() {
+            warn!("package.metadata.dist.macos-sign is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);
         }
         if github_attestations.is_some() {
             warn!("package.metadata.dist.github-attestations is set, but this is only accepted in workspace.metadata (value is being ignored): {}", package_manifest_path);

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -520,6 +520,11 @@ pub enum DistError {
         /// path to manifest
         manifest: Utf8PathBuf,
     },
+
+    /// Failure to decode base64-encoded certificate
+    #[error("We failed to decode the certificate stored in the CODESIGN_CERTIFICATE environment variable.")]
+    #[diagnostic(help("Is the value of this envirionment variable valid base64?"))]
+    CertificateDecodeError {},
 }
 
 /// This error indicates we tried to deserialize some YAML with serde_yml

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -462,6 +462,7 @@ fn get_new_dist_metadata(
             pr_run_mode: None,
             allow_dirty: None,
             ssldotcom_windows_sign: None,
+            macos_sign: None,
             github_attestations: None,
             msvc_crt_static: None,
             hosting: None,
@@ -959,6 +960,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         pr_run_mode,
         allow_dirty,
         ssldotcom_windows_sign,
+        macos_sign,
         github_attestations,
         msvc_crt_static,
         hosting,
@@ -1297,6 +1299,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "ssldotcom-windows-sign",
         "",
         ssldotcom_windows_sign.as_ref().map(|p| p.to_string()),
+    );
+
+    apply_optional_value(
+        table,
+        "macos-sign",
+        "# Whether to sign macOS executables\n",
+        *macos_sign,
     );
 
     apply_optional_value(

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -228,7 +228,9 @@ pub fn fetch_updater_from_source(dist_graph: &DistGraph, updater: &UpdaterStep) 
     Ok(())
 }
 
-fn create_tmp() -> DistResult<(TempDir, Utf8PathBuf)> {
+/// Creates a temporary directory, returning the directory and
+/// its path as a Utf8PathBuf.
+pub fn create_tmp() -> DistResult<(TempDir, Utf8PathBuf)> {
     let tmp_dir = TempDir::new()?;
     let tmp_root =
         Utf8PathBuf::from_path_buf(tmp_dir.path().to_owned()).expect("tempdir isn't utf8!?");

--- a/cargo-dist/src/sign/macos.rs
+++ b/cargo-dist/src/sign/macos.rs
@@ -1,0 +1,200 @@
+//! Codesigning using Apple's builtin `codesign` tool.
+//! Because Apple's tools are tightly integrated into their
+//! ecosystem, there's a couple of considerations here:
+//! 1) This can only be run on a Mac, and
+//! 2) Apple expects certificates to be located in the Keychain,
+//!    a Mac-specific certificate store, which interacts a bit
+//!    weirdly with our ephemeral runner setup in CI.
+//! Most of this module is actually concerned with ephemeral
+//! keychain setup, with the signing section of the code relatively
+//! short in comparison. The keychain code will be reused elsewhere
+//! in the future.
+//!
+//! The workflow we follow here is:
+//! 1) Create an ephemeral keychain in a temporary directory;
+//! 2) Configure it to be usable for signing;
+//! 3) Import the certificate specified in the environment;
+//! 4) Actually perform the signing;
+//! 5) Let the keychain be deleted when the temporary directory is dropped.
+//!
+//! In the future, this module will also support notarization.
+use std::path::PathBuf;
+
+use axoasset::LocalAsset;
+use axoprocess::Cmd;
+use base64::Engine;
+use camino::Utf8Path;
+use temp_dir::TempDir;
+use tracing::warn;
+
+use crate::{DistError, DistResult, TargetTriple};
+
+struct Keychain {
+    root: TempDir,
+    password: String,
+    pub path: PathBuf,
+}
+
+impl Keychain {
+    /// Creates a keychain in a temporary directory, secured
+    /// with the provided password.
+    pub fn create(password: String) -> DistResult<Self> {
+        let root = TempDir::new()?;
+        let path = root.path().join("signing.keychain-db");
+
+        let mut cmd = Cmd::new("/usr/bin/security", "create keychain");
+        cmd.arg("create-keychain");
+        cmd.arg("-p").arg(&password);
+        cmd.arg(&path);
+        cmd.stdout_to_stderr();
+        cmd.status()?;
+
+        // This sets a longer timeout so that it remains
+        // unlocked by the time we perform the signature;
+        // the keychain will be deleted before this
+        // lock period expires.
+        let mut cmd = Cmd::new("/usr/bin/security", "set timeout");
+        cmd.arg("set-keychain-settings");
+        cmd.arg("-lut").arg("21600");
+        cmd.arg(&path);
+        cmd.stdout_to_stderr();
+        cmd.status()?;
+
+        // Unlock for use in later commands
+        let mut cmd = Cmd::new("/usr/bin/security", "unlock keychain");
+        cmd.arg("unlock-keychain");
+        cmd.arg("-p").arg(&password);
+        cmd.arg(&path);
+        cmd.stdout_to_stderr();
+        cmd.status()?;
+
+        // Set as the default keychain for subsequent commands
+        let mut cmd = Cmd::new("/usr/bin/security", "set keychain as default");
+        cmd.arg("default-keychain");
+        cmd.arg("-s");
+        cmd.arg(&path);
+        cmd.stdout_to_stderr();
+        cmd.status()?;
+
+        Ok(Self {
+            root,
+            password,
+            path,
+        })
+    }
+
+    /// Imports certificate `certificate` with passphrase `passphrase`
+    /// into the keychain at `self`.
+    pub fn import_certificate(&self, certificate: &[u8], passphrase: &str) -> DistResult<()> {
+        // Temporarily write `certificate` into `path` for `security`
+        let root = Utf8Path::from_path(self.root.path()).unwrap();
+        let cert_path = root.join("cert.p12");
+        LocalAsset::new(&cert_path, certificate.to_owned())?.write_to_dir(root)?;
+
+        let mut cmd = Cmd::new("/usr/bin/security", "import certificate");
+        cmd.arg("import");
+        cmd.arg(&cert_path);
+        cmd.arg("-k").arg(&self.path);
+        cmd.arg("-P").arg(passphrase);
+        cmd.arg("-t").arg("cert");
+        cmd.arg("-f").arg("pkcs12");
+        cmd.arg("-A");
+        cmd.arg("-T")
+            .arg("/usr/bin/codesign")
+            .arg("-T")
+            .arg("/usr/bin/security")
+            .arg("-T")
+            .arg("/usr/bin/productsign");
+        cmd.stdout_to_stderr();
+        cmd.status()?;
+
+        let mut cmd = Cmd::new("/usr/bin/security", "configure certificate for signing");
+        cmd.arg("set-key-partition-list");
+        cmd.arg("-S").arg("apple-tool:,apple:,codesign:");
+        cmd.arg("-k").arg(&self.password);
+        cmd.arg(&self.path);
+        cmd.stdout_to_stderr();
+        cmd.status()?;
+
+        Ok(())
+    }
+}
+
+/// Configuration for the system macOS codesign(1)
+#[derive(Debug)]
+pub struct Codesign {
+    env: CodesignEnv,
+}
+
+struct CodesignEnv {
+    pub identity: String,
+    pub password: String,
+    pub certificate: Vec<u8>,
+}
+
+impl CodesignEnv {
+    pub fn from(identity: &str, password: &str, raw_certificate: &str) -> DistResult<Self> {
+        let certificate = base64::prelude::BASE64_STANDARD
+            .decode(raw_certificate)
+            .map_err(|_| DistError::CertificateDecodeError {})?;
+
+        Ok(Self {
+            identity: identity.to_owned(),
+            password: password.to_owned(),
+            certificate,
+        })
+    }
+}
+
+impl std::fmt::Debug for CodesignEnv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CodesignEnv")
+            .field("identity", &"<hidden>")
+            .field("password", &"<hidden>")
+            .field("certificate", &"<hidden>")
+            .finish()
+    }
+}
+
+impl Codesign {
+    pub fn new(host_target: &TargetTriple) -> DistResult<Option<Self>> {
+        if !host_target.contains("darwin") {
+            return Ok(None);
+        }
+
+        if let (Some(identity), Some(password), Some(certificate)) = (
+            Self::var("CODESIGN_IDENTITY"),
+            Self::var("CODESIGN_CERTIFICATE_PASSWORD"),
+            Self::var("CODESIGN_CERTIFICATE"),
+        ) {
+            let env = CodesignEnv::from(&identity, &password, &certificate)?;
+
+            Ok(Some(Self { env }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn var(var: &str) -> Option<String> {
+        let val = std::env::var(var).ok();
+        if val.is_none() {
+            warn!("{var} is missing");
+        }
+        val
+    }
+
+    pub fn sign(&self, file: &Utf8Path) -> DistResult<()> {
+        let password = uuid::Uuid::new_v4().as_hyphenated().to_string();
+        let keychain = Keychain::create(password)?;
+        keychain.import_certificate(&self.env.certificate, &self.env.password)?;
+
+        let mut cmd = Cmd::new("/usr/bin/codesign", "sign macOS artifacts");
+        cmd.arg("--sign").arg(&self.env.identity);
+        cmd.arg("--keychain").arg(&keychain.path);
+        cmd.arg(file);
+        cmd.stdout_to_stderr();
+        cmd.output()?;
+
+        Ok(())
+    }
+}

--- a/cargo-dist/src/sign/mod.rs
+++ b/cargo-dist/src/sign/mod.rs
@@ -1,15 +1,20 @@
 //! Code/artifact signing support
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use axoasset::AxoClient;
 use camino::Utf8Path;
 
 use crate::{config::ProductionMode, DistResult, TargetTriple};
 
+mod macos;
 mod ssldotcom;
 
 /// Code/artifact signing providers
 #[derive(Debug)]
 pub struct Signing {
+    macos: Option<macos::Codesign>,
     ssldotcom: Option<ssldotcom::CodeSignTool>,
 }
 
@@ -20,10 +25,16 @@ impl Signing {
         host_target: &TargetTriple,
         dist_dir: &Utf8Path,
         ssldotcom_windows_sign: Option<ProductionMode>,
+        macos_sign: bool,
     ) -> DistResult<Self> {
         let ssldotcom =
             ssldotcom::CodeSignTool::new(client, host_target, dist_dir, ssldotcom_windows_sign)?;
-        Ok(Self { ssldotcom })
+        let macos = if macos_sign {
+            macos::Codesign::new(host_target)?
+        } else {
+            None
+        };
+        Ok(Self { macos, ssldotcom })
     }
 
     /// Sign a file
@@ -31,6 +42,21 @@ impl Signing {
         if let Some(signer) = &self.ssldotcom {
             let extension = file.extension().unwrap_or_default();
             if let "exe" | "msi" | "ps1" = extension {
+                signer.sign(file)?;
+            }
+        }
+        if let Some(signer) = &self.macos {
+            // TODO: restructure, this is just to keep Windows
+            // from flagging dead code
+            #[cfg(unix)]
+            let is_executable = file.metadata()?.permissions().mode() & 0o111 != 0;
+            #[cfg(windows)]
+            let is_executable = true;
+
+            // At the moment, we're exclusively signing executables.
+            // In the future, we may need to sign app bundles (which are
+            // directories) or certain other metadata files.
+            if file.is_file() && is_executable {
                 signer.sign(file)?;
             }
         }

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -223,6 +223,8 @@ pub struct DistGraph {
     pub release_branch: Option<String>,
     /// \[unstable\] if Some, sign binaries with ssl.com
     pub ssldotcom_windows_sign: Option<ProductionMode>,
+    /// Whether to enable macOS codesigning
+    pub macos_sign: bool,
     /// Whether to enable GitHub Attestations
     pub github_attestations: bool,
     /// Path relative to the github-ci-dir for steps to include
@@ -899,6 +901,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             dispatch_releases,
             release_branch,
             ssldotcom_windows_sign,
+            macos_sign,
             github_attestations,
             tag_namespace,
             install_updater,
@@ -976,6 +979,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let msvc_crt_static = msvc_crt_static.unwrap_or(true);
         let local_builds_are_lies = artifact_mode == ArtifactMode::Lies;
         let ssldotcom_windows_sign = ssldotcom_windows_sign.clone();
+        let macos_sign = macos_sign.unwrap_or(false);
         let github_attestations = github_attestations.unwrap_or(false);
         let tag_namespace = tag_namespace.clone();
         let github_releases_repo = github_releases_repo.clone();
@@ -1148,6 +1152,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             &tools.cargo.host_target,
             &dist_dir,
             ssldotcom_windows_sign.clone(),
+            macos_sign,
         )?;
         Ok(Self {
             inner: DistGraph {
@@ -1170,6 +1175,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 github_release,
                 github_build_setup,
                 ssldotcom_windows_sign,
+                macos_sign,
                 github_attestations,
                 desired_cargo_dist_version,
                 desired_rust_toolchain,
@@ -1285,6 +1291,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             github_releases_repo: _,
             github_releases_submodule_path: _,
             ssldotcom_windows_sign: _,
+            macos_sign: _,
             hosting: _,
             extra_artifacts: _,
             github_custom_runners: _,

--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -210,6 +210,11 @@ jobs:
       SSLDOTCOM_CREDENTIAL_ID: ${{ secrets.SSLDOTCOM_CREDENTIAL_ID }}
       SSLDOTCOM_TOTP_SECRET: ${{ secrets.SSLDOTCOM_TOTP_SECRET }}
     {{%- endif %}}
+    {{%- if macos_sign %}}
+      CODESIGN_CERTIFICATE: ${{ secrets.CODESIGN_CERTIFICATE }}
+      CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+      CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+    {{%- endif %}}
     steps:
       - name: enable windows longpaths
         run: |


### PR DESCRIPTION
This adds support for codesigning on macOS, similar to the ssl.com feature on Windows. In the current revision, we only perform signing with a certificate - notarization will come in a subsequent feature.

As with ssl.com, the only feature in our config is the feature controlling whether or not to sign - the rest is handled via the environment/Actions secrets. The user needs to provide three fields:

* A pkcs12 certificate, base64-encoded.
* The passphrase for that certificate.
* The name of the codesigning identity belonging to that certificate.

If all three are present, we'll codesign any binaries and libraries during the local build process.

This uses the builtin macOS tooling, which means it can only be performed on a macOS host. (That's not too different from how we can only do the Windows codesigning on a Windows host.) Because interacting with the keychain is slightly wonky on something like a hosted runner, we've got a slightly complex process that takes a few steps. (This process is inspired by official documentation from GitHub: https://docs.github.com/en/actions/use-cases-and-examples/deploying/installing-an-apple-certificate-on-macos-runners-for-xcode-development)

* We create a fresh keychain database in a temporary directory, with a randomized password under our control.
* We unlock that keychain and configure it to remain unlocked for the duration of the signing process.
* We set that keychain as the default.
* We import our certificate into that keychain, and configure it so that it can only be used by `codesign`, `security` and `productsign`.
* We configure the key to be used for signing.
* We actually sign the binary.

I structured the core keychain stuff into a struct that can be reused, with a mind to using it in the `pkgbuild`/`productbuild` stages from #469.

Because the keychain is placed in a temporary directory under the control of `temp_dir`, it's deleted automatically after the signing process completes. That should mean that we don't even need to rely on the ephemerality of the runner to ensure that the certificate is deleted prior to the next job running.