### PR TITLE
feat: support app-specific force install

### DIFF
--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -291,6 +291,10 @@ pub struct Release {
     /// The version of the app
     // FIXME: should be a Version but JsonSchema doesn't support (yet?)
     pub app_version: String,
+    /// Environment variable to force an install location
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install_dir_env_var: Option<String>,
     /// Alternative display name that can be prettier
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -606,9 +610,12 @@ impl DistManifest {
         if let Some(position) = self.releases.iter().position(|r| r.app_name == name) {
             &mut self.releases[position]
         } else {
+            let install_dir_env_var =
+                Some(name.to_ascii_uppercase().replace('-', "_") + "_INSTALL_DIR");
             self.releases.push(Release {
                 app_name: name,
                 app_version: version,
+                install_dir_env_var,
                 artifacts: vec![],
                 hosting: Hosting::default(),
                 display: None,

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -977,6 +977,13 @@ expression: json_schema
               "$ref": "#/definitions/Hosting"
             }
           ]
+        },
+        "install_dir_env_var": {
+          "description": "Environment variable to force an install location",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -73,6 +73,8 @@ pub struct InstallerInfo {
     pub runtime_conditions: RuntimeConditions,
     /// platform support matrix
     pub platform_support: Option<PlatformSupport>,
+    /// Environment variable to force an install location
+    pub install_dir_env_var: String,
 }
 
 /// A fake fragment of an ExecutableZip artifact for installers

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1981,18 +1981,17 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         }
         let release = self.release(to_release);
         let release_id = &release.id;
-        let Some(schema_release) = self.manifest.release_by_name(&release.app_name) else {
-            warn!("skipping shell installer: couldn't find the release");
-            return;
-        };
-        let Some(install_dir_env_var) = schema_release.install_dir_env_var.to_owned() else {
-            warn!("skipping shell installer: couldn't determine app-specific environment variable");
-            return;
-        };
-        let Some(download_url) = schema_release.artifact_download_url() else {
-            warn!("skipping shell installer: couldn't compute a URL to download artifacts from");
-            return;
-        };
+        let schema_release = self
+            .manifest
+            .release_by_name(&release.app_name)
+            .expect("couldn't find the release!?");
+        let install_dir_env_var = schema_release
+            .install_dir_env_var
+            .to_owned()
+            .expect("couldn't determine app-specific environment variable!?");
+        let download_url = schema_release
+            .artifact_download_url()
+            .expect("couldn't compute a URL to download artifacts from!?");
         let artifact_name = format!("{release_id}-installer.sh");
         let artifact_path = self.inner.dist_dir.join(&artifact_name);
         let installer_url = format!("{download_url}/{artifact_name}");
@@ -2064,14 +2063,11 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         } else {
             &release.id
         };
-        let Some(download_url) = self
+        let download_url = self
             .manifest
             .release_by_name(&release.id)
             .and_then(|r| r.artifact_download_url())
-        else {
-            warn!("skipping Homebrew formula: couldn't compute a URL to download artifacts from");
-            return;
-        };
+            .expect("couldn't compute a URL to download artifacts from!?");
 
         let artifact_name = format!("{formula}.rb");
         let artifact_path = self.inner.dist_dir.join(&artifact_name);
@@ -2222,20 +2218,17 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         // Get the basic info about the installer
         let release = self.release(to_release);
         let release_id = &release.id;
-        let Some(schema_release) = self.manifest.release_by_name(&release.app_name) else {
-            warn!("skipping powershell installer: couldn't find the release");
-            return;
-        };
-        let Some(install_dir_env_var) = schema_release.install_dir_env_var.to_owned() else {
-            warn!("skipping shell installer: couldn't determine app-specific environment variable");
-            return;
-        };
-        let Some(download_url) = schema_release.artifact_download_url() else {
-            warn!(
-                "skipping powershell installer: couldn't compute a URL to download artifacts from"
-            );
-            return;
-        };
+        let schema_release = self
+            .manifest
+            .release_by_name(&release.app_name)
+            .expect("couldn't find the release!?");
+        let install_dir_env_var = schema_release
+            .install_dir_env_var
+            .to_owned()
+            .expect("couldn't determine app-specific environment variable!?");
+        let download_url = schema_release
+            .artifact_download_url()
+            .expect("couldn't compute a URL to download artifacts from!?");
         let artifact_name = format!("{release_id}-installer.ps1");
         let artifact_path = self.inner.dist_dir.join(&artifact_name);
         let installer_url = format!("{download_url}/{artifact_name}");
@@ -2299,14 +2292,11 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         }
         let release = self.release(to_release);
         let release_id = &release.id;
-        let Some(download_url) = self
+        let download_url = self
             .manifest
             .release_by_name(&release.app_name)
             .and_then(|r| r.artifact_download_url())
-        else {
-            warn!("skipping npm installer: couldn't compute a URL to download artifacts from");
-            return;
-        };
+            .expect("couldn't compute a URL to download artifacts from!?");
 
         let app_name = if let Some(name) = &release.npm_package {
             name.clone()

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1981,11 +1981,15 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         }
         let release = self.release(to_release);
         let release_id = &release.id;
-        let Some(download_url) = self
-            .manifest
-            .release_by_name(&release.app_name)
-            .and_then(|r| r.artifact_download_url())
-        else {
+        let Some(schema_release) = self.manifest.release_by_name(&release.app_name) else {
+            warn!("skipping shell installer: couldn't find the release");
+            return;
+        };
+        let Some(install_dir_env_var) = schema_release.install_dir_env_var.to_owned() else {
+            warn!("skipping shell installer: couldn't determine app-specific environment variable");
+            return;
+        };
+        let Some(download_url) = schema_release.artifact_download_url() else {
             warn!("skipping shell installer: couldn't compute a URL to download artifacts from");
             return;
         };
@@ -2042,6 +2046,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 install_libraries: release.install_libraries.clone(),
                 runtime_conditions,
                 platform_support: None,
+                install_dir_env_var,
             })),
             is_global: true,
         };
@@ -2198,6 +2203,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     install_libraries: release.install_libraries.clone(),
                     runtime_conditions,
                     platform_support: None,
+                    // Not actually needed for this installer type
+                    install_dir_env_var: String::new(),
                 },
                 install_libraries: release.install_libraries.clone(),
             })),
@@ -2215,11 +2222,15 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         // Get the basic info about the installer
         let release = self.release(to_release);
         let release_id = &release.id;
-        let Some(download_url) = self
-            .manifest
-            .release_by_name(&release.app_name)
-            .and_then(|r| r.artifact_download_url())
-        else {
+        let Some(schema_release) = self.manifest.release_by_name(&release.app_name) else {
+            warn!("skipping powershell installer: couldn't find the release");
+            return;
+        };
+        let Some(install_dir_env_var) = schema_release.install_dir_env_var.to_owned() else {
+            warn!("skipping shell installer: couldn't determine app-specific environment variable");
+            return;
+        };
+        let Some(download_url) = schema_release.artifact_download_url() else {
             warn!(
                 "skipping powershell installer: couldn't compute a URL to download artifacts from"
             );
@@ -2274,6 +2285,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 install_libraries: release.install_libraries.clone(),
                 runtime_conditions: RuntimeConditions::default(),
                 platform_support: None,
+                install_dir_env_var,
             })),
             is_global: true,
         };
@@ -2388,6 +2400,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     install_libraries: release.install_libraries.clone(),
                     runtime_conditions,
                     platform_support: None,
+                    // Not actually needed for this installer type
+                    install_dir_env_var: String::new(),
                 },
             })),
             is_global: true,

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -250,8 +250,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:{{ app_name|upper|replace("-", "_") }}_INSTALL_DIR)) {
-    $force_install_dir = $env:{{ app_name|upper|replace("-", "_")}}_INSTALL_DIR
+  if (($env:{{ install_dir_env_var }})) {
+    $force_install_dir = $env:{{ install_dir_env_var }}
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -247,7 +247,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:{{ app_name|upper|replace("-", "_") }}_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -246,6 +246,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:{{ app_name|upper|replace("-", "_") }}_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:{{ app_name|upper|replace("-", "_")}}_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -256,15 +266,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 {% if install_paths| selectattr("kind", "equalto", "CargoHome") %}
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
 {%- else -%}
-    $dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $dest_dir = $force_install_dir
     $dest_dir_lib = $dest_dir
 {%- endif %}
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
 {%- for install_path in install_paths %}
   if (-Not $dest_dir) {

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -250,8 +250,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:{{ app_name|upper|replace("-", "_") }}_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:{{ app_name|upper|replace("-", "_")}}_FORCE_INSTALL_DIR
+  if (($env:{{ app_name|upper|replace("-", "_") }}_INSTALL_DIR)) {
+    $force_install_dir = $env:{{ app_name|upper|replace("-", "_")}}_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -399,8 +399,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "{{ '${' }}{{ app_name|upper|replace("-", "_") }}_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="${{ app_name|upper|replace("-", "_") }}_FORCE_INSTALL_DIR"
+    if [ -n "{{ '${' }}{{ app_name|upper|replace("-", "_") }}_INSTALL_DIR:-}" ]; then
+        _force_install_dir="${{ app_name|upper|replace("-", "_") }}_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -399,8 +399,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "{{ '${' }}{{ app_name|upper|replace("-", "_") }}_INSTALL_DIR:-}" ]; then
-        _force_install_dir="${{ app_name|upper|replace("-", "_") }}_INSTALL_DIR"
+    if [ -n "{{ '${' }}{{ install_dir_env_var }}:-}" ]; then
+        _force_install_dir="${{ install_dir_env_var }}"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -394,24 +394,34 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "{{ '${' }}{{ app_name|upper|replace("-", "_") }}_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="${{ app_name|upper|replace("-", "_") }}_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+    if [ -n "${_force_install_dir:-}" ]; then
     {%- if install_paths | selectattr("kind", "equalto", "CargoHome") %}
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     {%- else %}
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _install_dir="$_force_install_dir"
+        _lib_install_dir="$_force_install_dir"
         _receipt_install_dir="$_install_dir"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     {%- endif %}
     fi
 

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AKAIKATANA_REPACK_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AKAIKATANA_REPACK_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AKAIKATANA_REPACK_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AKAIKATANA_REPACK_FORCE_INSTALL_DIR"
+    if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR
+  if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
+    $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1677,6 +1677,7 @@ try {
     {
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
+      "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -481,16 +481,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AKAIKATANA_REPACK_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AKAIKATANA_REPACK_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -486,8 +486,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AKAIKATANA_REPACK_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AKAIKATANA_REPACK_FORCE_INSTALL_DIR"
+    if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1169,6 +1169,7 @@ download_binary_and_run_installer "$@" || exit 1
     {
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
+      "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -485,16 +485,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AKAIKATANA_REPACK_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AKAIKATANA_REPACK_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1457,6 +1467,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1467,11 +1487,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1707,6 +1707,7 @@ try {
     {
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
+      "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -490,8 +490,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AKAIKATANA_REPACK_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AKAIKATANA_REPACK_FORCE_INSTALL_DIR"
+    if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1471,8 +1471,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR
+  if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
+    $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1468,7 +1468,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -502,8 +502,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AKAIKATANA_REPACK_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AKAIKATANA_REPACK_FORCE_INSTALL_DIR"
+    if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1497,8 +1497,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR
+  if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
+    $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1494,7 +1494,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -497,16 +497,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AKAIKATANA_REPACK_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AKAIKATANA_REPACK_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1483,6 +1493,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1493,11 +1513,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1733,6 +1733,7 @@ try {
     {
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
+      "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1446,7 +1446,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1685,6 +1685,7 @@ try {
     {
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
+      "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AKAIKATANA_REPACK_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AKAIKATANA_REPACK_FORCE_INSTALL_DIR"
+    if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1449,8 +1449,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR
+  if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
+    $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AKAIKATANA_REPACK_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AKAIKATANA_REPACK_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1435,6 +1445,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AKAIKATANA_REPACK_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1445,11 +1465,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3137,6 +3137,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -485,16 +485,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1457,6 +1467,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1467,11 +1487,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3170,6 +3170,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -490,8 +490,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1471,8 +1471,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1468,7 +1468,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -490,8 +490,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1475,8 +1475,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3172,6 +3172,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -485,16 +485,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1461,6 +1471,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1471,11 +1491,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1472,7 +1472,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1444,8 +1444,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3141,6 +3141,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1430,6 +1440,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1440,11 +1460,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1441,7 +1441,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1162,6 +1162,7 @@ download_binary_and_run_installer "$@" || exit 1
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.blake2b",

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1162,6 +1162,7 @@ download_binary_and_run_installer "$@" || exit 1
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.blake2s",

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1162,6 +1162,7 @@ download_binary_and_run_installer "$@" || exit 1
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha3-256",

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1162,6 +1162,7 @@ download_binary_and_run_installer "$@" || exit 1
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha3-512",

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -80,6 +80,7 @@ end
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -15,6 +15,7 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -15,6 +15,7 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -15,6 +15,7 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -14,6 +14,7 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1437,7 +1437,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_JS_FORCE_INSTALL_DIR)) {
@@ -3100,7 +3100,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_JS_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_JS_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_JS_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_JS_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1440,8 +1440,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_JS_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_JS_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_JS_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_JS_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }
@@ -2140,8 +2140,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -3103,8 +3103,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -3339,6 +3339,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.10.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
@@ -3365,6 +3366,7 @@ try {
     {
       "app_name": "axolotlsay-js",
       "app_version": "0.10.2",
+      "install_dir_env_var": "AXOLOTLSAY_JS_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_JS_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_JS_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1426,6 +1436,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_JS_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_JS_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1436,11 +1456,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME
@@ -2115,16 +2135,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -3069,6 +3099,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -3079,11 +3119,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -481,16 +481,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -486,8 +486,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2623,6 +2623,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -466,8 +466,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2603,6 +2603,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -461,16 +461,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -15,6 +15,7 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -15,6 +15,7 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -490,8 +490,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1475,8 +1475,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -485,16 +485,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1461,6 +1471,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1471,11 +1491,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1472,7 +1472,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3176,6 +3176,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1376,8 +1376,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1373,7 +1373,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1362,6 +1372,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1372,11 +1392,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1613,6 +1613,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1376,8 +1376,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1373,7 +1373,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1362,6 +1372,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1372,11 +1392,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1613,6 +1613,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -15,6 +15,7 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3146,6 +3146,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1446,7 +1446,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1449,8 +1449,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1435,6 +1445,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1445,11 +1465,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3138,6 +3138,7 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1678,6 +1678,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR/bin"
-        _receipt_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/bin")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir/bin"
+        _lib_install_dir="$_force_install_dir/bin"
+        _receipt_install_dir="$_force_install_dir"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1427,6 +1437,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1437,11 +1457,11 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+  if (($force_install_dir)) {
 
-    $dest_dir = Join-Path $env:CARGO_DIST_FORCE_INSTALL_DIR "bin"
+    $dest_dir = Join-Path $force_install_dir "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # first try $env:CARGO_HOME, then fallback to $HOME

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1441,8 +1441,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1438,7 +1438,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1424,8 +1424,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir"
+        _lib_install_dir="$_force_install_dir"
         _receipt_install_dir="$_install_dir"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $MY_ENV_VAR
@@ -1410,6 +1420,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1420,10 +1440,10 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-$dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  if (($force_install_dir)) {
+$dest_dir = $force_install_dir
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # Install to $env:MY_ENV_VAR

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1421,7 +1421,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1653,6 +1653,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1424,8 +1424,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1421,7 +1421,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1653,6 +1653,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir"
+        _lib_install_dir="$_force_install_dir"
         _receipt_install_dir="$_install_dir"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $MY_ENV_VAR/bin
@@ -1410,6 +1420,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1420,10 +1440,10 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-$dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  if (($force_install_dir)) {
+$dest_dir = $force_install_dir
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # Install to $env:MY_ENV_VAR/bin

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1424,8 +1424,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir"
+        _lib_install_dir="$_force_install_dir"
         _receipt_install_dir="$_install_dir"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $MY_ENV_VAR/My Axolotlsay Documents
@@ -1410,6 +1420,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1420,10 +1440,10 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-$dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  if (($force_install_dir)) {
+$dest_dir = $force_install_dir
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # Install to $env:MY_ENV_VAR/My Axolotlsay Documents

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1421,7 +1421,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1653,6 +1653,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir"
+        _lib_install_dir="$_force_install_dir"
         _receipt_install_dir="$_install_dir"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $MY_ENV_VAR/My Axolotlsay Documents/bin
@@ -1410,6 +1420,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1420,10 +1440,10 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-$dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  if (($force_install_dir)) {
+$dest_dir = $force_install_dir
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # Install to $env:MY_ENV_VAR/My Axolotlsay Documents/bin

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1424,8 +1424,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1421,7 +1421,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1653,6 +1653,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -479,8 +479,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1437,8 +1437,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -474,16 +474,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir"
+        _lib_install_dir="$_force_install_dir"
         _receipt_install_dir="$_install_dir"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $NO_SUCH_ENV_VAR/My Nonexistent Documents
@@ -1423,6 +1433,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1433,10 +1453,10 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-$dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  if (($force_install_dir)) {
+$dest_dir = $force_install_dir
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # Install to $env:NO_SUCH_ENV_VAR/My Nonexistent Documents

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1434,7 +1434,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1674,6 +1674,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1424,8 +1424,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1421,7 +1421,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1653,6 +1653,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir"
+        _lib_install_dir="$_force_install_dir"
         _receipt_install_dir="$_install_dir"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $HOME/.axolotlsay/bins
@@ -1410,6 +1420,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1420,10 +1440,10 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-$dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  if (($force_install_dir)) {
+$dest_dir = $force_install_dir
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # Install to $HOME/.axolotlsay/bins

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir"
+        _lib_install_dir="$_force_install_dir"
         _receipt_install_dir="$_install_dir"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $HOME/.axolotlsay
@@ -1410,6 +1420,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1420,10 +1440,10 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-$dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  if (($force_install_dir)) {
+$dest_dir = $force_install_dir
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # Install to $HOME/.axolotlsay

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1424,8 +1424,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1421,7 +1421,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1653,6 +1653,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1424,8 +1424,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir"
+        _lib_install_dir="$_force_install_dir"
         _receipt_install_dir="$_install_dir"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $HOME/My Axolotlsay Documents
@@ -1410,6 +1420,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1420,10 +1440,10 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-$dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  if (($force_install_dir)) {
+$dest_dir = $force_install_dir
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # Install to $HOME/My Axolotlsay Documents

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1421,7 +1421,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1653,6 +1653,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -478,8 +478,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1424,8 +1424,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -473,16 +473,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir"
+        _lib_install_dir="$_force_install_dir"
         _receipt_install_dir="$_install_dir"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $HOME/My Axolotlsay Documents/bin
@@ -1410,6 +1420,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1420,10 +1440,10 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-$dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  if (($force_install_dir)) {
+$dest_dir = $force_install_dir
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # Install to $HOME/My Axolotlsay Documents/bin

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1421,7 +1421,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1653,6 +1653,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -474,16 +474,26 @@ install() {
     local _install_dir_expr
     # Potentially-late-bound version of env_script_path to write to rcfiles like $HOME/.profile
     local _env_script_path_expr
+    # Forces the install to occur at this path, not the default
+    local _force_install_dir
+
+    # Check the newer app-specific variable before falling back
+    # to the older generic one
+    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
-    if [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
-        _install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _lib_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+    if [ -n "${_force_install_dir:-}" ]; then
+        _install_dir="$_force_install_dir"
+        _lib_install_dir="$_force_install_dir"
         _receipt_install_dir="$_install_dir"
-        _env_script_path="$CARGO_DIST_FORCE_INSTALL_DIR/env"
-        _install_dir_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR")"
-        _env_script_path_expr="$(replace_home "$CARGO_DIST_FORCE_INSTALL_DIR/env")"
+        _env_script_path="$_force_install_dir/env"
+        _install_dir_expr="$(replace_home "$_force_install_dir")"
+        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $HOME/.axolotlsay
@@ -1423,6 +1433,16 @@ function Invoke-Installer($artifacts, $platforms) {
 
   $info = $platforms[$arch]
 
+  # Forces the install to occur at this path, not the default
+  $force_install_dir = null
+  # Check the newer app-specific variable before falling back
+  # to the older generic one
+  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
+    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  }
+
   # The actual path we're going to install to
   $dest_dir = $null
   $dest_dir_lib = $null
@@ -1433,10 +1453,10 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt_dest_dir = $null
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
-  if (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-$dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+  if (($force_install_dir)) {
+$dest_dir = $force_install_dir
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
     # Install to $HOME/.axolotlsay

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -479,8 +479,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "${AXOLOTLSAY_FORCE_INSTALL_DIR:-}" ]; then
-        _force_install_dir="$AXOLOTLSAY_FORCE_INSTALL_DIR"
+    if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
+        _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
     fi
@@ -1437,8 +1437,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_FORCE_INSTALL_DIR
+  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
+    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
   }

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1434,7 +1434,7 @@ function Invoke-Installer($artifacts, $platforms) {
   $info = $platforms[$arch]
 
   # Forces the install to occur at this path, not the default
-  $force_install_dir = null
+  $force_install_dir = $null
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_FORCE_INSTALL_DIR)) {

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1674,6 +1674,7 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
+      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -15,6 +15,7 @@ stdout:
     {
       "app_name": "cargo-dist-schema",
       "app_version": "1.0.0-FAKEVERSION",
+      "install_dir_env_var": "CARGO_DIST_SCHEMA_INSTALL_DIR",
       "hosting": {
         "github": {
           "artifact_download_url": "https://github.com/axodotdev/cargo-dist/releases/download/cargo-dist-schema-v1.0.0-FAKEVERSION",

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -15,6 +15,7 @@ stdout:
     {
       "app_name": "cargo-dist-schema",
       "app_version": "1.0.0-FAKEVERSION",
+      "install_dir_env_var": "CARGO_DIST_SCHEMA_INSTALL_DIR",
       "hosting": {
         "github": {
           "artifact_download_url": "https://github.com/axodotdev/cargo-dist/releases/download/cargo-dist-schema/v1.0.0-FAKEVERSION",

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -15,6 +15,7 @@ stdout:
     {
       "app_name": "cargo-dist",
       "app_version": "1.0.0-FAKEVERSION",
+      "install_dir_env_var": "CARGO_DIST_INSTALL_DIR",
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",


### PR DESCRIPTION
This supports a new app-specific force install environment variable. We use the app's name, uppercased and with `-` replaced by `_`. For example, if the app name is `akaikatana-repack`, the new force install environment variable becomes `AKAIKATANA_REPACK_FORCE_INSTALL_DIR`.

This supports the new variable alongside the old one. In the longterm, we could consider removing the old one after a transition period where both are supported.

An axolotlsay PR to use the new environment variable is here: https://github.com/axodotdev/axoupdater/pull/169

refs #1375.