### PR TITLE
release: 0.21.2-prerelease.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.21.1-prerelease.10/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.21.2-prerelease.1/cargo-dist-installer.sh | sh"
       - name: Cache cargo-dist
         uses: actions/upload-artifact@v4
         with:
@@ -298,6 +298,11 @@ jobs:
             filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
             name=$(echo "$filename" | sed "s/\.rb$//")
             version=$(echo "$release" | jq .app_version --raw-output)
+
+            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+            brew update
+            # We avoid reformatting user-provided data such as the app description and homepage.
+            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
 
             git add "Formula/${filename}"
             git commit -m "${name} ${version}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "0.21.2-prerelease.1"
+version = "0.21.2-prerelease.2"
 dependencies = [
  "axoasset",
  "axoprocess",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.21.2-prerelease.1"
+version = "0.21.2-prerelease.2"
 dependencies = [
  "axoasset",
  "axocli",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.21.2-prerelease.1"
+version = "0.21.2-prerelease.2"
 dependencies = [
  "camino",
  "gazenot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "0.22.0-prerelease.1"
+version = "0.21.2-prerelease.1"
 dependencies = [
  "axoasset",
  "axoprocess",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.22.0-prerelease.1"
+version = "0.21.2-prerelease.1"
 dependencies = [
  "axoasset",
  "axocli",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.22.0-prerelease.1"
+version = "0.21.2-prerelease.1"
 dependencies = [
  "camino",
  "gazenot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
 homepage = "https://opensource.axo.dev/cargo-dist/"
-version = "0.22.0-prerelease.1"
+version = "0.21.2-prerelease.1"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!
-cargo-dist-schema = { version = "=0.22.0-prerelease.1", path = "cargo-dist-schema" }
-axoproject = { version = "=0.22.0-prerelease.1", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
+cargo-dist-schema = { version = "=0.21.2-prerelease.1", path = "cargo-dist-schema" }
+axoproject = { version = "=0.21.2-prerelease.1", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
 
 # first-party deps
 axocli = { version = "0.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ publish = false
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.21.1-prerelease.10"
+cargo-dist-version = "0.21.2-prerelease.1"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
 homepage = "https://opensource.axo.dev/cargo-dist/"
-version = "0.21.2-prerelease.1"
+version = "0.21.2-prerelease.2"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!
-cargo-dist-schema = { version = "=0.21.2-prerelease.1", path = "cargo-dist-schema" }
-axoproject = { version = "=0.21.2-prerelease.1", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
+cargo-dist-schema = { version = "=0.21.2-prerelease.2", path = "cargo-dist-schema" }
+axoproject = { version = "=0.21.2-prerelease.2", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
 
 # first-party deps
 axocli = { version = "0.2.0" }


### PR DESCRIPTION
The previous release went out as 0.22.0, but we're currently targeting 0.21.2. The diff from the 0.22.0 release: https://github.com/axodotdev/cargo-dist/compare/v0.21.1..v0.22.0-prerelease.1

0.22.0-prerelease.1 contains SPDX and `brew style`, which are also contained in this prerelease.