### PR TITLE
Use a more recent version of Ubuntu as the Linux runner

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -497,7 +497,7 @@ fn distribute_targets_to_runners_split<'a>(
 /// A string representing a Github Runner
 type GithubRunner = String;
 /// The Github Runner to use for Linux
-const GITHUB_LINUX_RUNNER: &str = "ubuntu-20.04";
+const GITHUB_LINUX_RUNNER: &str = "ubuntu-24.04";
 /// The Github Runner to use for Intel macos
 const GITHUB_MACOS_INTEL_RUNNER: &str = "macos-13";
 /// The Github Runner to use for Apple Silicon macos


### PR DESCRIPTION
This PR updates the defaults so that it uses the latest LTS version of Ubuntu 24.04, instead of 20.04 which will be EOL'd next year.