### PR TITLE
chore(deps): axoupdater 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "axoupdater"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cd170d3b144de5288b99c69f30b36ee5eba837bed33f458f39c890e2049162"
+checksum = "fa6f92ef9ab41a352f403f709ef0f09cda1f461795de52085cd46ed831ead02e"
 dependencies = [
  "axoasset",
  "axoprocess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ axoproject = { version = "=0.22.1", path = "axoproject", default-features = fals
 
 # first-party deps
 axocli = { version = "0.2.0" }
-axoupdater = { version = "0.7.1" }
+axoupdater = { version = "0.7.2" }
 axotag = "0.2.0"
 axoasset = { version = "1.0.0", features = ["json-serde", "toml-serde", "toml-edit", "compression", "remote"] }
 axoprocess = { version = "0.2.0" }


### PR DESCRIPTION
This contains a bugfix for `cargo dist selfupdate` which would occur if the install receipt pointed to an installation directory that doesn't exist.