### PR TITLE
feat: unmanaged installs

### DIFF
--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -639,6 +639,34 @@ expression: json_schema
         }
       }
     },
+    "EnvironmentVariables": {
+      "description": "Release-specific environment variables",
+      "type": "object",
+      "required": [
+        "disable_update_env_var",
+        "install_dir_env_var",
+        "no_modify_path_env_var",
+        "unmanaged_dir_env_var"
+      ],
+      "properties": {
+        "disable_update_env_var": {
+          "description": "Environment variable to disable updater features",
+          "type": "string"
+        },
+        "install_dir_env_var": {
+          "description": "Environment variable to force an install location",
+          "type": "string"
+        },
+        "no_modify_path_env_var": {
+          "description": "Environment variable to disable modifying the path",
+          "type": "string"
+        },
+        "unmanaged_dir_env_var": {
+          "description": "Environment variable to force an unmanaged install location",
+          "type": "string"
+        }
+      }
+    },
     "GithubCiInfo": {
       "description": "Github CI backend",
       "type": "object",
@@ -970,19 +998,23 @@ expression: json_schema
             "null"
           ]
         },
+        "env": {
+          "description": "Environment variables which control this release's installer's behaviour",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EnvironmentVariables"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "hosting": {
           "description": "Hosting info",
           "allOf": [
             {
               "$ref": "#/definitions/Hosting"
             }
-          ]
-        },
-        "install_dir_env_var": {
-          "description": "Environment variable to force an install location",
-          "type": [
-            "string",
-            "null"
           ]
         }
       }

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -79,6 +79,12 @@ pub struct InstallerInfo {
     pub platform_support: Option<PlatformSupport>,
     /// Environment variable to force an install location
     pub install_dir_env_var: String,
+    /// Like the above, but for unmanaged installs
+    pub unmanaged_dir_env_var: String,
+    /// Environment variable to disable self-update features
+    pub disable_update_env_var: String,
+    /// Environment variable to disable modifying the path
+    pub no_modify_path_env_var: String,
 }
 
 /// A fake fragment of an ExecutableZip artifact for installers

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1684,10 +1684,16 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             .manifest
             .release_by_name(&release.app_name)
             .expect("couldn't find the release!?");
-        let install_dir_env_var = schema_release
-            .install_dir_env_var
-            .to_owned()
+
+        let env_vars = schema_release
+            .env
+            .as_ref()
             .expect("couldn't determine app-specific environment variable!?");
+        let install_dir_env_var = env_vars.install_dir_env_var.to_owned();
+        let unmanaged_dir_env_var = env_vars.unmanaged_dir_env_var.to_owned();
+        let disable_update_env_var = env_vars.disable_update_env_var.to_owned();
+        let no_modify_path_env_var = env_vars.no_modify_path_env_var.to_owned();
+
         let download_url = schema_release
             .artifact_download_url()
             .expect("couldn't compute a URL to download artifacts from!?");
@@ -1745,6 +1751,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 runtime_conditions,
                 platform_support: None,
                 install_dir_env_var,
+                unmanaged_dir_env_var,
+                disable_update_env_var,
+                no_modify_path_env_var,
             })),
             is_global: true,
         };
@@ -1907,6 +1916,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     platform_support: None,
                     // Not actually needed for this installer type
                     install_dir_env_var: String::new(),
+                    unmanaged_dir_env_var: String::new(),
+                    disable_update_env_var: String::new(),
+                    no_modify_path_env_var: String::new(),
                 },
                 install_libraries: config.install_libraries.clone(),
             })),
@@ -1933,10 +1945,16 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             .manifest
             .release_by_name(&release.app_name)
             .expect("couldn't find the release!?");
-        let install_dir_env_var = schema_release
-            .install_dir_env_var
-            .to_owned()
+
+        let env_vars = schema_release
+            .env
+            .as_ref()
             .expect("couldn't determine app-specific environment variable!?");
+        let install_dir_env_var = env_vars.install_dir_env_var.to_owned();
+        let unmanaged_dir_env_var = env_vars.unmanaged_dir_env_var.to_owned();
+        let disable_update_env_var = env_vars.disable_update_env_var.to_owned();
+        let no_modify_path_env_var = env_vars.no_modify_path_env_var.to_owned();
+
         let download_url = schema_release
             .artifact_download_url()
             .expect("couldn't compute a URL to download artifacts from!?");
@@ -1990,6 +2008,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 runtime_conditions: RuntimeConditions::default(),
                 platform_support: None,
                 install_dir_env_var,
+                unmanaged_dir_env_var,
+                disable_update_env_var,
+                no_modify_path_env_var,
             })),
             is_global: true,
         };
@@ -2104,6 +2125,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     platform_support: None,
                     // Not actually needed for this installer type
                     install_dir_env_var: String::new(),
+                    unmanaged_dir_env_var: String::new(),
+                    disable_update_env_var: String::new(),
+                    no_modify_path_env_var: String::new(),
                 },
             })),
             is_global: true,

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -61,7 +61,13 @@ if ($env:{{ disable_update_env_var }}) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:{{ no_modify_path_env_var }}) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:{{ unmanaged_dir_env_var }}
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -55,6 +55,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\{{ app_name }}"
 
+if ($env:{{ disable_update_env_var }}) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:{{ unmanaged_dir_env_var }}
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -219,7 +231,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\{{ app_name }}-update.exe"
@@ -248,12 +260,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:{{ install_dir_env_var }})) {
     $force_install_dir = $env:{{ install_dir_env_var }}
+    $flat_install_layout = {% if install_paths | selectattr("kind", "equalto", "CargoHome") -%} $false {%- else -%} $true {%- endif %}
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = {% if install_paths | selectattr("kind", "equalto", "CargoHome") -%} $false {%- else -%} $true {%- endif %}
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -267,13 +285,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-{% if install_paths| selectattr("kind", "equalto", "CargoHome") %}
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
-{%- else -%}
-    $dest_dir = $force_install_dir
-    $dest_dir_lib = $dest_dir
-{%- endif %}
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
 {%- for install_path in install_paths %}
@@ -361,13 +379,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/{{ app_name }}-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/{{ app_name }}-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -21,7 +21,22 @@ APP_VERSION="{{ app_version }}"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-{{ base_url }}}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "{{ '${' }}{{ no_modify_path_env_var }}:-}" ]; then
+    NO_MODIFY_PATH="${{ no_modify_path_env_var }}"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "{{ '${' }}{{ disable_update_env_var }}:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="{{ '${' }}{{ unmanaged_dir_env_var }}:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {{ receipt | tojson }}
 EORECEIPT
@@ -200,7 +215,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -241,12 +256,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -396,33 +416,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "{{ '${' }}{{ install_dir_env_var }}:-}" ]; then
         _force_install_dir="${{ install_dir_env_var }}"
+        _flat_install_layout={%- if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "0" {%- else -%} "1" {%- endif %}
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout={%- if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "0" {%- else -%} "1" {%- endif %}
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-    {%- if install_paths | selectattr("kind", "equalto", "CargoHome") %}
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-    {%- else %}
-        _install_dir="$_force_install_dir"
-        _lib_install_dir="$_force_install_dir"
-        _receipt_install_dir="$_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-    {%- endif %}
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
 
     {%- for install_path in install_paths %}

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.0"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AKAIKATANA_REPACK_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AKAIKATANA_REPACK_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AKAIKATANA_REPACK_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AKAIKATANA_REPACK_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
+if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AKAIKATANA_REPACK_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/akaikatana-repack-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/akaikatana-repack-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1685,7 +1745,12 @@ try {
     {
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
-      "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AKAIKATANA_REPACK_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH"
+      },
       "display_name": "akaikatana-repack",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1305,7 +1305,13 @@ if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AKAIKATANA_REPACK_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AKAIKATANA_REPACK_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.0"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AKAIKATANA_REPACK_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AKAIKATANA_REPACK_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AKAIKATANA_REPACK_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AKAIKATANA_REPACK_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -483,24 +503,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1169,7 +1205,12 @@ download_binary_and_run_installer "$@" || exit 1
     {
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
-      "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AKAIKATANA_REPACK_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH"
+      },
       "display_name": "akaikatana-repack",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1333,7 +1333,13 @@ if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AKAIKATANA_REPACK_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AKAIKATANA_REPACK_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.0"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AKAIKATANA_REPACK_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AKAIKATANA_REPACK_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AKAIKATANA_REPACK_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AKAIKATANA_REPACK_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -487,24 +507,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1291,6 +1327,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
+if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AKAIKATANA_REPACK_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1440,7 +1488,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
@@ -1469,12 +1517,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1488,9 +1542,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1558,13 +1616,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/akaikatana-repack-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/akaikatana-repack-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1715,7 +1775,12 @@ try {
     {
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
-      "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AKAIKATANA_REPACK_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH"
+      },
       "display_name": "akaikatana-repack",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1357,7 +1357,13 @@ if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AKAIKATANA_REPACK_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AKAIKATANA_REPACK_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.0"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AKAIKATANA_REPACK_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AKAIKATANA_REPACK_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AKAIKATANA_REPACK_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AKAIKATANA_REPACK_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -499,24 +519,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1315,6 +1351,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
+if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AKAIKATANA_REPACK_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1466,7 +1514,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
@@ -1495,12 +1543,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1514,9 +1568,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1584,13 +1642,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/akaikatana-repack-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/akaikatana-repack-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1741,7 +1801,12 @@ try {
     {
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
-      "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AKAIKATANA_REPACK_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH"
+      },
       "display_name": "akaikatana-repack",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.0"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AKAIKATANA_REPACK_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AKAIKATANA_REPACK_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AKAIKATANA_REPACK_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AKAIKATANA_REPACK_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
+if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AKAIKATANA_REPACK_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1418,7 +1466,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
@@ -1447,12 +1495,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1466,9 +1520,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1536,13 +1594,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/akaikatana-repack-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/akaikatana-repack-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1693,7 +1753,12 @@ try {
     {
       "app_name": "akaikatana-repack",
       "app_version": "0.2.0",
-      "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AKAIKATANA_REPACK_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH"
+      },
       "display_name": "akaikatana-repack",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1305,7 +1305,13 @@ if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AKAIKATANA_REPACK_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AKAIKATANA_REPACK_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3145,7 +3205,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -487,24 +507,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1291,6 +1327,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1440,7 +1488,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1469,12 +1517,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1488,9 +1542,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1558,13 +1616,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3178,7 +3238,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1333,7 +1333,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -487,24 +507,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1295,6 +1331,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1444,7 +1492,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1473,12 +1521,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1492,9 +1546,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1562,13 +1620,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3180,7 +3240,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1337,7 +1337,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1308,7 +1308,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1266,6 +1302,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1413,7 +1461,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1442,12 +1490,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1461,9 +1515,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1531,13 +1589,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3149,7 +3209,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1162,7 +1198,12 @@ download_binary_and_run_installer "$@" || exit 1
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1162,7 +1198,12 @@ download_binary_and_run_installer "$@" || exit 1
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1162,7 +1198,12 @@ download_binary_and_run_installer "$@" || exit 1
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1162,7 +1198,12 @@ download_binary_and_run_installer "$@" || exit 1
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -80,7 +80,12 @@ end
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -15,7 +15,12 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -15,7 +15,12 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -15,7 +15,12 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -14,7 +14,12 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1304,7 +1304,13 @@ if ($env:AXOLOTLSAY_JS_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_JS_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_JS_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false
@@ -3035,7 +3041,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.10.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_JS_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_JS_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_JS_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_JS_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_JS_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_JS_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1262,6 +1298,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay-js"
 
+if ($env:AXOLOTLSAY_JS_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_JS_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1409,7 +1457,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-js-update.exe"
@@ -1438,12 +1486,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_JS_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_JS_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1457,9 +1511,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1527,13 +1585,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-js-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-js-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1696,7 +1756,22 @@ APP_VERSION="0.10.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -1887,7 +1962,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -1928,12 +2003,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -2145,24 +2225,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -2933,6 +3029,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -3080,7 +3188,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -3109,12 +3217,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -3128,9 +3242,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -3198,13 +3316,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3355,7 +3475,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.10.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [
@@ -3384,7 +3509,12 @@ try {
     {
       "app_name": "axolotlsay-js",
       "app_version": "0.10.2",
-      "install_dir_env_var": "AXOLOTLSAY_JS_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_JS_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_JS_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_JS_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_JS_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay-js",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -483,24 +503,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -2623,7 +2659,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -205,7 +220,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -246,12 +261,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -463,24 +483,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -2603,7 +2639,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -15,7 +15,12 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -15,7 +15,12 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -487,24 +507,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1295,6 +1331,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1444,7 +1492,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1473,12 +1521,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1492,9 +1546,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1562,13 +1620,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3184,7 +3244,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1337,7 +1337,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1240,7 +1240,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1198,6 +1234,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1345,7 +1393,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1374,12 +1422,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1393,9 +1447,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1463,13 +1521,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1621,7 +1681,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1240,7 +1240,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1198,6 +1234,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1345,7 +1393,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1374,12 +1422,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1393,9 +1447,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1463,13 +1521,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1621,7 +1681,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -15,7 +15,12 @@ expression: self.payload
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1418,7 +1466,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1447,12 +1495,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1466,9 +1520,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1536,13 +1594,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3154,7 +3214,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -3146,7 +3206,12 @@ run("axolotlsay");
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1305,7 +1305,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="0"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="0"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir/bin"
-        _lib_install_dir="$_force_install_dir/bin"
-        _receipt_install_dir="$_force_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
@@ -1263,6 +1299,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1410,7 +1458,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1439,12 +1487,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $false
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $false
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1458,9 +1512,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-
-    $dest_dir = Join-Path $force_install_dir "bin"
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1528,13 +1586,15 @@ function Invoke-Installer($artifacts, $platforms) {
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1686,7 +1746,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1288,7 +1288,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="1"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="1"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir"
-        _lib_install_dir="$_force_install_dir"
-        _receipt_install_dir="$_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $MY_ENV_VAR
@@ -1246,6 +1282,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1393,7 +1441,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1422,12 +1470,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $true
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $true
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1441,8 +1495,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-$dest_dir = $force_install_dir
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1503,13 +1562,15 @@ $dest_dir = $force_install_dir
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1661,7 +1722,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1288,7 +1288,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="1"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="1"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir"
-        _lib_install_dir="$_force_install_dir"
-        _receipt_install_dir="$_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $MY_ENV_VAR/bin
@@ -1246,6 +1282,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1393,7 +1441,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1422,12 +1470,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $true
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $true
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1441,8 +1495,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-$dest_dir = $force_install_dir
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1503,13 +1562,15 @@ $dest_dir = $force_install_dir
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1661,7 +1722,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1288,7 +1288,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="1"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="1"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir"
-        _lib_install_dir="$_force_install_dir"
-        _receipt_install_dir="$_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $MY_ENV_VAR/My Axolotlsay Documents
@@ -1246,6 +1282,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1393,7 +1441,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1422,12 +1470,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $true
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $true
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1441,8 +1495,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-$dest_dir = $force_install_dir
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1503,13 +1562,15 @@ $dest_dir = $force_install_dir
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1661,7 +1722,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1288,7 +1288,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="1"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="1"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir"
-        _lib_install_dir="$_force_install_dir"
-        _receipt_install_dir="$_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $MY_ENV_VAR/My Axolotlsay Documents/bin
@@ -1246,6 +1282,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1393,7 +1441,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1422,12 +1470,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $true
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $true
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1441,8 +1495,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-$dest_dir = $force_install_dir
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1503,13 +1562,15 @@ $dest_dir = $force_install_dir
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1661,7 +1722,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1301,7 +1301,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -218,7 +233,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -259,12 +274,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -476,24 +496,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="1"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="1"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir"
-        _lib_install_dir="$_force_install_dir"
-        _receipt_install_dir="$_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $NO_SUCH_ENV_VAR/My Nonexistent Documents
@@ -1259,6 +1295,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1406,7 +1454,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1435,12 +1483,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $true
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $true
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1454,8 +1508,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-$dest_dir = $force_install_dir
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1524,13 +1583,15 @@ $dest_dir = $force_install_dir
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1682,7 +1743,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1288,7 +1288,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="1"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="1"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir"
-        _lib_install_dir="$_force_install_dir"
-        _receipt_install_dir="$_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $HOME/.axolotlsay/bins
@@ -1246,6 +1282,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1393,7 +1441,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1422,12 +1470,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $true
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $true
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1441,8 +1495,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-$dest_dir = $force_install_dir
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1503,13 +1562,15 @@ $dest_dir = $force_install_dir
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1661,7 +1722,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1288,7 +1288,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="1"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="1"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir"
-        _lib_install_dir="$_force_install_dir"
-        _receipt_install_dir="$_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $HOME/.axolotlsay
@@ -1246,6 +1282,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1393,7 +1441,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1422,12 +1470,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $true
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $true
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1441,8 +1495,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-$dest_dir = $force_install_dir
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1503,13 +1562,15 @@ $dest_dir = $force_install_dir
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1661,7 +1722,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1288,7 +1288,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="1"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="1"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir"
-        _lib_install_dir="$_force_install_dir"
-        _receipt_install_dir="$_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $HOME/My Axolotlsay Documents
@@ -1246,6 +1282,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1393,7 +1441,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1422,12 +1470,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $true
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $true
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1441,8 +1495,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-$dest_dir = $force_install_dir
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1503,13 +1562,15 @@ $dest_dir = $force_install_dir
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1661,7 +1722,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1288,7 +1288,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -217,7 +232,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -258,12 +273,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -475,24 +495,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="1"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="1"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir"
-        _lib_install_dir="$_force_install_dir"
-        _receipt_install_dir="$_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $HOME/My Axolotlsay Documents/bin
@@ -1246,6 +1282,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1393,7 +1441,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1422,12 +1470,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $true
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $true
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1441,8 +1495,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-$dest_dir = $force_install_dir
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1503,13 +1562,15 @@ $dest_dir = $force_install_dir
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1661,7 +1722,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -26,7 +26,22 @@ APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
+    NO_MODIFY_PATH="$AXOLOTLSAY_NO_MODIFY_PATH"
+else
+    NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
+fi
+if [ "${AXOLOTLSAY_DISABLE_UPDATE:-0}" = "1" ]; then
+    INSTALL_UPDATER=0
+else
+    INSTALL_UPDATER=1
+fi
+UNMANAGED_INSTALL="${AXOLOTLSAY_UNMANAGED_INSTALL:-}"
+if [ -n "${UNMANAGED_INSTALL}" ]; then
+    NO_MODIFY_PATH=1
+    INSTALL_UPDATER=0
+fi
+
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
@@ -218,7 +233,7 @@ download_binary_and_run_installer() {
     fi
 
     # ...and then the updater, if it exists
-    if [ -n "$_updater_name" ]; then
+    if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
@@ -259,12 +274,17 @@ download_binary_and_run_installer() {
     ignore rm -rf "$_dir"
 
     # Install the install receipt
-    mkdir -p "$RECEIPT_HOME" || {
-        err "unable to create receipt directory at $RECEIPT_HOME"
-    }
-    echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
-    # shellcheck disable=SC2320
-    local _retval=$?
+    if [ "$INSTALL_UPDATER" = "1" ]; then
+        if ! mkdir -p "$RECEIPT_HOME"; then
+            err "unable to create receipt directory at $RECEIPT_HOME"
+        else
+            echo "$RECEIPT" > "$RECEIPT_HOME/$APP_NAME-receipt.json"
+            # shellcheck disable=SC2320
+            local _retval=$?
+        fi
+    else
+        local _retval=0
+    fi
 
     return "$_retval"
 }
@@ -476,24 +496,40 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
+    # Installs all files into a single directory
+    local _flat_install_layout
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
+        _flat_install_layout="1"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
+        _flat_install_layout="1"
+    elif [ -n "$UNMANAGED_INSTALL" ]; then
+        _force_install_dir="$UNMANAGED_INSTALL"
+        _flat_install_layout="1"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        _install_dir="$_force_install_dir"
-        _lib_install_dir="$_force_install_dir"
-        _receipt_install_dir="$_install_dir"
-        _env_script_path="$_force_install_dir/env"
-        _install_dir_expr="$(replace_home "$_force_install_dir")"
-        _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        if [ "$_flat_install_layout" = "0" ]; then
+            _install_dir="$_force_install_dir/bin"
+            _lib_install_dir="$_force_install_dir/bin"
+            _receipt_install_dir="$_force_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        else
+            _install_dir="$_force_install_dir"
+            _lib_install_dir="$_force_install_dir"
+            _receipt_install_dir="$_install_dir"
+            _env_script_path="$_force_install_dir/env"
+            _install_dir_expr="$(replace_home "$_force_install_dir")"
+            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+        fi
     fi
     if [ -z "${_install_dir:-}" ]; then
         # Install to $HOME/.axolotlsay
@@ -1259,6 +1295,18 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
+if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
+  $install_updater = $false
+} else {
+  $install_updater = $true
+}
+
+$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+if ($unmanaged_install) {
+  $NoModifyPath = $true
+  $install_updater = $false
+}
+
 function Install-Binary($install_args) {
   if ($Help) {
     Get-Help $PSCommandPath -Detailed
@@ -1406,7 +1454,7 @@ function Download($download_url, $platforms) {
     $staticlib_paths += "$tmp\$lib_name"
   }
 
-  if ($null -ne $info["updater"]) {
+  if (($null -ne $info["updater"]) -and $install_updater) {
     $updater_id = $info["updater"]["artifact_name"]
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
@@ -1435,12 +1483,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
+  $flat_install_layout = $false
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
+    $flat_install_layout = $true
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
+    $flat_install_layout = $true
+  } elseif ($unmanaged_install) {
+    $force_install_dir = $unmanaged_install
+    $flat_install_layout = $true
   }
 
   # The actual path we're going to install to
@@ -1454,8 +1508,13 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-$dest_dir = $force_install_dir
-    $dest_dir_lib = $dest_dir
+    if (-not $flat_install_layout) {
+      $dest_dir = Join-Path $force_install_dir "bin"
+      $dest_dir_lib = $dest_dir
+    } else {
+      $dest_dir = $force_install_dir
+      $dest_dir_lib = $dest_dir
+    }
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
@@ -1524,13 +1583,15 @@ $dest_dir = $force_install_dir
   $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
 
   # Write the install receipt
-  $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-  # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-  # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-  # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-  # default in newer .NETs but I'd rather not rely on that at this point).
-  $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-  [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  if ($install_updater) {
+    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
+    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
+    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
+    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
+    # default in newer .NETs but I'd rather not rely on that at this point).
+    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
+  }
 
   # Respect the environment, but CLI takes precedence
   if ($null -eq $NoModifyPath) {
@@ -1682,7 +1743,12 @@ try {
     {
       "app_name": "axolotlsay",
       "app_version": "0.2.2",
-      "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
+        "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
+        "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+      },
       "display_name": "axolotlsay",
       "display": true,
       "artifacts": [

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1301,7 +1301,13 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
+$NoModifyPath = $false
+if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
+    $NoModifyPath = $true
+}
+
 $unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
+
 if ($unmanaged_install) {
   $NoModifyPath = $true
   $install_updater = $false

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -15,7 +15,12 @@ stdout:
     {
       "app_name": "cargo-dist-schema",
       "app_version": "1.0.0-FAKEVERSION",
-      "install_dir_env_var": "CARGO_DIST_SCHEMA_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "CARGO_DIST_SCHEMA_INSTALL_DIR",
+        "unmanaged_dir_env_var": "CARGO_DIST_SCHEMA_UNMANAGED_INSTALL",
+        "disable_update_env_var": "CARGO_DIST_SCHEMA_DISABLE_UPDATE",
+        "no_modify_path_env_var": "CARGO_DIST_SCHEMA_NO_MODIFY_PATH"
+      },
       "display_name": "cargo-dist-schema",
       "display": true,
       "hosting": {

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -15,7 +15,12 @@ stdout:
     {
       "app_name": "cargo-dist-schema",
       "app_version": "1.0.0-FAKEVERSION",
-      "install_dir_env_var": "CARGO_DIST_SCHEMA_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "CARGO_DIST_SCHEMA_INSTALL_DIR",
+        "unmanaged_dir_env_var": "CARGO_DIST_SCHEMA_UNMANAGED_INSTALL",
+        "disable_update_env_var": "CARGO_DIST_SCHEMA_DISABLE_UPDATE",
+        "no_modify_path_env_var": "CARGO_DIST_SCHEMA_NO_MODIFY_PATH"
+      },
       "display_name": "cargo-dist-schema",
       "display": true,
       "hosting": {

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -15,7 +15,12 @@ stdout:
     {
       "app_name": "cargo-dist",
       "app_version": "1.0.0-FAKEVERSION",
-      "install_dir_env_var": "CARGO_DIST_INSTALL_DIR",
+      "env": {
+        "install_dir_env_var": "CARGO_DIST_INSTALL_DIR",
+        "unmanaged_dir_env_var": "CARGO_DIST_UNMANAGED_INSTALL",
+        "disable_update_env_var": "CARGO_DIST_DISABLE_UPDATE",
+        "no_modify_path_env_var": "CARGO_DIST_NO_MODIFY_PATH"
+      },
       "display_name": "cargo-dist",
       "display": true,
       "artifacts": [


### PR DESCRIPTION
The new "unmanaged" installation mode allows for something close to "untar and move on" installations. It disables modifying the `PATH` and creation of environment files, and ensures all files are installed into a single flat directory no matter what other configuration is in place. It also disables installing a standalone updater and the creation of an install receipt.

The new "don't install an updater/receipt" behaviour is also controllable behind a new public environment variable, `$APPNAME_DISABLE_UPDATE`.

Fixes #1400.