### PR TITLE
feat: enable public migration

### DIFF
--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -276,7 +276,7 @@ pub struct InitArgs {
     #[clap(long, value_delimiter(','))]
     pub hosting: Vec<HostingStyle>,
     /// Opts into the new configuration format
-    #[clap(long, hide = true)]
+    #[clap(long)]
     pub opt_in_migrate: bool,
 }
 

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -175,6 +175,9 @@ Possible values:
 - github:    Host on Github Releases
 - axodotdev: Host on Axo Releases ("Abyss")
 
+#### `--opt-in-migrate`
+Opts into the new configuration format
+
 #### `-h, --help`
 Print help (see a summary with '-h')
 


### PR DESCRIPTION
* Publicizes the `--opt-in-migrate` flag, which was previously hidden.
* Leaves package-specific config alone in `[package.metadata.dist]`.

Fixes #1405.