### PR TITLE
feat: return an error for an invalid scope

### DIFF
--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -160,6 +160,13 @@ pub enum DistError {
     #[error("Cannot enable npm support without forcing artifacts to be .tar.gz")]
     MustEnableTarGz,
 
+    /// User supplied an illegal npm scope
+    #[error("The npm-scope field must be an all-lowercase value; the supplied value was {scope}")]
+    ScopeMustBeLowercase {
+        /// The incorrectly-formatted scope
+        scope: String,
+    },
+
     /// Completely unknown format to install-path
     ///
     /// NOTE: we can't use `diagnostic(help)` here because this will get crammed into

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -760,6 +760,8 @@ fn get_new_dist_metadata(
                         let v = v.trim();
                         if v.is_empty() {
                             Ok(())
+                        } else if v != v.to_ascii_lowercase() {
+                            Err("npm scopes must be lowercase")
                         } else if let Some(v) = v.strip_prefix('@') {
                             if v.is_empty() {
                                 Err("@ must be followed by something")

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -2016,6 +2016,12 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
 
         let app_name = config.package.clone();
         let npm_package_name = if let Some(scope) = &config.scope {
+            if scope.to_ascii_lowercase() != *scope {
+                return Err(DistError::ScopeMustBeLowercase {
+                    scope: scope.to_owned(),
+                });
+            }
+
             format!("{scope}/{}", app_name)
         } else {
             app_name.clone()


### PR DESCRIPTION
If the user supplies an npm scope with invalid characters, we should error out instead of accepting it. Accepting it means it will error out during publish instead.

Fixes #994.