### PR TITLE
feat: deprecate --no-modify-path

### DIFF
--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -61,7 +61,10 @@ if ($env:{{ disable_update_env_var }}) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set {{ no_modify_path_env_var }}=1 in the environment"
+}
+
 if ($env:{{ no_modify_path_env_var }}) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -109,6 +109,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set {{ no_modify_path_env_var }}=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AKAIKATANA_REPACK_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AKAIKATANA_REPACK_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AKAIKATANA_REPACK_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AKAIKATANA_REPACK_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AKAIKATANA_REPACK_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1333,7 +1334,10 @@ if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AKAIKATANA_REPACK_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AKAIKATANA_REPACK_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AKAIKATANA_REPACK_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1357,7 +1358,10 @@ if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AKAIKATANA_REPACK_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AKAIKATANA_REPACK_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AKAIKATANA_REPACK_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AKAIKATANA_REPACK_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AKAIKATANA_REPACK_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AKAIKATANA_REPACK_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1333,7 +1334,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1337,7 +1338,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1308,7 +1309,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_JS_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1304,7 +1305,10 @@ if ($env:AXOLOTLSAY_JS_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_JS_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_JS_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }
@@ -1841,6 +1845,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -3041,7 +3046,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1337,7 +1338,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1240,7 +1241,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1240,7 +1241,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1305,7 +1306,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1288,7 +1289,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1288,7 +1289,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1288,7 +1289,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1288,7 +1289,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -106,6 +106,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1301,7 +1302,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1288,7 +1289,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1288,7 +1289,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1288,7 +1289,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -105,6 +105,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1288,7 +1289,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -106,6 +106,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
+                say "--no-modify-path has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -1301,7 +1302,10 @@ if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
   $install_updater = $true
 }
 
-$NoModifyPath = $false
+if ($NoModifyPath) {
+    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
+}
+
 if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
     $NoModifyPath = $true
 }


### PR DESCRIPTION
We're moving installer options to the environment. The other options largely already live here, so this move is just for consistency.

We can print this warning for a major release or two before removing these.