### PR TITLE
feat: track install layout in receipt

### DIFF
--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -2979,6 +2979,8 @@ pub enum InstallLayout {
     Flat,
     /// Separated into file type-specific directories
     Hierarchical,
+    /// Like Hierarchical, but with only a bin subdirectory
+    CargoHome,
 }
 
 /// Struct representing an install receipt

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -2969,11 +2969,25 @@ pub struct Provider {
     pub version: String,
 }
 
+/// Which style of installation layout this app uses
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InstallLayout {
+    /// Not specified; will be determined later
+    Unspecified,
+    /// All files are in a single directory
+    Flat,
+    /// Separated into file type-specific directories
+    Hierarchical,
+}
+
 /// Struct representing an install receipt
 #[derive(Clone, Debug, Serialize)]
 pub struct InstallReceipt {
     /// The location on disk where this app was installed
     pub install_prefix: String,
+    /// The layout within the above prefix
+    pub install_layout: InstallLayout,
     /// A list of all binaries installed by this app
     pub binaries: Vec<String>,
     /// A list of all C dynamic libraries installed by this app
@@ -3005,8 +3019,9 @@ impl InstallReceipt {
         };
 
         Some(InstallReceipt {
-            // These first two are placeholder values which the installer will update
+            // These first five are placeholder values which the installer will update
             install_prefix: "AXO_INSTALL_PREFIX".to_owned(),
+            install_layout: InstallLayout::Unspecified,
             binaries: vec!["CARGO_DIST_BINS".to_owned()],
             cdylibs: vec!["CARGO_DIST_DYLIBS".to_owned()],
             cstaticlibs: vec!["CARGO_DIST_STATICLIBS".to_owned()],

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -271,10 +271,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:{{ install_dir_env_var }})) {
     $force_install_dir = $env:{{ install_dir_env_var }}
-    $install_layout = {% if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "hierarchical" {%- else -%} "flat" {%- endif %}
+    $install_layout = {% if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "cargo-home" {%- else -%} "flat" {%- endif %}
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = {% if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "hierarchical" {%- else -%} "flat" {%- endif %}
+    $install_layout = {% if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "cargo-home" {%- else -%} "flat" {%- endif %}
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -291,7 +291,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -316,7 +316,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
 {%- elif install_path.kind == "HomeSubdir" %}
     # Install to $HOME/{{ install_path.subdir }}
     $dest_dir = if (($base_dir = $HOME)) {

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -291,12 +291,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -266,18 +266,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:{{ install_dir_env_var }})) {
     $force_install_dir = $env:{{ install_dir_env_var }}
-    $flat_install_layout = {% if install_paths | selectattr("kind", "equalto", "CargoHome") -%} $false {%- else -%} $true {%- endif %}
+    $install_layout = {% if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "hierarchical" {%- else -%} "flat" {%- endif %}
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = {% if install_paths | selectattr("kind", "equalto", "CargoHome") -%} $false {%- else -%} $true {%- endif %}
+    $install_layout = {% if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "hierarchical" {%- else -%} "flat" {%- endif %}
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -291,7 +291,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -316,6 +316,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
 {%- elif install_path.kind == "HomeSubdir" %}
     # Install to $HOME/{{ install_path.subdir }}
     $dest_dir = if (($base_dir = $HOME)) {
@@ -323,6 +324,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
 {%- elif install_path.kind == "EnvSubdir" %}
     # Install to $env:{{ install_path.env_key }}{% if install_path.subdir | length %}/{% endif %}{{ install_path.subdir }}
     $dest_dir = if (($base_dir = $env:{{ install_path.env_key }})) {
@@ -330,6 +332,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
 {%- else %}
     {{ error("unimplemented install_path format: " ~ install_path.kind) }}
 {%- endif %}
@@ -343,6 +346,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -435,21 +435,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
 
     {%- for install_path in install_paths %}

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -423,10 +423,10 @@ install() {
     # to the older generic one
     if [ -n "{{ '${' }}{{ install_dir_env_var }}:-}" ]; then
         _force_install_dir="${{ install_dir_env_var }}"
-        _install_layout={%- if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "hierarchical" {%- else -%} "flat" {%- endif %}
+        _install_layout={%- if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "cargo-home" {%- else -%} "flat" {%- endif %}
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout={%- if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "hierarchical" {%- else -%} "flat" {%- endif %}
+        _install_layout={%- if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "cargo-home" {%- else -%} "flat" {%- endif %}
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -435,7 +435,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -455,7 +455,7 @@ install() {
     {%- for install_path in install_paths %}
     if [ -z "${_install_dir:-}" ]; then
     {%- if install_path.kind == "CargoHome" %}
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -416,26 +416,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "{{ '${' }}{{ install_dir_env_var }}:-}" ]; then
         _force_install_dir="${{ install_dir_env_var }}"
-        _flat_install_layout={%- if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "0" {%- else -%} "1" {%- endif %}
+        _install_layout={%- if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "hierarchical" {%- else -%} "flat" {%- endif %}
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout={%- if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "0" {%- else -%} "1" {%- endif %}
+        _install_layout={%- if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "hierarchical" {%- else -%} "flat" {%- endif %}
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -455,6 +455,7 @@ install() {
     {%- for install_path in install_paths %}
     if [ -z "${_install_dir:-}" ]; then
     {%- if install_path.kind == "CargoHome" %}
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -482,6 +483,7 @@ install() {
             _env_script_path_expr='$HOME/.cargo/env'
         fi
     {%- elif install_path.kind == "HomeSubdir" %}
+        _install_layout="flat"
         # Install to $HOME/{{ install_path.subdir }}
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/{{ install_path.subdir }}"
@@ -492,6 +494,7 @@ install() {
             _env_script_path_expr='$HOME/{{ install_path.subdir }}/env'
         fi
     {%- elif install_path.kind == "EnvSubdir" %}
+        _install_layout="flat"
         # Install to ${{ install_path.env_key }}{% if install_path.subdir | length %}/{% endif %}{{ install_path.subdir }}
         if [ -n "{{ "${" }}{{ install_path.env_key }}:-}" ]; then
             _install_dir="${{ install_path.env_key }}{% if install_path.subdir | length %}/{% endif %}{{ install_path.subdir }}"
@@ -521,6 +524,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -522,21 +522,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -510,10 +510,10 @@ install() {
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -522,7 +522,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -539,7 +539,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -503,26 +503,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -539,6 +539,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -581,6 +582,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -514,10 +514,10 @@ install() {
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -526,7 +526,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -543,7 +543,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1531,10 +1531,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1551,7 +1551,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1574,7 +1574,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -507,26 +507,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -543,6 +543,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -585,6 +586,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1323,7 +1326,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1523,18 +1526,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1548,7 +1551,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1571,6 +1574,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1580,6 +1584,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -526,21 +526,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1551,12 +1565,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -538,21 +538,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1577,12 +1591,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -526,10 +526,10 @@ install() {
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -538,7 +538,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -555,7 +555,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1557,10 +1557,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1577,7 +1577,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1600,7 +1600,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -519,26 +519,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -555,6 +555,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -597,6 +598,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1347,7 +1350,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1549,18 +1552,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1574,7 +1577,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1597,6 +1600,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1606,6 +1610,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1509,10 +1509,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1529,7 +1529,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1552,7 +1552,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1529,12 +1543,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/akaikatana-repack"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AKAIKATANA_REPACK_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AKAIKATANA_REPACK_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\akaikatana-repack"
 
@@ -1501,18 +1504,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AKAIKATANA_REPACK_INSTALL_DIR)) {
     $force_install_dir = $env:AKAIKATANA_REPACK_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1526,7 +1529,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1549,6 +1552,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1558,6 +1562,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -507,26 +507,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -543,6 +543,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -585,6 +586,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1323,7 +1326,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1523,18 +1526,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1548,7 +1551,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1571,6 +1574,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1580,6 +1584,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -526,21 +526,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1551,12 +1565,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -514,10 +514,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -526,7 +526,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -543,7 +543,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1531,10 +1531,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1551,7 +1551,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1574,7 +1574,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -526,21 +526,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1555,12 +1569,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -514,10 +514,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -526,7 +526,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -543,7 +543,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1535,10 +1535,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1555,7 +1555,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1578,7 +1578,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -507,26 +507,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -543,6 +543,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -585,6 +586,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1327,7 +1330,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1527,18 +1530,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1552,7 +1555,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1575,6 +1578,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1584,6 +1588,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1504,10 +1504,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1524,7 +1524,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1547,7 +1547,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1524,12 +1538,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1298,7 +1301,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1496,18 +1499,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1521,7 +1524,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,6 +1547,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1553,6 +1557,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay-js"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_JS_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_JS_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1294,7 +1297,7 @@ $app_name = 'axolotlsay-js'
 $app_version = '0.10.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay-js"
 
@@ -1492,18 +1495,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_JS_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_JS_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1517,7 +1520,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1540,6 +1543,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1549,6 +1553,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
@@ -1779,7 +1784,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -2231,26 +2236,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -2267,6 +2272,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -2309,6 +2315,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -3031,7 +3039,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.10.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -3229,18 +3237,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -3254,7 +3262,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -3277,6 +3285,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -3286,6 +3295,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_JS_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_JS_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1500,10 +1500,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_JS_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_JS_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1520,7 +1520,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1543,7 +1543,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed
@@ -2243,10 +2243,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -2255,7 +2255,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -2272,7 +2272,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -3242,10 +3242,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -3262,7 +3262,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -3285,7 +3285,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1520,12 +1534,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }
@@ -2255,21 +2279,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -3262,12 +3300,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -503,26 +503,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -539,6 +539,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -581,6 +582,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -522,21 +522,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -510,10 +510,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -522,7 +522,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -539,7 +539,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -490,10 +490,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -502,7 +502,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -519,7 +519,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -502,21 +502,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -483,26 +483,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -519,6 +519,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -561,6 +562,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -526,21 +526,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1555,12 +1569,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -514,10 +514,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -526,7 +526,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -543,7 +543,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1535,10 +1535,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1555,7 +1555,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1578,7 +1578,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -507,26 +507,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -543,6 +543,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -585,6 +586,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1327,7 +1330,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1527,18 +1530,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1552,7 +1555,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1575,6 +1578,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1584,6 +1588,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1456,12 +1470,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1436,10 +1436,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1456,7 +1456,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1479,7 +1479,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1230,7 +1233,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1428,18 +1431,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1453,7 +1456,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1476,6 +1479,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1485,6 +1489,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1456,12 +1470,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1436,10 +1436,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1456,7 +1456,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1479,7 +1479,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1230,7 +1233,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1428,18 +1431,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1453,7 +1456,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1476,6 +1479,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1485,6 +1489,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1501,18 +1504,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1526,7 +1529,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1549,6 +1552,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1558,6 +1562,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1509,10 +1509,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1529,7 +1529,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1552,7 +1552,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1529,12 +1543,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -502,10 +502,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,7 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="hierarchical"
+        _install_layout="cargo-home"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -1501,10 +1501,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1521,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1544,7 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
-    $install_layout = "hierarchical"
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="cargo-home"
@@ -1521,12 +1535,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="0"
+        _install_layout="hierarchical"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="hierarchical"
         # first try $CARGO_HOME, then fallback to $HOME/.cargo
         if [ -n "${CARGO_HOME:-}" ]; then
             _receipt_install_dir="$CARGO_HOME"
@@ -573,6 +574,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1295,7 +1298,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1493,18 +1496,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $false
+    $install_layout = "hierarchical"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1518,7 +1521,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1541,6 +1544,7 @@ function Invoke-Installer($artifacts, $platforms) {
     $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $root
+    $install_layout = "hierarchical"
   }
 
   # Looks like all of the above assignments failed
@@ -1550,6 +1554,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $MY_ENV_VAR
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR"
@@ -556,6 +557,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1278,7 +1281,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1476,18 +1479,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1501,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1517,6 +1520,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
 
   # Looks like all of the above assignments failed
@@ -1526,6 +1530,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="flat"
@@ -1504,12 +1518,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -1504,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="flat"
@@ -1504,12 +1518,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $MY_ENV_VAR/bin
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR/bin"
@@ -556,6 +557,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1278,7 +1281,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1476,18 +1479,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1501,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1517,6 +1520,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
 
   # Looks like all of the above assignments failed
@@ -1526,6 +1530,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -1504,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $MY_ENV_VAR/My Axolotlsay Documents
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR/My Axolotlsay Documents"
@@ -556,6 +557,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1278,7 +1281,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1476,18 +1479,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1501,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1517,6 +1520,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
 
   # Looks like all of the above assignments failed
@@ -1526,6 +1530,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="flat"
@@ -1504,12 +1518,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -1504,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $MY_ENV_VAR/My Axolotlsay Documents/bin
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR/My Axolotlsay Documents/bin"
@@ -556,6 +557,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1278,7 +1281,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1476,18 +1479,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1501,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1517,6 +1520,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
 
   # Looks like all of the above assignments failed
@@ -1526,6 +1530,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="flat"
@@ -1504,12 +1518,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -1504,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -515,21 +515,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="flat"
@@ -1518,12 +1532,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -496,26 +496,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -532,6 +532,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $NO_SUCH_ENV_VAR/My Nonexistent Documents
         if [ -n "${NO_SUCH_ENV_VAR:-}" ]; then
             _install_dir="$NO_SUCH_ENV_VAR/My Nonexistent Documents"
@@ -543,6 +544,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $MY_ENV_VAR/My Axolotlsay Documents
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR/My Axolotlsay Documents"
@@ -568,6 +570,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1291,7 +1295,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1489,18 +1493,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1514,7 +1518,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1530,6 +1534,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
   if (-Not $dest_dir) {
     # Install to $env:MY_ENV_VAR/My Axolotlsay Documents
@@ -1538,6 +1543,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
 
   # Looks like all of the above assignments failed
@@ -1547,6 +1553,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -515,7 +515,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -1518,7 +1518,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="flat"
@@ -1504,12 +1518,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $HOME/.axolotlsay/bins
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/.axolotlsay/bins"
@@ -556,6 +557,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1278,7 +1281,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1476,18 +1479,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1501,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1517,6 +1520,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
 
   # Looks like all of the above assignments failed
@@ -1526,6 +1530,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -1504,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $HOME/.axolotlsay
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/.axolotlsay"
@@ -556,6 +557,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1278,7 +1281,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1476,18 +1479,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1501,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1517,6 +1520,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
 
   # Looks like all of the above assignments failed
@@ -1526,6 +1530,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="flat"
@@ -1504,12 +1518,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -1504,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="flat"
@@ -1504,12 +1518,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $HOME/My Axolotlsay Documents
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/My Axolotlsay Documents"
@@ -556,6 +557,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1278,7 +1281,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1476,18 +1479,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1501,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1517,6 +1520,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
 
   # Looks like all of the above assignments failed
@@ -1526,6 +1530,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -1504,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -495,26 +495,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -531,6 +531,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $HOME/My Axolotlsay Documents/bin
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/My Axolotlsay Documents/bin"
@@ -556,6 +557,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1278,7 +1281,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1476,18 +1479,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1501,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1517,6 +1520,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
 
   # Looks like all of the above assignments failed
@@ -1526,6 +1530,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -514,21 +514,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="flat"
@@ -1504,12 +1518,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -514,7 +514,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -1504,7 +1504,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -515,21 +515,35 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
-            _install_dir="$_force_install_dir/bin"
-            _lib_install_dir="$_force_install_dir/bin"
-            _receipt_install_dir="$_force_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        else
-            _install_dir="$_force_install_dir"
-            _lib_install_dir="$_force_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$_force_install_dir/env"
-            _install_dir_expr="$(replace_home "$_force_install_dir")"
-            _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
-        fi
+        case "$_install_layout" in
+            "hierarchical")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/lib"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "cargo-home")
+                _install_dir="$_force_install_dir/bin"
+                _lib_install_dir="$_force_install_dir/bin"
+                _receipt_install_dir="$_force_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir/bin")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            "flat")
+                _install_dir="$_force_install_dir"
+                _lib_install_dir="$_force_install_dir"
+                _receipt_install_dir="$_install_dir"
+                _env_script_path="$_force_install_dir/env"
+                _install_dir_expr="$(replace_home "$_force_install_dir")"
+                _env_script_path_expr="$(replace_home "$_force_install_dir/env")"
+                ;;
+            *)
+                err "Unrecognized install layout: $_install_layout"
+                ;;
+        esac
     fi
     if [ -z "${_install_dir:-}" ]; then
         _install_layout="flat"
@@ -1518,12 +1532,22 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
-      $dest_dir = Join-Path $force_install_dir "bin"
-      $dest_dir_lib = $dest_dir
-    } else {
-      $dest_dir = $force_install_dir
-      $dest_dir_lib = $dest_dir
+    switch ($install_layout) {
+      "hierarchical" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = Join-Path $force_install_dir "lib"
+      }
+      "cargo-home" {
+        $dest_dir = Join-Path $force_install_dir "bin"
+        $dest_dir_lib = $dest_dir
+      }
+      "flat" {
+        $dest_dir = $force_install_dir
+        $dest_dir_lib = $dest_dir
+      }
+      Default {
+        throw "Error: unrecognized installation layout: $install_layout"
+      }
     }
     $receipt_dest_dir = $force_install_dir
   }

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -43,7 +43,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 # Are we happy with this same path on Linux and Mac?
 RECEIPT_HOME="${HOME}/.config/axolotlsay"
@@ -496,26 +496,26 @@ install() {
     local _env_script_path_expr
     # Forces the install to occur at this path, not the default
     local _force_install_dir
-    # Installs all files into a single directory
-    local _flat_install_layout
+    # Which install layout to use - "flat" or "hierarchical"
+    local _install_layout="unspecified"
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _flat_install_layout="1"
+        _install_layout="flat"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
-        _flat_install_layout="1"
+        _install_layout="flat"
     fi
 
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_flat_install_layout" = "0" ]; then
+        if [ "$_install_layout" = "hierarchical" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -532,6 +532,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $HOME/.axolotlsay
         if [ -n "${HOME:-}" ]; then
             _install_dir="$HOME/.axolotlsay"
@@ -543,6 +544,7 @@ install() {
         fi
     fi
     if [ -z "${_install_dir:-}" ]; then
+        _install_layout="flat"
         # Install to $MY_ENV_VAR/My Axolotlsay Documents/bin
         if [ -n "${MY_ENV_VAR:-}" ]; then
             _install_dir="$MY_ENV_VAR/My Axolotlsay Documents/bin"
@@ -568,6 +570,8 @@ install() {
     RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
+    # And replace the install layout
+    RECEIPT=$(echo "$RECEIPT" | sed "s'\"install_layout\":\"unspecified\"'\"install_layout\":\"$_install_layout\"'")
 
     say "installing to $_install_dir"
     ensure mkdir -p "$_install_dir"
@@ -1291,7 +1295,7 @@ $app_name = 'axolotlsay'
 $app_version = '0.2.2'
 
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 $receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
 
@@ -1489,18 +1493,18 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # Forces the install to occur at this path, not the default
   $force_install_dir = $null
-  $flat_install_layout = $false
+  $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $flat_install_layout = $true
+    $install_layout = "flat"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
-    $flat_install_layout = $true
+    $install_layout = "flat"
   }
 
   # The actual path we're going to install to
@@ -1514,7 +1518,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if (-not $flat_install_layout) {
+    if ($install_layout -eq "hierarchical") {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {
@@ -1530,6 +1534,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
   if (-Not $dest_dir) {
     # Install to $env:MY_ENV_VAR/My Axolotlsay Documents/bin
@@ -1538,6 +1543,7 @@ function Invoke-Installer($artifacts, $platforms) {
     }
     $dest_dir_lib = $dest_dir
     $receipt_dest_dir = $dest_dir
+    $install_layout = "flat"
   }
 
   # Looks like all of the above assignments failed
@@ -1547,6 +1553,7 @@ function Invoke-Installer($artifacts, $platforms) {
 
   # The replace call here ensures proper escaping is inlined into the receipt
   $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
+  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
 
   $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
   $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -515,7 +515,7 @@ install() {
     # Before actually consulting the configured install strategy, see
     # if we're overriding it.
     if [ -n "${_force_install_dir:-}" ]; then
-        if [ "$_install_layout" = "hierarchical" ]; then
+        if [ "$_install_layout" = "hierarchical" ] || [ "$_install_layout" = "cargo-home" ]; then
             _install_dir="$_force_install_dir/bin"
             _lib_install_dir="$_force_install_dir/bin"
             _receipt_install_dir="$_force_install_dir"
@@ -1518,7 +1518,7 @@ function Invoke-Installer($artifacts, $platforms) {
   # Before actually consulting the configured install strategy, see
   # if we're overriding it.
   if (($force_install_dir)) {
-    if ($install_layout -eq "hierarchical") {
+    if (($install_layout -eq "hierarchical") -or ($install_layout -eq "cargo-home")) {
       $dest_dir = Join-Path $force_install_dir "bin"
       $dest_dir_lib = $dest_dir
     } else {


### PR DESCRIPTION
In preparation for allowing this to be configured by devs and overridden by users, this starts tracking the installation layout in install receipts. Doing this makes sure we can tell the updater what layout to use in the future, even if the desired layout isn't the default for the software.

Right now we have two kinds:
* "flat" - all files in a single directory
* "hierarchical" - files separated into subdirectories
* "cargo-home" - like hierarchical, but with only a "bin" subdirectory