### PR TITLE
fix(ci): always serialize upload_files

### DIFF
--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -106,7 +106,8 @@ pub struct DistManifest {
     pub linkage: Vec<Linkage>,
     /// Files to upload
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    // We need to make sure we always serialize this when it's empty,
+    // because we index into this array unconditionally during upload.
     pub upload_files: Vec<String>,
     /// Whether Artifact Attestations should be found in the GitHub Release
     ///

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -127,6 +127,7 @@ expression: json_schema
     },
     "upload_files": {
       "description": "Files to upload",
+      "default": [],
       "type": "array",
       "items": {
         "type": "string"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -2065,7 +2065,8 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1494,7 +1494,8 @@ download_binary_and_run_installer "$@" || exit 1
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -2095,7 +2095,8 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -2121,7 +2121,8 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -2105,7 +2105,8 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3677,6 +3677,7 @@ run("axolotlsay");
     }
   },
   "linkage": [],
+  "upload_files": [],
   "github_attestations": true
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3670,7 +3670,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3700,7 +3700,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3702,7 +3702,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3668,7 +3668,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3764,7 +3764,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -3668,7 +3668,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1477,7 +1477,8 @@ download_binary_and_run_installer "$@" || exit 1
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1477,7 +1477,8 @@ download_binary_and_run_installer "$@" || exit 1
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1477,7 +1477,8 @@ download_binary_and_run_installer "$@" || exit 1
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1477,7 +1477,8 @@ download_binary_and_run_installer "$@" || exit 1
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -359,7 +359,8 @@ end
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -283,7 +283,8 @@ expression: self.payload
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3657,7 +3657,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -281,7 +281,8 @@ expression: self.payload
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -289,7 +289,8 @@ expression: self.payload
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -283,7 +283,8 @@ expression: self.payload
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3590,7 +3590,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -4016,7 +4016,8 @@ try {
       "pr_run_mode": "upload"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3670,7 +3670,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -3011,7 +3011,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2937,7 +2937,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3590,7 +3590,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -281,7 +281,8 @@ expression: self.payload
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -281,7 +281,8 @@ expression: self.payload
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3706,7 +3706,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -2058,7 +2058,8 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -2058,7 +2058,8 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -281,7 +281,8 @@ expression: self.payload
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ owo-release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3708,7 +3708,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3590,7 +3590,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3590,7 +3590,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3590,7 +3590,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3590,7 +3590,8 @@ run("axolotlsay");
       "pr_run_mode": "upload"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3590,7 +3590,8 @@ run("axolotlsay");
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }
 
 ================ release.yml ================

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -2058,5 +2058,6 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -2034,5 +2034,6 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -2034,5 +2034,6 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -2034,5 +2034,6 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -2034,5 +2034,6 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -2055,5 +2055,6 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -2034,5 +2034,6 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -2034,5 +2034,6 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -2034,5 +2034,6 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -2034,5 +2034,6 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -2055,5 +2055,6 @@ try {
       "pr_run_mode": "plan"
     }
   },
-  "linkage": []
+  "linkage": [],
+  "upload_files": []
 }

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -56,6 +56,7 @@ stdout:
     }
   },
   "linkage": [],
+  "upload_files": [],
   "github_attestations": true
 }
 

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -56,6 +56,7 @@ stdout:
     }
   },
   "linkage": [],
+  "upload_files": [],
   "github_attestations": true
 }
 

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -506,6 +506,7 @@ stdout:
     }
   },
   "linkage": [],
+  "upload_files": [],
   "github_attestations": true
 }
 


### PR DESCRIPTION
While it's usually an error if we received a totally empty set of artifacts, it's possible in the global build job under a very specific set of conditions:

* There are no installers, *and*
* The source tarball was disabled

In this case we need to make sure we still provide an upload_files array in the manifest so that we can always index into it.

Fixes #1387.