### PR TITLE
feat: support any format in npm

### DIFF
--- a/book/src/installers/npm.md
+++ b/book/src/installers/npm.md
@@ -80,11 +80,4 @@ npm-package = "cli"
 You'll end up publish the binaries in "axolotlsay" to an npm package called "@axodotdev/cli".
 
 
-## Limitations and Caveats
-
-The current implementation can only [unpack `.tar.gz` archives][issue-unpacking]. As a result, `cargo dist init` will prompt you to change [windows-archive][config-windows-archive] and [unix-archive][config-unix-archive] to ".tar.gz" if you enable the npm installer, erroring if you decline.
-
 [artifact-url]: ../reference/artifact-url.md
-[config-windows-archive]: ../reference/config.md#windows-archive
-[config-unix-archive]: ../reference/config.md#unix-archive
-[issue-unpacking]: https://github.com/axodotdev/cargo-dist/issues/226

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -156,10 +156,6 @@ pub enum DistError {
         inner: AxoprojectError,
     },
 
-    /// User declined to force tar.gz with npm
-    #[error("Cannot enable npm support without forcing artifacts to be .tar.gz")]
-    MustEnableTarGz,
-
     /// User supplied an illegal npm scope
     #[error("The npm-scope field must be an all-lowercase value; the supplied value was {scope}")]
     ScopeMustBeLowercase {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -7,8 +7,8 @@ use serde::Deserialize;
 
 use crate::{
     config::{
-        self, CiStyle, CompressionImpl, Config, DistMetadata, HostingStyle, InstallPathStrategy,
-        InstallerStyle, MacPkgConfig, PublishStyle, ZipStyle,
+        self, CiStyle, Config, DistMetadata, HostingStyle, InstallPathStrategy, InstallerStyle,
+        MacPkgConfig, PublishStyle,
     },
     do_generate,
     errors::{DistError, DistResult},
@@ -785,31 +785,6 @@ fn get_new_dist_metadata(
                 eprintln!("{check} npm packages will be published under {scope}");
             }
             eprintln!();
-        }
-
-        // FIXME (#226): If they have an npm installer, force on tar.gz compression
-        const TAR_GZ: Option<ZipStyle> = Some(ZipStyle::Tar(CompressionImpl::Gzip));
-        if meta.unix_archive != TAR_GZ || meta.windows_archive != TAR_GZ {
-            let prompt = r#"the npm installer requires binaries to be distributed as .tar.gz, is that ok?
-    otherwise we would distribute your binaries as .zip on windows, .tar.xz everywhere else
-    (this is a hopefully temporary limitation of the npm installer's implementation)"#;
-            let default = true;
-            let force_targz = if args.yes {
-                default
-            } else {
-                let res = Confirm::with_theme(&theme)
-                    .with_prompt(prompt)
-                    .default(default)
-                    .interact()?;
-                eprintln!();
-                res
-            };
-            if force_targz {
-                meta.unix_archive = TAR_GZ;
-                meta.windows_archive = TAR_GZ;
-            } else {
-                Err(DistError::MustEnableTarGz)?;
-            }
         }
     }
 

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -2071,13 +2071,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             .iter()
             .map(|a| a.target_triple.clone())
             .collect::<Vec<_>>();
-        let has_sketchy_archives = artifacts
-            .iter()
-            .any(|a| a.zip_style != ZipStyle::Tar(CompressionImpl::Gzip));
 
-        if has_sketchy_archives {
-            warn!("the npm installer currently only knows how to unpack .tar.gz archives\n  consider setting windows-archive and unix-archive to .tar.gz in your config");
-        }
         if artifacts.is_empty() {
             warn!("skipping npm installer: not building any supported platforms (use --artifacts=global)");
             return Ok(());

--- a/cargo-dist/templates/installer/npm/binary.js
+++ b/cargo-dist/templates/installer/npm/binary.js
@@ -94,7 +94,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };

--- a/cargo-dist/templates/installer/npm/npm-shrinkwrap.json
+++ b/cargo-dist/templates/installer/npm/npm-shrinkwrap.json
@@ -13,8 +13,7 @@
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -39,18 +38,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -125,15 +112,6 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/clone": {
@@ -412,34 +390,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/minizlib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -632,22 +582,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tar": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -771,15 +705,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     }
   }

--- a/cargo-dist/templates/installer/npm/package.json
+++ b/cargo-dist/templates/installer/npm/package.json
@@ -27,8 +27,7 @@
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "devDependencies": {
     "prettier": "^3.3.3"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -2103,13 +2103,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2117,7 +2118,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2153,6 +2154,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2195,11 +2198,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2342,7 +2393,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2392,8 +2445,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2423,18 +2475,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2509,15 +2549,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2795,34 +2826,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -3015,22 +3018,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3155,15 +3142,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3182,8 +3160,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -2107,13 +2107,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2121,7 +2122,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2157,6 +2158,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2199,11 +2202,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2346,7 +2397,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2395,8 +2448,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2426,18 +2478,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2512,15 +2552,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2798,34 +2829,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -3018,22 +3021,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3158,15 +3145,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3184,8 +3162,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -2076,13 +2076,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2090,7 +2091,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2126,6 +2127,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2168,11 +2171,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2315,7 +2366,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2364,8 +2417,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2395,18 +2447,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2481,15 +2521,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2767,34 +2798,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2987,22 +2990,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3127,15 +3114,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3153,8 +3131,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1512,13 +1512,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -1526,7 +1527,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -1562,6 +1563,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -1604,11 +1607,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -1751,7 +1802,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -1800,8 +1853,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -1831,18 +1883,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -1917,15 +1957,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2203,34 +2234,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2423,22 +2426,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -2563,15 +2550,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -2589,8 +2567,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1492,13 +1492,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -1506,7 +1507,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -1542,6 +1543,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -1584,11 +1587,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -1731,7 +1782,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -1780,8 +1833,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -1811,18 +1863,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -1897,15 +1937,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2183,34 +2214,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2403,22 +2406,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -2543,15 +2530,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -2569,8 +2547,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -2107,13 +2107,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2121,7 +2122,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2157,6 +2158,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2199,11 +2202,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2346,7 +2397,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2397,8 +2450,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2428,18 +2480,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2514,15 +2554,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2800,34 +2831,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -3020,22 +3023,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3160,15 +3147,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3188,8 +3166,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -2081,13 +2081,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2095,7 +2096,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2131,6 +2132,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2173,11 +2176,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2320,7 +2371,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2369,8 +2422,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2400,18 +2452,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2486,15 +2526,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2772,34 +2803,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2992,22 +2995,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3132,15 +3119,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3158,8 +3136,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -2073,13 +2073,14 @@ Licensed under either of
 at your option.
 
 ================ axolotlsay-npm-package.tar.gz/package/binary-install.js ================
-const { existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
 
 const axios = require("axios");
-const tar = require("tar");
 const rimraf = require("rimraf");
+const tmpDir = tmpdir();
 
 const error = (msg) => {
   console.error(msg);
@@ -2087,7 +2088,7 @@ const error = (msg) => {
 };
 
 class Package {
-  constructor(name, url, binaries) {
+  constructor(name, url, filename, zipExt, binaries) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -2123,6 +2124,8 @@ class Package {
     }
     this.url = url;
     this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
     this.installDirectory = join(__dirname, "node_modules", ".bin_real");
     this.binaries = binaries;
 
@@ -2165,11 +2168,59 @@ class Package {
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then((res) => {
         return new Promise((resolve, reject) => {
-          const sink = res.data.pipe(
-            tar.x({ strip: 1, C: this.installDirectory }),
-          );
-          sink.on("finish", () => resolve());
-          sink.on("error", (err) => reject(err));
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                const result = spawnSync("unzip", [
+                  "-q",
+                  tempFile,
+                  "-d",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
         });
       })
       .then(() => {
@@ -2312,7 +2363,9 @@ const getPlatform = () => {
 const getPackage = () => {
   const platform = getPlatform();
   const url = `${artifactDownloadUrl}/${platform.artifactName}`;
-  let binary = new Package(name, url, platform.bins);
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(name, url, filename, ext, platform.bins);
 
   return binary;
 };
@@ -2361,8 +2414,7 @@ install(false);
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",
-        "rimraf": "^5.0.8",
-        "tar": "^7.4.3"
+        "rimraf": "^5.0.8"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
@@ -2392,18 +2444,6 @@ install(false);
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "version": "8.0.2"
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "version": "4.0.1"
     },
     "node_modules/@pkgjs/parseargs": {
       "engines": {
@@ -2478,15 +2518,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "version": "2.0.1"
-    },
-    "node_modules/chownr": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "version": "3.0.0"
     },
     "node_modules/clone": {
       "engines": {
@@ -2764,34 +2795,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "version": "7.1.2"
     },
-    "node_modules/minizlib": {
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-      "version": "3.0.1"
-    },
-    "node_modules/mkdirp": {
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "version": "3.0.1"
-    },
     "node_modules/path-key": {
       "engines": {
         "node": ">=8"
@@ -2984,22 +2987,6 @@ install(false);
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "version": "5.0.1"
     },
-    "node_modules/tar": {
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "version": "7.4.3"
-    },
     "node_modules/tunnel": {
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -3124,15 +3111,6 @@ install(false);
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "version": "6.0.1"
-    },
-    "node_modules/yallist": {
-      "engines": {
-        "node": ">=18"
-      },
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "version": "5.0.0"
     }
   },
   "requires": true,
@@ -3150,8 +3128,7 @@ install(false);
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",
-    "rimraf": "^5.0.8",
-    "tar": "^7.4.3"
+    "rimraf": "^5.0.8"
   },
   "description": "💬 a CLI for learning to distribute CLIs in rust",
   "devDependencies": {


### PR DESCRIPTION
This removes the node tar library, and instead commits to unzipping/untarring files the same way that we do in the shell and powershell installers.

Fixes #226.

This isn't tested yet; opening a PR to make sure I'm not completely off base in the JS-side formatting/logic.