### PR TITLE
feat: adjust new config opt-in

### DIFF
--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -275,9 +275,6 @@ pub struct InitArgs {
     /// `cargo dist init` will persist the values you pass to that location.
     #[clap(long, value_delimiter(','))]
     pub hosting: Vec<HostingStyle>,
-    /// Opts into the new configuration format
-    #[clap(long)]
-    pub opt_in_migrate: bool,
 }
 
 /// Which style(s) of configuration to generate
@@ -380,9 +377,6 @@ pub struct UpdateArgs {
     /// `cargo dist init` will persist the values you pass to that location.
     #[clap(long, value_delimiter(','))]
     pub hosting: Vec<HostingStyle>,
-    /// Opts into the new configuration format
-    #[clap(long, hide = true)]
-    pub opt_in_migrate: bool,
 }
 
 /// A style of CI to generate

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -26,8 +26,6 @@ pub struct InitArgs {
     pub with_json_config: Option<Utf8PathBuf>,
     /// Hosts to enable
     pub host: Vec<HostingStyle>,
-    /// Whether to migrate to the new config format
-    pub migrate_to_new_config: bool,
 }
 
 /// Input for --with-json-config
@@ -109,34 +107,32 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
     let mut newly_initted_generic = false;
     // Users who haven't initted yet should be opted into the
     // new config format by default.
-    let desired_workspace_kind =
-        if root_workspace.kind == WorkspaceKind::Rust && !initted && args.migrate_to_new_config {
-            newly_initted_generic = true;
-            WorkspaceKind::Generic
-        // Already-initted users should be asked whether to migrate.
-        } else if root_workspace.kind == WorkspaceKind::Rust && args.migrate_to_new_config {
-            let prompt = r#"Would you like to opt in to the new configuration format?
+    let desired_workspace_kind = if root_workspace.kind == WorkspaceKind::Rust && !initted {
+        newly_initted_generic = true;
+        WorkspaceKind::Generic
+    // Already-initted users should be asked whether to migrate.
+    } else if root_workspace.kind == WorkspaceKind::Rust {
+        let prompt = r#"Would you like to opt in to the new configuration format?
     Future versions of cargo-dist will feature major changes to the
     configuration format, including a new cargo-dist-specific configuration file."#;
-            let res = if args.yes {
-                // We want to avoid --yes pulling it in at this point.
-                false
-            } else {
-                dialoguer::Confirm::with_theme(&theme())
-                    .with_prompt(prompt)
-                    .default(args.migrate_to_new_config)
-                    .interact()?
-            };
+        let res = if args.yes {
+            false
+        } else {
+            dialoguer::Confirm::with_theme(&theme())
+                .with_prompt(prompt)
+                .default(false)
+                .interact()?
+        };
 
-            if res {
-                is_migrating = true;
-                WorkspaceKind::Generic
-            } else {
-                root_workspace.kind
-            }
+        if res {
+            is_migrating = true;
+            WorkspaceKind::Generic
         } else {
             root_workspace.kind
-        };
+        }
+    } else {
+        root_workspace.kind
+    };
 
     let multi_meta = if let Some(json_path) = &args.with_json_config {
         // json update path, read from a file and apply all requested updates verbatim

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -303,7 +303,6 @@ fn cmd_init(cli: &Cli, args: &InitArgs) -> Result<(), miette::Report> {
         no_generate: args.skip_generate,
         with_json_config: args.with_json_config.clone(),
         host: args.hosting.iter().map(|host| host.to_lib()).collect(),
-        migrate_to_new_config: args.opt_in_migrate,
     };
     do_init(&config, &args)?;
     Ok(())

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -175,9 +175,6 @@ Possible values:
 - github:    Host on Github Releases
 - axodotdev: Host on Axo Releases ("Abyss")
 
-#### `--opt-in-migrate`
-Opts into the new configuration format
-
 #### `-h, --help`
 Print help (see a summary with '-h')
 


### PR DESCRIPTION
Based on a conversation with @ashleygwilliams, a few changes to the new config format stuff in `cargo dist init`.

* Removes the `--opt-in-migrate` flag
* New projects always get the new config
* Existing projects are offered the chance to migrate, with the default being no
* Existing projects using `cargo dist init -y` don't get migrated