### PR TITLE
feat: add minimum supported axoupdater check (library)

### DIFF
--- a/axoproject/src/generic.rs
+++ b/axoproject/src/generic.rs
@@ -254,8 +254,6 @@ fn process_virtual_workspace(
             cargo_metadata_table: None,
             #[cfg(feature = "cargo-projects")]
             cargo_profiles: crate::rust::CargoProfiles::new(),
-            #[cfg(feature = "cargo-projects")]
-            axoupdater_versions: Default::default(),
         },
     })
 }
@@ -310,8 +308,6 @@ fn upgrade_package_to_workspace(package: PackageInfo) -> Result<WorkspaceStructu
             cargo_metadata_table: None,
             #[cfg(feature = "cargo-projects")]
             cargo_profiles: Default::default(),
-            #[cfg(feature = "cargo-projects")]
-            axoupdater_versions: Default::default(),
         },
         sub_workspaces: vec![],
         packages: vec![package],
@@ -382,6 +378,7 @@ fn process_package(manifest_path: &Utf8Path, package: Package) -> Result<Package
         #[cfg(feature = "cargo-projects")]
         cargo_package_id: None,
         npm_scope: None,
+        axoupdater_version: None,
     };
 
     // Load and apply auto-includes

--- a/axoproject/src/generic.rs
+++ b/axoproject/src/generic.rs
@@ -255,7 +255,7 @@ fn process_virtual_workspace(
             #[cfg(feature = "cargo-projects")]
             cargo_profiles: crate::rust::CargoProfiles::new(),
             #[cfg(feature = "cargo-projects")]
-            axoupdater_version: None,
+            axoupdater_versions: Default::default(),
         },
     })
 }
@@ -311,7 +311,7 @@ fn upgrade_package_to_workspace(package: PackageInfo) -> Result<WorkspaceStructu
             #[cfg(feature = "cargo-projects")]
             cargo_profiles: Default::default(),
             #[cfg(feature = "cargo-projects")]
-            axoupdater_version: None,
+            axoupdater_versions: Default::default(),
         },
         sub_workspaces: vec![],
         packages: vec![package],

--- a/axoproject/src/generic.rs
+++ b/axoproject/src/generic.rs
@@ -378,7 +378,7 @@ fn process_package(manifest_path: &Utf8Path, package: Package) -> Result<Package
         #[cfg(feature = "cargo-projects")]
         cargo_package_id: None,
         npm_scope: None,
-        axoupdater_version: None,
+        axoupdater_versions: Default::default(),
     };
 
     // Load and apply auto-includes

--- a/axoproject/src/generic.rs
+++ b/axoproject/src/generic.rs
@@ -254,6 +254,8 @@ fn process_virtual_workspace(
             cargo_metadata_table: None,
             #[cfg(feature = "cargo-projects")]
             cargo_profiles: crate::rust::CargoProfiles::new(),
+            #[cfg(feature = "cargo-projects")]
+            axoupdater_version: None,
         },
     })
 }
@@ -308,6 +310,8 @@ fn upgrade_package_to_workspace(package: PackageInfo) -> Result<WorkspaceStructu
             cargo_metadata_table: None,
             #[cfg(feature = "cargo-projects")]
             cargo_profiles: Default::default(),
+            #[cfg(feature = "cargo-projects")]
+            axoupdater_version: None,
         },
         sub_workspaces: vec![],
         packages: vec![package],

--- a/axoproject/src/javascript.rs
+++ b/axoproject/src/javascript.rs
@@ -182,6 +182,8 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
             cargo_metadata_table: None,
             #[cfg(feature = "cargo-projects")]
             cargo_profiles: crate::rust::CargoProfiles::new(),
+            #[cfg(feature = "cargo-projects")]
+            axoupdater_version: None,
         },
     })
 }

--- a/axoproject/src/javascript.rs
+++ b/axoproject/src/javascript.rs
@@ -183,7 +183,7 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
             #[cfg(feature = "cargo-projects")]
             cargo_profiles: crate::rust::CargoProfiles::new(),
             #[cfg(feature = "cargo-projects")]
-            axoupdater_version: None,
+            axoupdater_versions: Default::default(),
         },
     })
 }

--- a/axoproject/src/javascript.rs
+++ b/axoproject/src/javascript.rs
@@ -162,7 +162,7 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
         #[cfg(feature = "cargo-projects")]
         cargo_package_id: None,
         build_command,
-        axoupdater_version: None,
+        axoupdater_versions: Default::default(),
     };
     crate::merge_auto_includes(&mut info, &root_auto_includes);
 

--- a/axoproject/src/javascript.rs
+++ b/axoproject/src/javascript.rs
@@ -162,6 +162,7 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
         #[cfg(feature = "cargo-projects")]
         cargo_package_id: None,
         build_command,
+        axoupdater_version: None,
     };
     crate::merge_auto_includes(&mut info, &root_auto_includes);
 
@@ -182,8 +183,6 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
             cargo_metadata_table: None,
             #[cfg(feature = "cargo-projects")]
             cargo_profiles: crate::rust::CargoProfiles::new(),
-            #[cfg(feature = "cargo-projects")]
-            axoupdater_versions: Default::default(),
         },
     })
 }

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -522,7 +522,7 @@ pub struct PackageInfo {
     pub cargo_package_id: Option<PackageId>,
     /// The versions of axoupdater directly depended on, if any
     #[cfg(feature = "cargo-projects")]
-    pub axoupdater_versions: Vec<Version>,
+    pub axoupdater_versions: Vec<(String, Version)>,
     /// npm scope (with the @, like "@axodotdev")
     pub npm_scope: Option<String>,
     /// Command to run to build this package

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -520,9 +520,9 @@ pub struct PackageInfo {
     /// A unique id used by Cargo to refer to the package
     #[cfg(feature = "cargo-projects")]
     pub cargo_package_id: Option<PackageId>,
-    /// The version of axoupdater directly depended on, if any
+    /// The versions of axoupdater directly depended on, if any
     #[cfg(feature = "cargo-projects")]
-    pub axoupdater_version: Option<Version>,
+    pub axoupdater_versions: Vec<Version>,
     /// npm scope (with the @, like "@axodotdev")
     pub npm_scope: Option<String>,
     /// Command to run to build this package

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -335,6 +335,9 @@ pub struct WorkspaceInfo {
     /// Any [profile.*] entries we found in the root Cargo.toml
     #[cfg(feature = "cargo-projects")]
     pub cargo_profiles: rust::CargoProfiles,
+    #[cfg(feature = "cargo-projects")]
+    /// Which version of axoproject (the Rust library) is in use, if any
+    pub axoupdater_version: Option<Version>,
 }
 
 /// A URL to a repository, with some normalization applied

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -6,7 +6,7 @@
 #![deny(missing_docs)]
 #![allow(clippy::result_large_err)]
 
-use std::fmt::Display;
+use std::{collections::BTreeMap, fmt::Display};
 
 #[cfg(feature = "cargo-projects")]
 use axoasset::serde_json;
@@ -336,8 +336,8 @@ pub struct WorkspaceInfo {
     #[cfg(feature = "cargo-projects")]
     pub cargo_profiles: rust::CargoProfiles,
     #[cfg(feature = "cargo-projects")]
-    /// Which version of axoproject (the Rust library) is in use, if any
-    pub axoupdater_version: Option<Version>,
+    /// Which versions of axoproject (the Rust library) are in use, if any
+    pub axoupdater_versions: BTreeMap<String, Version>,
 }
 
 /// A URL to a repository, with some normalization applied

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -6,7 +6,7 @@
 #![deny(missing_docs)]
 #![allow(clippy::result_large_err)]
 
-use std::{collections::BTreeMap, fmt::Display};
+use std::fmt::Display;
 
 #[cfg(feature = "cargo-projects")]
 use axoasset::serde_json;
@@ -335,9 +335,6 @@ pub struct WorkspaceInfo {
     /// Any [profile.*] entries we found in the root Cargo.toml
     #[cfg(feature = "cargo-projects")]
     pub cargo_profiles: rust::CargoProfiles,
-    #[cfg(feature = "cargo-projects")]
-    /// Which versions of axoproject (the Rust library) are in use, if any
-    pub axoupdater_versions: BTreeMap<String, Version>,
 }
 
 /// A URL to a repository, with some normalization applied
@@ -523,6 +520,9 @@ pub struct PackageInfo {
     /// A unique id used by Cargo to refer to the package
     #[cfg(feature = "cargo-projects")]
     pub cargo_package_id: Option<PackageId>,
+    /// The version of axoupdater directly depended on, if any
+    #[cfg(feature = "cargo-projects")]
+    pub axoupdater_version: Option<Version>,
     /// npm scope (with the @, like "@axodotdev")
     pub npm_scope: Option<String>,
     /// Command to run to build this package

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -404,7 +404,7 @@ impl RepositoryUrl {
 ///
 /// This notably includes finding readmes and licenses even if the user didn't
 /// specify their location -- something Cargo does but Guppy (and cargo-metadata) don't.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PackageInfo {
     /// The unoverrideable name of the package within its own package management system.
     ///

--- a/axoproject/src/rust.rs
+++ b/axoproject/src/rust.rs
@@ -205,13 +205,19 @@ fn package_info(
     let query = pkg_graph.query_forward(std::iter::once(package.id()))?;
     let package_set = query.resolve();
     let mut axoupdater_versions = vec![];
-    for package in package_set.packages(DependencyDirection::Reverse) {
-        if package.name() == "axoupdater" {
-            axoupdater_versions.push(Version::Cargo(package.version().to_owned()))
+    for p in package_set.packages(DependencyDirection::Reverse) {
+        if p.name() == "axoupdater" {
+            axoupdater_versions.push((
+                package.name().to_owned(),
+                Version::Cargo(p.version().to_owned()),
+            ))
         } else {
-            for subpackage in package.direct_links() {
+            for subpackage in p.direct_links() {
                 if subpackage.dep_name() == "axoupdater" {
-                    axoupdater_versions.push(Version::Cargo(subpackage.to().version().to_owned()))
+                    axoupdater_versions.push((
+                        p.name().to_owned(),
+                        Version::Cargo(subpackage.to().version().to_owned()),
+                    ))
                 }
             }
         }

--- a/axoproject/src/rust.rs
+++ b/axoproject/src/rust.rs
@@ -87,20 +87,21 @@ fn workspace_info(pkg_graph: &PackageGraph) -> Result<WorkspaceStructure> {
     let target_dir = workspace.target_directory().to_owned();
     let workspace_dir = workspace.root().to_owned();
 
-    let mut axoupdater_version = None;
+    let mut axoupdater_versions = BTreeMap::new();
     for package in members.packages(DependencyDirection::Reverse) {
         let mut version = None;
+        let name = package.name().to_owned();
         if package.name() == "axoupdater" {
             version = Some(package.version());
         } else {
-            for package in package.direct_links() {
-                if package.dep_name() == "axoupdater" {
-                    version = Some(package.to().version());
+            for subpackage in package.direct_links() {
+                if subpackage.dep_name() == "axoupdater" {
+                    version = Some(subpackage.to().version());
                 }
             }
         }
         if let Some(version) = version {
-            axoupdater_version = Some(Version::Cargo(version.to_owned()));
+            axoupdater_versions.insert(name, Version::Cargo(version.to_owned()));
         }
     }
 
@@ -117,7 +118,7 @@ fn workspace_info(pkg_graph: &PackageGraph) -> Result<WorkspaceStructure> {
             root_auto_includes,
             cargo_metadata_table,
             cargo_profiles,
-            axoupdater_version,
+            axoupdater_versions,
         },
     })
 }

--- a/axoproject/src/rust.rs
+++ b/axoproject/src/rust.rs
@@ -206,19 +206,12 @@ fn package_info(
     let package_set = query.resolve();
     let mut axoupdater_versions = vec![];
     for p in package_set.packages(DependencyDirection::Reverse) {
-        if p.name() == "axoupdater" {
-            axoupdater_versions.push((
-                package.name().to_owned(),
-                Version::Cargo(p.version().to_owned()),
-            ))
-        } else {
-            for subpackage in p.direct_links() {
-                if subpackage.dep_name() == "axoupdater" {
-                    axoupdater_versions.push((
-                        p.name().to_owned(),
-                        Version::Cargo(subpackage.to().version().to_owned()),
-                    ))
-                }
+        for subpackage in p.direct_links() {
+            if subpackage.dep_name() == "axoupdater" {
+                axoupdater_versions.push((
+                    p.name().to_owned(),
+                    Version::Cargo(subpackage.to().version().to_owned()),
+                ))
             }
         }
     }

--- a/axoproject/src/tests.rs
+++ b/axoproject/src/tests.rs
@@ -9,7 +9,7 @@ fn get_package(packages: &[(PackageIdx, &crate::PackageInfo)], name: &str) -> cr
     packages
         .iter()
         .find(|(_, p)| p.name == name)
-        .unwrap()
+        .unwrap_or_else(|| panic!("no package found with {name}"))
         .1
         .to_owned()
 }
@@ -24,7 +24,7 @@ fn test_self_detect() {
     assert_eq!(project.kind, WorkspaceKind::Rust);
     assert_eq!(packages.len(), 3);
 
-    let package = packages[1].1;
+    let package = get_package(&packages, "axoproject");
     assert_eq!(package.name, "axoproject");
     assert_eq!(package.binaries.len(), 0);
 }

--- a/axoproject/src/tests.rs
+++ b/axoproject/src/tests.rs
@@ -5,6 +5,15 @@ use crate::{
     WorkspaceKind,
 };
 
+fn get_package(packages: &[(PackageIdx, &crate::PackageInfo)], name: &str) -> crate::PackageInfo {
+    packages
+        .iter()
+        .find(|(_, p)| p.name == name)
+        .unwrap()
+        .1
+        .to_owned()
+}
+
 #[cfg(feature = "cargo-projects")]
 #[test]
 fn test_self_detect() {
@@ -15,7 +24,7 @@ fn test_self_detect() {
     assert_eq!(project.kind, WorkspaceKind::Rust);
     assert_eq!(packages.len(), 3);
 
-    let package = packages[0].1;
+    let package = packages[1].1;
     assert_eq!(package.name, "axoproject");
     assert_eq!(package.binaries.len(), 0);
 }
@@ -130,38 +139,38 @@ fn test_cargo_nonvirtual() {
     assert_eq!(packages.len(), 6);
 
     {
-        let package = packages[0].1;
-        assert_eq!(package.name, "some-cdylib");
+        let package = get_package(&packages, "some-cdylib");
+        assert_eq!(package.name, "some-cdylib", "packages: {:?}", packages);
         assert!(package.binaries.is_empty());
     }
 
     {
-        let package = packages[1].1;
+        let package = get_package(&packages, "some-lib");
         assert_eq!(package.name, "some-lib");
         assert!(package.binaries.is_empty());
     }
 
     {
-        let package = packages[2].1;
+        let package = get_package(&packages, "some-other-lib");
         assert_eq!(package.name, "some-other-lib");
         assert!(package.binaries.is_empty());
     }
 
     {
-        let package = packages[3].1;
+        let package = get_package(&packages, "some-staticlib");
         assert_eq!(package.name, "some-staticlib");
         assert!(package.binaries.is_empty());
     }
 
     {
-        let package = packages[4].1;
+        let package = get_package(&packages, "test-bin");
         assert_eq!(package.name, "test-bin");
         assert_eq!(&package.binaries[..], &["test-bin"]);
         assert!(!package.publish);
     }
 
     {
-        let package = packages[5].1;
+        let package = get_package(&packages, "nonvirtual");
         assert_eq!(package.name, "nonvirtual");
         assert_eq!(&package.binaries[..], &["cargo-nonvirtual", "nonvirtual"]);
         assert!(package.publish);

--- a/book/src/installers/updater.md
+++ b/book/src/installers/updater.md
@@ -23,7 +23,7 @@ New release installed!
 
 If you would prefer to handle polling for updates yourself, for example in order to incorporate it as an internal subcommand of your own software, axoupdater is available as a [crate] which can be used as a library within your program. More information about how to use axoupdater as a library in your own program can be found in its README and in its [API documentation][axoupdater-docs].
 
-## Minimum supported updater version checking
+## Minimum supported version checking
 
 While cargo-dist will always fetch up to date versions of the updater when building your software, if you use axoupdater as a library then it's important to make sure that it's kept up to date to ensure compatibility. To help you test this, cargo-dist will attempt to check if the packages it's disting use axoupdater as a dependency; if it detects an unsupported, too-old version of axoupdater is in use, it will then refuse to continue to build in order to avoid distributing a package that's unsafe to update.
 

--- a/book/src/installers/updater.md
+++ b/book/src/installers/updater.md
@@ -23,6 +23,10 @@ New release installed!
 
 If you would prefer to handle polling for updates yourself, for example in order to incorporate it as an internal subcommand of your own software, axoupdater is available as a [crate] which can be used as a library within your program. More information about how to use axoupdater as a library in your own program can be found in its README and in its [API documentation][axoupdater-docs].
 
+## Minimum supported updater version checking
+
+While cargo-dist will always fetch up to date versions of the updater when building your software, if you use axoupdater as a library then it's important to make sure that it's kept up to date to ensure compatibility. To help you test this, cargo-dist will attempt to check if the packages it's disting use axoupdater as a dependency; if it detects an unsupported, too-old version of axoupdater is in use, it will then refuse to continue to build in order to avoid distributing a package that's unsafe to update.
+
 ## GitHub Actions and Rate Limits in CI
 
 By default, axoupdater uses unauthenticated GitHub API calls when fetching release information. This is reliable in normal use, but it's much more likely to run into rate limits in the highly artificial environment of a CI test. If you're testing the standalone updater in your CI configuration, we recommend setting the `AXOUPDATER_GITHUB_TOKEN` environment variable to the value of the `GITHUB_TOKEN` secret that GitHub Action defines automatically.

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -35,7 +35,8 @@ impl<'a> DistGraphBuilder<'a> {
         for (binary_idx, binary) in self.inner.binaries.iter().enumerate() {
             let package = self.workspaces.package(binary.pkg_idx);
 
-            if let Some(axoproject::Version::Cargo(version)) = &package.axoupdater_version {
+            let oldest = package.axoupdater_versions.iter().min();
+            if let Some(axoproject::Version::Cargo(version)) = oldest {
                 let axoupdater_min_version = semver::Version::parse(AXOUPDATER_MINIMUM_VERSION)
                     .expect("invalid axoupdater const?!");
 

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -35,14 +35,18 @@ impl<'a> DistGraphBuilder<'a> {
         for (binary_idx, binary) in self.inner.binaries.iter().enumerate() {
             let package = self.workspaces.package(binary.pkg_idx);
 
-            let oldest = package.axoupdater_versions.iter().min();
-            if let Some(axoproject::Version::Cargo(version)) = oldest {
+            let oldest = package
+                .axoupdater_versions
+                .iter()
+                .min_by(|a, b| a.1.cmp(&b.1));
+            if let Some((source, axoproject::Version::Cargo(version))) = oldest {
                 let axoupdater_min_version = semver::Version::parse(AXOUPDATER_MINIMUM_VERSION)
                     .expect("invalid axoupdater const?!");
 
                 if *version < axoupdater_min_version {
                     return Err(DistError::AxoupdaterTooOld {
                         package_name: package.name.to_owned(),
+                        source_name: source.to_owned(),
                         minimum: axoupdater_min_version,
                         your_version: version.to_owned(),
                     });

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -28,14 +28,18 @@ impl<'a> DistGraphBuilder<'a> {
         let mut targets = SortedMap::<TargetTriple, Vec<BinaryIdx>>::new();
 
         let workspace = self.workspaces.workspace(workspace_idx);
-        if let Some(axoproject::Version::Cargo(version)) = &workspace.axoupdater_version {
+        let oldest = workspace
+            .axoupdater_versions
+            .iter()
+            .min_by(|a, b| a.1.cmp(b.1));
+        if let Some((_, axoproject::Version::Cargo(version))) = oldest {
             let axoupdater_min_version = semver::Version::parse(AXOUPDATER_MINIMUM_VERSION)
                 .expect("invalid axoupdater const?!");
 
             if *version < axoupdater_min_version {
                 return Err(DistError::AxoupdaterTooOld {
-                    minimum: version.to_owned(),
-                    your_version: axoupdater_min_version,
+                    minimum: axoupdater_min_version,
+                    your_version: version.to_owned(),
                 });
             }
         }

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -19,7 +19,10 @@ use crate::{
 };
 
 impl<'a> DistGraphBuilder<'a> {
-    pub(crate) fn compute_cargo_builds(&mut self, workspace_idx: WorkspaceIdx) -> Vec<BuildStep> {
+    pub(crate) fn compute_cargo_builds(
+        &mut self,
+        workspace_idx: WorkspaceIdx,
+    ) -> DistResult<Vec<BuildStep>> {
         // For now we can be really simplistic and just do a workspace build for every
         // target-triple we have a binary-that-needs-a-real-build for.
         let mut targets = SortedMap::<TargetTriple, Vec<BinaryIdx>>::new();
@@ -30,7 +33,10 @@ impl<'a> DistGraphBuilder<'a> {
                 .expect("invalid axoupdater const?!");
 
             if *version < axoupdater_min_version {
-                warn!("Your project uses axoupdater as a library. We've detected that you're using {}, but this version of cargo-dist expects a version of at least {} (or greater). Please consider updating to ensure your users don't experience inconsistent update behaviour.", version, axoupdater_min_version);
+                return Err(DistError::AxoupdaterTooOld {
+                    minimum: version.to_owned(),
+                    your_version: axoupdater_min_version,
+                });
             }
         }
 
@@ -135,7 +141,7 @@ impl<'a> DistGraphBuilder<'a> {
                 }));
             }
         }
-        builds
+        Ok(builds)
     }
 }
 

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -555,6 +555,18 @@ pub enum DistError {
     #[error("No bundle identifier was specified")]
     #[diagnostic(help("Please either enter a bundle identifier, or disable the Mac .pkg"))]
     MacPkgBundleIdentifierMissing {},
+
+    /// Project depends on a too-old axoupdater
+    #[error("Your project uses axoupdater as a library, but the version specified ({your_version}) is older than the minimum supported version ({minimum}),")]
+    #[diagnostic(help(
+        "Please update the version of axoupdater in your Cargo.toml to at least {minimum}"
+    ))]
+    AxoupdaterTooOld {
+        /// Minimum supported version
+        minimum: semver::Version,
+        /// Version the project uses
+        your_version: semver::Version,
+    },
 }
 
 /// This error indicates we tried to deserialize some YAML with serde_yml

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -559,7 +559,7 @@ pub enum DistError {
     /// Project depends on a too-old axoupdater
     #[error("Your project ({package_name}) uses axoupdater as a library, but the version specified ({your_version}) is older than the minimum supported version ({minimum}),")]
     #[diagnostic(help(
-        "Please update the version of axoupdater in your Cargo.toml to at least {minimum}"
+        "https://opensource.axo.dev/cargo-dist/book/installers/updater.html#minimum-supported-updater-version-checking"
     ))]
     AxoupdaterTooOld {
         /// Name of the package

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -557,11 +557,13 @@ pub enum DistError {
     MacPkgBundleIdentifierMissing {},
 
     /// Project depends on a too-old axoupdater
-    #[error("Your project uses axoupdater as a library, but the version specified ({your_version}) is older than the minimum supported version ({minimum}),")]
+    #[error("Your project ({package_name}) uses axoupdater as a library, but the version specified ({your_version}) is older than the minimum supported version ({minimum}),")]
     #[diagnostic(help(
         "Please update the version of axoupdater in your Cargo.toml to at least {minimum}"
     ))]
     AxoupdaterTooOld {
+        /// Name of the package
+        package_name: String,
         /// Minimum supported version
         minimum: semver::Version,
         /// Version the project uses

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -557,13 +557,15 @@ pub enum DistError {
     MacPkgBundleIdentifierMissing {},
 
     /// Project depends on a too-old axoupdater
-    #[error("Your project ({package_name}) uses axoupdater as a library, but the version specified ({your_version}) is older than the minimum supported version ({minimum}),")]
+    #[error("Your project ({package_name}) uses axoupdater as a library, but the version specified ({your_version}) is older than the minimum supported version ({minimum}). (The dependency comes via {source_name} in the dependency tree.)")]
     #[diagnostic(help(
         "https://opensource.axo.dev/cargo-dist/book/installers/updater.html#minimum-supported-updater-version-checking"
     ))]
     AxoupdaterTooOld {
         /// Name of the package
         package_name: String,
+        /// The package that depended on axoupdater
+        source_name: String,
         /// Minimum supported version
         minimum: semver::Version,
         /// Version the project uses

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -559,7 +559,7 @@ pub enum DistError {
     /// Project depends on a too-old axoupdater
     #[error("Your project ({package_name}) uses axoupdater as a library, but the version specified ({your_version}) is older than the minimum supported version ({minimum}). (The dependency comes via {source_name} in the dependency tree.)")]
     #[diagnostic(help(
-        "https://opensource.axo.dev/cargo-dist/book/installers/updater.html#minimum-supported-updater-version-checking"
+        "https://opensource.axo.dev/cargo-dist/book/installers/updater.html#minimum-supported-version-checking"
     ))]
     AxoupdaterTooOld {
         /// Name of the package

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -165,6 +165,7 @@ fn run_build_step(
 
 const AXOUPDATER_ASSET_ROOT: &str =
     "https://github.com/axodotdev/axoupdater/releases/latest/download";
+const AXOUPDATER_MINIMUM_VERSION: &str = "0.7.0";
 
 /// Fetches an installer executable and installs it in the expected target path.
 pub fn fetch_updater(dist_graph: &DistGraph, updater: &UpdaterStep) -> DistResult<()> {

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -113,7 +113,7 @@ pub fn mock_package(name: &str, ver: &str) -> PackageInfo {
         cargo_package_id: None,
         npm_scope: None,
         build_command: None,
-        axoupdater_version: None,
+        axoupdater_versions: Default::default(),
     }
 }
 

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -139,6 +139,7 @@ pub fn mock_workspace(packages: Vec<PackageInfo>) -> WorkspaceGraph {
             },
             cargo_metadata_table: None,
             cargo_profiles: Default::default(),
+            axoupdater_version: None,
         },
     };
     workspaces.add_workspace(workspace, None);

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -139,7 +139,7 @@ pub fn mock_workspace(packages: Vec<PackageInfo>) -> WorkspaceGraph {
             },
             cargo_metadata_table: None,
             cargo_profiles: Default::default(),
-            axoupdater_version: None,
+            axoupdater_versions: Default::default(),
         },
     };
     workspaces.add_workspace(workspace, None);

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -113,6 +113,7 @@ pub fn mock_package(name: &str, ver: &str) -> PackageInfo {
         cargo_package_id: None,
         npm_scope: None,
         build_command: None,
+        axoupdater_version: None,
     }
 }
 
@@ -139,7 +140,6 @@ pub fn mock_workspace(packages: Vec<PackageInfo>) -> WorkspaceGraph {
             },
             cargo_metadata_table: None,
             cargo_profiles: Default::default(),
-            axoupdater_versions: Default::default(),
         },
     };
     workspaces.add_workspace(workspace, None);


### PR DESCRIPTION
This adds a check when building Rust software which uses axoupdater as a library. If the user is using a version older than what this version of cargo-dist was for, it emits a warning at buildtime. I tested it on cargo-dist itself by bumping the const to something that doesn't exist, and confirmed it works:

```
 WARN Your project uses axoupdater as a library. We've detected that you're using 0.7.2, but this version of cargo-dist expects a version of at least 0.10.0 (or greater). Please consider updating to ensure your users don't experience inconsistent update behaviour.
```

To support this, I added support in axoproject for detecting if axoupdater is present and, if it is, its version is recorded. I briefly considered tracking the full dep tree in the axoproject info but that seemed like overkill.

Fixes #1392.