### PR TITLE
feat: disable single-library mode for dist=false

### DIFF
--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -545,12 +545,16 @@ fn select_packages(
     // add that package as a release still, on the assumption it's a Library
     if releases.is_empty() {
         if let ReleaseType::Package { idx, version: _ } = announcing.release {
-            releases.push(ReleaseArtifacts {
-                package_idx: PackageIdx(idx),
-                executables: vec![],
-                cdylibs: vec![],
-                cstaticlibs: vec![],
-            });
+            let config = graph.package_config(PackageIdx(idx));
+
+            if config.dist != Some(false) {
+                releases.push(ReleaseArtifacts {
+                    package_idx: PackageIdx(idx),
+                    executables: vec![],
+                    cdylibs: vec![],
+                    cstaticlibs: vec![],
+                });
+            }
         }
     }
 

--- a/cargo-dist/tests/gallery/dist.rs
+++ b/cargo-dist/tests/gallery/dist.rs
@@ -192,6 +192,21 @@ impl<'a> TestContext<'a, Tools> {
         self.load_dist_results(test_name, true)
     }
 
+    pub fn cargo_dist_build_tag(&self, test_name: &str, tag_name: &str) -> Result<DistResult> {
+        // If the dist target dir exists, delete it to avoid cross-contamination
+        let out_path = Utf8Path::new("target/distrib/");
+        if out_path.exists() {
+            LocalAsset::remove_dir_all(out_path)?;
+        }
+
+        eprintln!("running dist build --tag={tag_name}...");
+        self.tools
+            .cargo_dist
+            .output_checked(|cmd| cmd.arg("dist").arg("build").arg("--tag").arg(tag_name))?;
+
+        self.load_dist_results(test_name, true)
+    }
+
     /// Run 'dist generate' and return paths to various files that were generated
     pub fn cargo_dist_generate(&self, test_name: &str) -> Result<GenerateResult> {
         self.cargo_dist_generate_prefixed(test_name, "")

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -1652,6 +1652,43 @@ targets = ["x86_64-pc-windows-msvc"]
 }
 
 #[test]
+// Should produce an error on `build` because the requested tag matches a package with dist=false
+#[should_panic(expected = r#"This workspace doesn't have anything for dist to Release!"#)]
+fn axolotlsay_dist_false() {
+    let test_name = _function_name!();
+    AXOLOTLSAY.run_test(|ctx| {
+        let dist_version = ctx.tools.cargo_dist.version().unwrap();
+        ctx.patch_cargo_toml(format!(r#"
+[workspace.metadata.dist]
+cargo-dist-version = "{dist_version}"
+installers = ["shell", "powershell", "homebrew", "npm", "msi", "pkg"]
+tap = "axodotdev/homebrew-packages"
+publish-jobs = ["homebrew", "npm"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
+install-success-msg = ">o_o< everything's installed!"
+ci = ["github"]
+unix-archive = ".tar.gz"
+windows-archive = ".tar.gz"
+npm-scope = "@axodotdev"
+dist = false
+
+[package.metadata.wix]
+upgrade-guid = "B36177BE-EA4D-44FB-B05C-EDDABDAA95CA"
+path-guid = "BFD25009-65A4-4D1E-97F1-0030465D90D6"
+
+[package.metadata.dist.mac-pkg-config]
+identifier = "dev.axo.axolotsay"
+
+"#
+        ))?;
+
+        ctx.cargo_dist_build_tag(test_name, "axolotlsay-v0.2.2")?;
+
+        Ok(())
+    }).unwrap()
+}
+
+#[test]
 fn axolotlsay_disable_source_tarball() -> Result<(), miette::Report> {
     let test_name = _function_name!();
     AXOLOTLSAY.run_test(|ctx| {


### PR DESCRIPTION
In the past, we'd ignore `dist=false` when trying to enable single-package/library mode. This is, frankly, quite confusing and not desirable. Even if it's a slightly backwards incompatible change, we should make this do what it actually says.

Fixes #1287.