### PR TITLE
fix: standalone updater installation

### DIFF
--- a/book/src/installers/updater.md
+++ b/book/src/installers/updater.md
@@ -40,6 +40,14 @@ A sample in cargo-dist's CI configuration can be found [here][cargo-dist-ci-conf
 
 If you use the axoupdater crate to implement the updater yourself, instructions for opting into a token in CI can be found [here][axoupdater-token-docs].
 
+## Releases with issues surrounding the standalone updater
+
+cargo-dist versions 0.21.1, 0.22.0 and 0.22.1 contain a bug which prevents the shell installer from installing the standalone updater alongside your binaries. This bug doesn't affect the PowerShell installer. Users of installers created with these releases will have had your software installed as normal, but won't have received an updater. Users whose first installation came via one of these installers will need to upgrade manually using a new shell installer.
+
+Users who first installed with an installer created with an older cargo-dist will still have their updater from their original installation, and so they will be able to update as normal.
+
+This issue was resolved in cargo-dist 0.23.0.
+
 [axoupdater]: https://github.com/axodotdev/axoupdater
 [axoupdater-docs]: https://docs.rs/axoupdater/
 [axoupdater-token-docs]: https://github.com/axodotdev/axoupdater?tab=readme-ov-file#github-actions-and-rate-limits-in-ci

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -176,8 +176,8 @@ download_binary_and_run_installer() {
             _staticlibs_js_array=""
             {%- endif %}
             {%- if archive.updater %}
-            _updater_name="{{ archive.updater.id }}"
-            _updater_bin="{{ archive.updater.binary }}"
+            _updater_name="{{ platform_support.updaters[archive.updater].id }}"
+            _updater_bin="{{ platform_support.updaters[archive.updater].binary }}"
             {%- else %}
             _updater_name=""
             _updater_bin=""

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -173,8 +173,8 @@ download_binary_and_run_installer() {
             _libs_js_array=""
             _staticlibs=""
             _staticlibs_js_array=""
-            _updater_name=""
-            _updater_bin=""
+            _updater_name="akaikatana-repack-x86_64-apple-darwin-update"
+            _updater_bin="akaikatana-repack-x86_64-apple-darwin-update"
             ;;
         "akaikatana-repack-x86_64-pc-windows-msvc.zip")
             _arch="x86_64-pc-windows-msvc"
@@ -185,8 +185,8 @@ download_binary_and_run_installer() {
             _libs_js_array=""
             _staticlibs=""
             _staticlibs_js_array=""
-            _updater_name=""
-            _updater_bin=""
+            _updater_name="akaikatana-repack-x86_64-pc-windows-msvc-update"
+            _updater_bin="akaikatana-repack-x86_64-pc-windows-msvc-update"
             ;;
         "akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz")
             _arch="x86_64-unknown-linux-gnu"
@@ -197,8 +197,8 @@ download_binary_and_run_installer() {
             _libs_js_array=""
             _staticlibs=""
             _staticlibs_js_array=""
-            _updater_name=""
-            _updater_bin=""
+            _updater_name="akaikatana-repack-x86_64-unknown-linux-gnu-update"
+            _updater_bin="akaikatana-repack-x86_64-unknown-linux-gnu-update"
             ;;
         *)
             err "internal installer error: selected download $_artifact_name doesn't exist!?"

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -173,8 +173,8 @@ download_binary_and_run_installer() {
             _libs_js_array=""
             _staticlibs=""
             _staticlibs_js_array=""
-            _updater_name=""
-            _updater_bin=""
+            _updater_name="axolotlsay-x86_64-apple-darwin-update"
+            _updater_bin="axolotlsay-x86_64-apple-darwin-update"
             ;;
         "axolotlsay-x86_64-pc-windows-msvc.tar.gz")
             _arch="x86_64-pc-windows-msvc"
@@ -185,8 +185,8 @@ download_binary_and_run_installer() {
             _libs_js_array=""
             _staticlibs=""
             _staticlibs_js_array=""
-            _updater_name=""
-            _updater_bin=""
+            _updater_name="axolotlsay-x86_64-pc-windows-msvc-update"
+            _updater_bin="axolotlsay-x86_64-pc-windows-msvc-update"
             ;;
         "axolotlsay-x86_64-unknown-linux-gnu.tar.gz")
             _arch="x86_64-unknown-linux-gnu"
@@ -197,8 +197,8 @@ download_binary_and_run_installer() {
             _libs_js_array=""
             _staticlibs=""
             _staticlibs_js_array=""
-            _updater_name=""
-            _updater_bin=""
+            _updater_name="axolotlsay-x86_64-unknown-linux-gnu-update"
+            _updater_bin="axolotlsay-x86_64-unknown-linux-gnu-update"
             ;;
         *)
             err "internal installer error: selected download $_artifact_name doesn't exist!?"


### PR DESCRIPTION
This was broken in a refactor in 19af85324be25d023b2bac291aa105f081d7da30. That commit updated how we fetch platform-specific information, but it missed that the `updater` field in the new type is differently-shaped than the field from the new type. Specifically, the new `archive` we're working on has an `updater` field that's an *index into a table of updaters* intead of an *updater struct* - so trying to read its `id` and `bin` fields was doomed to failure.

The snapshots in #1346 actually exposed this problem, but both Aria and I missed it in review. We need to be more careful about this in the future.

Fixes #1443.