### PR TITLE
fix: invalid updater for first in array

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -175,7 +175,7 @@ download_binary_and_run_installer() {
             _staticlibs=""
             _staticlibs_js_array=""
             {%- endif %}
-            {%- if archive.updater %}
+            {%- if archive.updater != None %}
             _updater_name="{{ platform_support.updaters[archive.updater].id }}"
             _updater_bin="{{ platform_support.updaters[archive.updater].binary }}"
             {%- else %}

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -161,8 +161,8 @@ download_binary_and_run_installer() {
             _libs_js_array=""
             _staticlibs=""
             _staticlibs_js_array=""
-            _updater_name=""
-            _updater_bin=""
+            _updater_name="akaikatana-repack-aarch64-apple-darwin-update"
+            _updater_bin="akaikatana-repack-aarch64-apple-darwin-update"
             ;;
         "akaikatana-repack-x86_64-apple-darwin.tar.xz")
             _arch="x86_64-apple-darwin"

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -161,8 +161,8 @@ download_binary_and_run_installer() {
             _libs_js_array=""
             _staticlibs=""
             _staticlibs_js_array=""
-            _updater_name=""
-            _updater_bin=""
+            _updater_name="axolotlsay-aarch64-apple-darwin-update"
+            _updater_bin="axolotlsay-aarch64-apple-darwin-update"
             ;;
         "axolotlsay-x86_64-apple-darwin.tar.gz")
             _arch="x86_64-apple-darwin"


### PR DESCRIPTION
Because minijinja's syntax derives from Python, it's also inherited Python's semantics for falsiness. `0` is falsy and, in this context, so is `Some(0)`. The result is that `if archive.updater` wasn't just checking for definedness but for truthiness, and it would be false for the updater with index `0`.

Fixes #1450.