### PR TITLE
Specify path to Cargo.toml when generating wix for package

### DIFF
--- a/cargo-dist/src/backend/installer/msi.rs
+++ b/cargo-dist/src/backend/installer/msi.rs
@@ -67,6 +67,7 @@ impl MsiInstallerInfo {
     /// run `cargo wix print wxs` to get what the msi should contain
     pub fn generate_wxs_string(&self) -> DistResult<WxsRenders> {
         let mut b = wix::print::wxs::Builder::new();
+        b.input(Some(self.manifest_path.as_str()));
         // Build this specific package
         b.package(Some(&self.pkg_spec));
         let output = self


### PR DESCRIPTION
To avoid an error when generating a wix file for a package whose Cargo.toml is in a sub-folder, specify the full path to the package's Cargo.toml.

Fixes Issue #1453.