### PR TITLE
fix: print Windows paths correctly

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -22,7 +22,10 @@ use crate::{
     DistError, DistGraph, SortedMap, SortedSet, TargetTriple,
 };
 
+#[cfg(not(windows))]
 const GITHUB_CI_DIR: &str = ".github/workflows/";
+#[cfg(windows)]
+const GITHUB_CI_DIR: &str = r".github\workflows\";
 const GITHUB_CI_FILE: &str = "release.yml";
 
 /// Info about running cargo-dist in Github CI


### PR DESCRIPTION
Prior to this, our path handling for Windows produced some slightly chaotic paths - they would begin and end with Unix-style line endings, but would have one native Windows line ending in the middle. This fixes that: we now normalize the path we get from `git`, and assign the constant with the hardcoded file separator appropriately on Windows.

Note that this never affected the behaviour of anything; this was always just a display bug.

Before:

```
generated Github CI to C:/Users/misty/inittest\.github/workflows/release.yml
```

After:

```
generated Github CI to C:\Users\misty\inittest\.github\workflows\release.yml
```

Fixes #1456.