### PR TITLE
Introduce unified manifest file

### DIFF
--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -501,6 +501,9 @@ pub enum ArtifactKind {
     /// A checksum of another artifact
     #[serde(rename = "checksum")]
     Checksum,
+    /// The checksums of many artifacts
+    #[serde(rename = "unified-checksum")]
+    UnifiedChecksum,
     /// A tarball containing the source code
     #[serde(rename = "source-tarball")]
     SourceTarball,

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -200,6 +200,21 @@ expression: json_schema
           }
         },
         {
+          "description": "The checksums of many artifacts",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "unified-checksum"
+              ]
+            }
+          }
+        },
+        {
           "description": "A tarball containing the source code",
           "type": "object",
           "required": [

--- a/cargo-dist/src/config/v0.rs
+++ b/cargo-dist/src/config/v0.rs
@@ -157,9 +157,8 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub npm_scope: Option<String>,
 
-    /// A scope to prefix npm packages with (@ should be included).
-    ///
-    /// This is required if you're using an npm installer.
+    /// Which checksum algorithm to use, from: sha256, sha512, sha3-256,
+    /// sha3-512, blake2s, blake2b, or false (to disable checksums)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checksum: Option<ChecksumStyle>,
 

--- a/cargo-dist/src/config/v1/layer.rs
+++ b/cargo-dist/src/config/v1/layer.rs
@@ -16,7 +16,7 @@ where
 
     /// Merges this value with another layer of itself, preferring the new layer
     ///
-    /// (asymteric case where the rhs is an Option but we're just A Value)
+    /// (asymmetric case where the rhs is an Option but we're just A Value)
     fn apply_val_layer(&mut self, layer: Option<Self::Layer>) {
         if let Some(val) = layer {
             self.apply_layer(val);

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -151,6 +151,10 @@ fn run_build_step(
             dest_path.as_deref(),
             for_artifact.as_ref(),
         )?,
+        BuildStep::UnifiedChecksum(UnifiedChecksumStep {
+            checksum,
+            dest_path,
+        }) => generate_unified_checksum(manifest, *checksum, dest_path)?,
         BuildStep::GenerateSourceTarball(SourceTarballStep {
             committish,
             prefix,
@@ -330,6 +334,10 @@ fn build_fake(
             dest_path.as_deref(),
             for_artifact.as_ref(),
         )?,
+        BuildStep::UnifiedChecksum(UnifiedChecksumStep {
+            checksum,
+            dest_path,
+        }) => generate_unified_checksum(manifest, *checksum, dest_path)?,
         // Except source tarballs, which are definitely not okay
         // We mock these because it requires:
         // 1. git to be installed;
@@ -396,6 +404,39 @@ fn generate_and_write_checksum(
             artifact.checksums.insert(checksum.ext().to_owned(), output);
         }
     }
+    Ok(())
+}
+
+/// Collect all checksums for all artifacts and write them to a unified checksum file
+fn generate_unified_checksum(
+    manifest: &DistManifest,
+    checksum: ChecksumStyle,
+    dest_path: &Utf8Path,
+) -> DistResult<()> {
+    let mut output = String::new();
+    use std::fmt::Write;
+
+    let expected_checksum_ext = checksum.ext();
+
+    for artifact in manifest.artifacts.values() {
+        let artifact_name = if let Some(artifact_name) = artifact.name.as_deref() {
+            artifact_name
+        } else {
+            continue;
+        };
+
+        for (checksum_ext, checksum) in &artifact.checksums {
+            if checksum_ext != expected_checksum_ext {
+                tracing::warn!(
+                    "Found checksum {checksum_ext} for {artifact_name}, expected only {expected_checksum_ext}"
+                );
+                continue;
+            }
+
+            writeln!(&mut output, "{checksum} {artifact_name}").unwrap();
+        }
+    }
+    axoasset::LocalAsset::write_new(&output, dest_path)?;
     Ok(())
 }
 

--- a/cargo-dist/src/manifest.rs
+++ b/cargo-dist/src/manifest.rs
@@ -366,6 +366,11 @@ fn add_manifest_artifact(
             description = None;
             kind = cargo_dist_schema::ArtifactKind::Checksum;
         }
+        ArtifactKind::UnifiedChecksum(_) => {
+            install_hint = None;
+            description = None;
+            kind = cargo_dist_schema::ArtifactKind::UnifiedChecksum;
+        }
         ArtifactKind::SourceTarball(_) => {
             install_hint = None;
             description = None;

--- a/cargo-dist/tests/gallery/dist.rs
+++ b/cargo-dist/tests/gallery/dist.rs
@@ -104,6 +104,7 @@ pub struct AppResult {
     homebrew_installer_path: Option<Utf8PathBuf>,
     powershell_installer_path: Option<Utf8PathBuf>,
     npm_installer_package_path: Option<Utf8PathBuf>,
+    unified_checksum_path: Option<Utf8PathBuf>,
 }
 
 pub struct PlanResult {
@@ -238,6 +239,7 @@ impl<'a> TestContext<'a, Tools> {
             let homebrew_installer = Utf8PathBuf::from(format!("{target_dir}/{brew_app_name}.rb"));
             let npm_installer =
                 Utf8PathBuf::from(format!("{target_dir}/{app_name}-npm-package.tar.gz"));
+            let unified_checksum_path = Utf8PathBuf::from(format!("{target_dir}/sha256.sum"));
             app_results.push(AppResult {
                 test_name: test_name.to_owned(),
                 trust_hashes,
@@ -247,6 +249,9 @@ impl<'a> TestContext<'a, Tools> {
                 powershell_installer_path: ps_installer.exists().then_some(ps_installer),
                 homebrew_installer_path: homebrew_installer.exists().then_some(homebrew_installer),
                 npm_installer_package_path: npm_installer.exists().then_some(npm_installer),
+                unified_checksum_path: unified_checksum_path
+                    .exists()
+                    .then_some(unified_checksum_path),
             })
         }
 

--- a/cargo-dist/tests/gallery/dist/snapshot.rs
+++ b/cargo-dist/tests/gallery/dist/snapshot.rs
@@ -46,6 +46,14 @@ impl DistResult {
                     .unwrap_or_default(),
                 app.npm_installer_package_path.as_deref(),
             )?;
+            append_snapshot_file(
+                &mut snapshots,
+                app.unified_checksum_path
+                    .as_deref()
+                    .and_then(|p| p.file_name())
+                    .unwrap_or_default(),
+                app.unified_checksum_path.as_deref(),
+            )?;
         }
 
         Ok(Snapshots {

--- a/cargo-dist/tests/gallery/dist/snapshot.rs
+++ b/cargo-dist/tests/gallery/dist/snapshot.rs
@@ -168,6 +168,10 @@ pub fn snapshot_settings_with_gallery_filter() -> insta::Settings {
         r#""build_environment": "windows""#,
         r#""build_environment": "indeterminate""#,
     );
+    settings.add_filter(
+        r"[0-9a-f]{64} ([a-zA-Z0-9-]+)-npm-package\.tar\.gz",
+        "CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz",
+    );
     settings
 }
 

--- a/cargo-dist/tests/gallery/dist/snapshot.rs
+++ b/cargo-dist/tests/gallery/dist/snapshot.rs
@@ -169,8 +169,12 @@ pub fn snapshot_settings_with_gallery_filter() -> insta::Settings {
         r#""build_environment": "indeterminate""#,
     );
     settings.add_filter(
-        r"[0-9a-f]{64} ([a-zA-Z0-9-]+)-npm-package\.tar\.gz",
-        "CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz",
+        r"[0-9a-f]{64} ([a-zA-Z0-9-_]+)\.tar\.gz",
+        "CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz",
+    );
+    settings.add_filter(
+        r"[0-9a-f]{64} ([a-zA-Z0-9-_]+)\.pkg",
+        "CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.pkg",
     );
     settings
 }

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1777,6 +1777,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+142e0662b2d165342ba462d51c6b360f0385d0ac2cd1777cead765f15b63fc5c source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1803,6 +1806,7 @@ try {
         "akaikatana-repack-installer.sh",
         "akaikatana-repack-installer.ps1",
         "akaikatana-repack.rb",
+        "sha256.sum",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz.sha256",
         "akaikatana-repack-x86_64-apple-darwin.tar.xz",
@@ -2035,6 +2039,10 @@ try {
       ],
       "install_hint": "brew install mistydemeo/formulae/akaikatana-repack",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1778,7 +1778,7 @@ try {
 }
 
 ================ sha256.sum ================
-142e0662b2d165342ba462d51c6b360f0385d0ac2cd1777cead765f15b63fc5c source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1214,7 +1214,7 @@ downloader() {
 download_binary_and_run_installer "$@" || exit 1
 
 ================ sha256.sum ================
-142e0662b2d165342ba462d51c6b360f0385d0ac2cd1777cead765f15b63fc5c source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1213,6 +1213,9 @@ downloader() {
 
 download_binary_and_run_installer "$@" || exit 1
 
+================ sha256.sum ================
+142e0662b2d165342ba462d51c6b360f0385d0ac2cd1777cead765f15b63fc5c source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1237,6 +1240,7 @@ download_binary_and_run_installer "$@" || exit 1
         "source.tar.gz",
         "source.tar.gz.sha256",
         "akaikatana-repack-installer.sh",
+        "sha256.sum",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz.sha256",
         "akaikatana-repack-x86_64-apple-darwin.tar.xz",
@@ -1448,6 +1452,10 @@ download_binary_and_run_installer "$@" || exit 1
       "target_triples": [
         "x86_64-unknown-linux-musl"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1808,7 +1808,7 @@ try {
 }
 
 ================ sha256.sum ================
-142e0662b2d165342ba462d51c6b360f0385d0ac2cd1777cead765f15b63fc5c source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1807,6 +1807,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+142e0662b2d165342ba462d51c6b360f0385d0ac2cd1777cead765f15b63fc5c source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1833,6 +1836,7 @@ try {
         "akaikatana-repack-installer.sh",
         "akaikatana-repack-installer.ps1",
         "akaikatana-repack.rb",
+        "sha256.sum",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz.sha256",
         "akaikatana-repack-x86_64-apple-darwin.tar.xz",
@@ -2065,6 +2069,10 @@ try {
       ],
       "install_hint": "brew install mistydemeo/formulae/akaikatana-repack",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1833,6 +1833,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+142e0662b2d165342ba462d51c6b360f0385d0ac2cd1777cead765f15b63fc5c source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1859,6 +1862,7 @@ try {
         "akaikatana-repack-installer.sh",
         "akaikatana-repack-installer.ps1",
         "akaikatana-repack.rb",
+        "sha256.sum",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz.sha256",
         "akaikatana-repack-x86_64-apple-darwin.tar.xz",
@@ -2091,6 +2095,10 @@ try {
       ],
       "install_hint": "brew install mistydemeo/formulae/akaikatana-repack",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1834,7 +1834,7 @@ try {
 }
 
 ================ sha256.sum ================
-142e0662b2d165342ba462d51c6b360f0385d0ac2cd1777cead765f15b63fc5c source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1786,7 +1786,7 @@ try {
 }
 
 ================ sha256.sum ================
-142e0662b2d165342ba462d51c6b360f0385d0ac2cd1777cead765f15b63fc5c source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1785,6 +1785,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+142e0662b2d165342ba462d51c6b360f0385d0ac2cd1777cead765f15b63fc5c source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1811,6 +1814,7 @@ try {
         "akaikatana-repack-installer.sh",
         "akaikatana-repack-installer.ps1",
         "akaikatana-repack.rb",
+        "sha256.sum",
         "akaikatana-repack-aarch64-apple-darwin-update",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz",
         "akaikatana-repack-aarch64-apple-darwin.tar.xz.sha256",
@@ -2075,6 +2079,10 @@ try {
       ],
       "install_hint": "brew install mistydemeo/formulae/akaikatana-repack",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+f34166ec8dd84f6cfa6643733e1de538539355efc00aea53fbda263cd61a2ecc axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3242,6 +3246,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -3623,6 +3628,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-f34166ec8dd84f6cfa6643733e1de538539355efc00aea53fbda263cd61a2ecc axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-6638c24608479e3e35caa69fc77fc1721e8517a4c9410e917863bec44f7f8131 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+6638c24608479e3e35caa69fc77fc1721e8517a4c9410e917863bec44f7f8131 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3241,6 +3245,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -3617,6 +3622,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3246,6 +3246,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+c3f52004f440435da76b054d4113132ff205f4c116b798c6a05f61ad987e7887 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3274,6 +3278,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -3647,6 +3652,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3247,8 +3247,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3247,7 +3247,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-c3f52004f440435da76b054d4113132ff205f4c116b798c6a05f61ad987e7887 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3248,6 +3248,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+187b40c83319610de250f5e5b471ee89bd0fd50ea67b7d78fc51f70fd26ffbf2 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3276,6 +3280,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -3649,6 +3654,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3249,7 +3249,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-187b40c83319610de250f5e5b471ee89bd0fd50ea67b7d78fc51f70fd26ffbf2 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3249,8 +3249,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+caf7276a521e32a73149a5843d9922919a92f5269336fd5f6bc35d38b22a5cc3 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3242,6 +3246,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -3615,6 +3620,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-caf7276a521e32a73149a5843d9922919a92f5269336fd5f6bc35d38b22a5cc3 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3219,13 +3219,13 @@ run("axolotlsay");
 
 ================ sha256.sum ================
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 axolotlsay-aarch64-apple-darwin.pkg
-8c03c4bdf1e8745f82d9c197a340dca2668a89e4529e57f7bc4d7eec7e000233 axolotlsay-aarch64-apple-darwin.tar.gz
-46c543bc15c20d554e51d9a87b02886c9987872a74c5d82e36acb64bbc39ccc4 axolotlsay-npm-package.tar.gz
+0b8f2ece31d03b7deb5ec51f272f0c813d3e089d16b1f6fdb925c85560a4ed4f axolotlsay-aarch64-apple-darwin.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 axolotlsay-x86_64-apple-darwin.pkg
-9b09a4896a0f7c68a9ce9619ebc0b2e07a351d6a673136ce79b61ebae21cfeb6 axolotlsay-x86_64-apple-darwin.tar.gz
+a1dbddc71d911e0fc1eb9ccaaf2d068406fbd5b7cb12e09edfdedc7ccbcd5ca3 axolotlsay-x86_64-apple-darwin.tar.gz
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 axolotlsay-x86_64-pc-windows-msvc.msi
-f54e3eedbd9a7a3fc7966b7706d3ec07f0fb864a3a8ee54d88fa0832f12731fd axolotlsay-x86_64-pc-windows-msvc.tar.gz
-90eea05ca3752335cdcd512dfdc334695b843558b70de8a50201b901881a491d axolotlsay-x86_64-unknown-linux-gnu.tar.gz
+7780b1a0d9477f19957c1706d05edd78c52e97f6699ef460a12322221daeb8e5 axolotlsay-x86_64-pc-windows-msvc.tar.gz
+04dd420e074fb3eb0200228afc76c75498995d04d7c20c4d5d47571434c4a10c axolotlsay-x86_64-unknown-linux-gnu.tar.gz
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3217,6 +3217,17 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 axolotlsay-aarch64-apple-darwin.pkg
+8c03c4bdf1e8745f82d9c197a340dca2668a89e4529e57f7bc4d7eec7e000233 axolotlsay-aarch64-apple-darwin.tar.gz
+46c543bc15c20d554e51d9a87b02886c9987872a74c5d82e36acb64bbc39ccc4 axolotlsay-npm-package.tar.gz
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 axolotlsay-x86_64-apple-darwin.pkg
+9b09a4896a0f7c68a9ce9619ebc0b2e07a351d6a673136ce79b61ebae21cfeb6 axolotlsay-x86_64-apple-darwin.tar.gz
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 axolotlsay-x86_64-pc-windows-msvc.msi
+f54e3eedbd9a7a3fc7966b7706d3ec07f0fb864a3a8ee54d88fa0832f12731fd axolotlsay-x86_64-pc-windows-msvc.tar.gz
+90eea05ca3752335cdcd512dfdc334695b843558b70de8a50201b901881a491d axolotlsay-x86_64-unknown-linux-gnu.tar.gz
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3245,6 +3256,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -3642,6 +3654,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3218,15 +3218,15 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 axolotlsay-aarch64-apple-darwin.pkg
-0b8f2ece31d03b7deb5ec51f272f0c813d3e089d16b1f6fdb925c85560a4ed4f axolotlsay-aarch64-apple-darwin.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 axolotlsay-x86_64-apple-darwin.pkg
-a1dbddc71d911e0fc1eb9ccaaf2d068406fbd5b7cb12e09edfdedc7ccbcd5ca3 axolotlsay-x86_64-apple-darwin.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.pkg
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.pkg
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 axolotlsay-x86_64-pc-windows-msvc.msi
-7780b1a0d9477f19957c1706d05edd78c52e97f6699ef460a12322221daeb8e5 axolotlsay-x86_64-pc-windows-msvc.tar.gz
-04dd420e074fb3eb0200228afc76c75498995d04d7c20c4d5d47571434c4a10c axolotlsay-x86_64-unknown-linux-gnu.tar.gz
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+0142dc6c05af98c9084c67115be3bceb24fecbc7d6783e039e3c919d48c3d32a axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3242,6 +3246,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -3615,6 +3620,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-0142dc6c05af98c9084c67115be3bceb24fecbc7d6783e039e3c919d48c3d32a axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1230,6 +1230,7 @@ download_binary_and_run_installer "$@" || exit 1
         "source.tar.gz",
         "source.tar.gz.blake2b",
         "axolotlsay-installer.sh",
+        "blake2b.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.blake2b",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -1432,6 +1433,10 @@ download_binary_and_run_installer "$@" || exit 1
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "blake2b.sum": {
+      "name": "blake2b.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1230,6 +1230,7 @@ download_binary_and_run_installer "$@" || exit 1
         "source.tar.gz",
         "source.tar.gz.blake2s",
         "axolotlsay-installer.sh",
+        "blake2s.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.blake2s",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -1432,6 +1433,10 @@ download_binary_and_run_installer "$@" || exit 1
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "blake2s.sum": {
+      "name": "blake2s.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1230,6 +1230,7 @@ download_binary_and_run_installer "$@" || exit 1
         "source.tar.gz",
         "source.tar.gz.sha3-256",
         "axolotlsay-installer.sh",
+        "sha3-256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha3-256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -1432,6 +1433,10 @@ download_binary_and_run_installer "$@" || exit 1
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "sha3-256.sum": {
+      "name": "sha3-256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1230,6 +1230,7 @@ download_binary_and_run_installer "$@" || exit 1
         "source.tar.gz",
         "source.tar.gz.sha3-512",
         "axolotlsay-installer.sh",
+        "sha3-512.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha3-512",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -1432,6 +1433,10 @@ download_binary_and_run_installer "$@" || exit 1
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "sha3-512.sum": {
+      "name": "sha3-512.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -68,7 +68,7 @@ class AxolotlBrew < Formula
 end
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -67,6 +67,9 @@ class AxolotlBrew < Formula
   end
 end
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -92,6 +95,7 @@ end
         "source.tar.gz",
         "source.tar.gz.sha256",
         "axolotl-brew.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -294,6 +298,10 @@ end
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -2,6 +2,9 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -26,6 +29,7 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
+        "sha256.sum",
         "axolotlsay-aarch64-unknown-linux-gnu.tar.xz",
         "axolotlsay-aarch64-unknown-linux-gnu.tar.xz.sha256",
         "axolotlsay-aarch64-unknown-linux-musl.tar.xz",
@@ -216,6 +220,10 @@ expression: self.payload
       "target_triples": [
         "x86_64-unknown-linux-musl"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-34cbcf6643c823f6561caa84f9e076d16ced08dedf060b4fef79320f11149105 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3214,6 +3214,9 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+34cbcf6643c823f6561caa84f9e076d16ced08dedf060b4fef79320f11149105 axolotlsay-npm-package.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3240,6 +3243,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -3613,6 +3617,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     }
   },
   "systems": {

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -2,6 +2,9 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -26,6 +29,7 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.xz",
         "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.xz",
@@ -216,6 +220,10 @@ expression: self.payload
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -2,6 +2,9 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -26,6 +29,7 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.xz",
         "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.xz",
@@ -224,6 +228,10 @@ expression: self.payload
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -2,6 +2,9 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -25,6 +28,7 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.xz",
         "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.xz",
@@ -218,6 +222,10 @@ expression: self.payload
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-cb4dfeb71c4e5451146c3fb40078f72af97528972dfc132ba2e6242d65839f46 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+cb4dfeb71c4e5451146c3fb40078f72af97528972dfc132ba2e6242d65839f46 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3242,6 +3246,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -3537,6 +3542,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1776,6 +1776,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+75d8c6cbd1ddf538fc8fb63d2b29e0db7789ce11b58e3332733dd9faed50b709 source.tar.gz
+
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
@@ -3551,6 +3554,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+75d8c6cbd1ddf538fc8fb63d2b29e0db7789ce11b58e3332733dd9faed50b709 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3577,6 +3583,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.xz",
         "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.xz",
@@ -3611,6 +3618,7 @@ try {
         "axolotlsay-js-installer.sh",
         "axolotlsay-js-installer.ps1",
         "axolotlsay-js.rb",
+        "sha256.sum",
         "axolotlsay-js-aarch64-apple-darwin.tar.xz",
         "axolotlsay-js-aarch64-apple-darwin.tar.xz.sha256",
         "axolotlsay-js-x86_64-apple-darwin.tar.xz",
@@ -4021,6 +4029,10 @@ try {
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1777,7 +1777,7 @@ try {
 }
 
 ================ sha256.sum ================
-75d8c6cbd1ddf538fc8fb63d2b29e0db7789ce11b58e3332733dd9faed50b709 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3555,7 +3555,7 @@ try {
 }
 
 ================ sha256.sum ================
-75d8c6cbd1ddf538fc8fb63d2b29e0db7789ce11b58e3332733dd9faed50b709 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-ec6c1d3848961e9d897c8793a104197606552353c12d46a7bc802008806ff913 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+ec6c1d3848961e9d897c8793a104197606552353c12d46a7bc802008806ff913 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3242,6 +3246,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -3615,6 +3620,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2644,7 +2644,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-e6f853f440cd8ea358c2d38f779ba9a4ddd3fe888df5ea3f082c289c1a108d24 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2644,8 +2644,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2643,6 +2643,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+e6f853f440cd8ea358c2d38f779ba9a4ddd3fe888df5ea3f082c289c1a108d24 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -2669,6 +2673,7 @@ run("axolotlsay");
         "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2942,6 +2947,10 @@ run("axolotlsay");
       "target_triples": [
         "x86_64-unknown-linux-musl"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2623,6 +2623,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+280baf2981584566fce75a57b28f5075b59b6b1307b9b2181335397e023b0b37 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -2649,6 +2653,7 @@ run("axolotlsay");
         "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2877,6 +2882,10 @@ run("axolotlsay");
       "target_triples": [
         "x86_64-unknown-linux-musl"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2624,8 +2624,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2624,7 +2624,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-280baf2981584566fce75a57b28f5075b59b6b1307b9b2181335397e023b0b37 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+f8dc27cab7338ad359e28eef70d66b7fe0239e975308f5cde10076e035842f34 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3242,6 +3246,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -3537,6 +3542,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-f8dc27cab7338ad359e28eef70d66b7fe0239e975308f5cde10076e035842f34 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -2,6 +2,9 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -26,6 +29,7 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.xz",
         "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.xz",
@@ -216,6 +220,10 @@ expression: self.payload
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -2,6 +2,9 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -26,6 +29,7 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.xz",
         "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.xz",
@@ -216,6 +220,10 @@ expression: self.payload
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3253,8 +3253,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3252,6 +3252,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+89116b2b5e7bd5c40dfdbff30d36e5233ff953ec79a01cbbca68d9e94b685cf5 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3280,6 +3284,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -3653,6 +3658,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3253,7 +3253,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-89116b2b5e7bd5c40dfdbff30d36e5233ff953ec79a01cbbca68d9e94b685cf5 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1712,6 +1712,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1738,6 +1741,7 @@ try {
         "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -2028,6 +2032,10 @@ try {
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1713,7 +1713,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1712,6 +1712,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1738,6 +1741,7 @@ try {
         "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-aarch64-apple-darwin.pkg",
@@ -2028,6 +2032,10 @@ try {
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1713,7 +1713,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -2,6 +2,9 @@
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -26,6 +29,7 @@ expression: self.payload
       "artifacts": [
         "source.tar.gz",
         "source.tar.gz.sha256",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.xz",
         "axolotlsay-aarch64-apple-darwin.tar.xz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.xz",
@@ -216,6 +220,10 @@ expression: self.payload
       "target_triples": [
         "x86_64-unknown-linux-gnu"
       ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3223,7 +3223,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-475b4625fca3e213ab8a38fcb887afdacca13f625decf251005481770bcf91e3 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3222,6 +3222,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+475b4625fca3e213ab8a38fcb887afdacca13f625decf251005481770bcf91e3 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3250,6 +3254,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin-update",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
@@ -3655,6 +3660,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3223,8 +3223,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-f0674e45ffa2f8d4bb30718534aaf25c79acc9133c87d80d65fc5debdefacd7e axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+f0674e45ffa2f8d4bb30718534aaf25c79acc9133c87d80d65fc5debdefacd7e axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3242,6 +3246,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -3537,6 +3542,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+8f47b69cb2e1725dc9bee834487a0f974f3b8d7367af0915d1c62eaac82e5973 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3242,6 +3246,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -3537,6 +3542,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-8f47b69cb2e1725dc9bee834487a0f974f3b8d7367af0915d1c62eaac82e5973 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+bbd3df81bcb22de602ce58a2c866704505787bc02e7f4bd29a5c862673c99ce8 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3242,6 +3246,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -3537,6 +3542,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-bbd3df81bcb22de602ce58a2c866704505787bc02e7f4bd29a5c862673c99ce8 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-c6230d18aa601c26b0320eab61fc1730c8cf7187669ba60ae006ea536b5c56f2 axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+c6230d18aa601c26b0320eab61fc1730c8cf7187669ba60ae006ea536b5c56f2 axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3242,6 +3246,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -3537,6 +3542,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3214,6 +3214,10 @@ install(false);
 const { run } = require("./binary");
 run("axolotlsay");
 
+================ sha256.sum ================
+ed0992d85cb66ae9ab9aaa118c244683eba33578d15b5f3d05e93d168de4cd6f axolotlsay-npm-package.tar.gz
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -3242,6 +3246,7 @@ run("axolotlsay");
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
         "axolotlsay-npm-package.tar.gz",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -3537,6 +3542,10 @@ run("axolotlsay");
       ],
       "install_hint": "brew install axodotdev/packages/axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-ed0992d85cb66ae9ab9aaa118c244683eba33578d15b5f3d05e93d168de4cd6f axolotlsay-npm-package.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) npm-package.tar.gz
 6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
 
 ================ dist-manifest.json ================

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1777,6 +1777,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1804,6 +1807,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2028,6 +2032,10 @@ try {
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1778,7 +1778,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1753,6 +1753,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1780,6 +1783,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2004,6 +2008,10 @@ try {
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1753,6 +1753,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1780,6 +1783,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2004,6 +2008,10 @@ try {
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1753,6 +1753,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1780,6 +1783,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2004,6 +2008,10 @@ try {
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1753,6 +1753,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1780,6 +1783,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2004,6 +2008,10 @@ try {
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1777,7 +1777,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1776,6 +1776,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1803,6 +1806,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2027,6 +2031,10 @@ try {
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1753,6 +1753,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1780,6 +1783,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2004,6 +2008,10 @@ try {
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1753,6 +1753,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1780,6 +1783,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2004,6 +2008,10 @@ try {
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1753,6 +1753,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1780,6 +1783,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2004,6 +2008,10 @@ try {
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1753,6 +1753,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1780,6 +1783,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2004,6 +2008,10 @@ try {
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1777,7 +1777,7 @@ try {
 }
 
 ================ sha256.sum ================
-6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1776,6 +1776,9 @@ try {
   exit 1
 }
 
+================ sha256.sum ================
+6dd3a33b92c3c35b05d8b4c350e7600d9db3f000e402ac0bf226859ec6b0c984 source.tar.gz
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",
@@ -1803,6 +1806,7 @@ try {
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
         "axolotlsay.rb",
+        "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
@@ -2027,6 +2031,10 @@ try {
       ],
       "install_hint": "brew install axolotlsay",
       "description": "Install prebuilt binaries via Homebrew"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -31,6 +31,7 @@ stdout:
         "cargo-dist-installer.ps1",
         "cargo-dist.rb",
         "cargo-dist-npm-package.tar.gz",
+        "sha256.sum",
         "cargo-dist-aarch64-apple-darwin.tar.xz",
         "cargo-dist-aarch64-apple-darwin.tar.xz.sha256",
         "cargo-dist-aarch64-unknown-linux-gnu.tar.xz",
@@ -488,6 +489,10 @@ stdout:
     "dist-manifest-schema.json": {
       "name": "dist-manifest-schema.json",
       "kind": "extra-artifact"
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
     },
     "source.tar.gz": {
       "name": "source.tar.gz",


### PR DESCRIPTION
Closes #1321

This writes out unified checksum files like `sha256.sum` or `sha512.sum` (which are compatible with GNU-style `sha256sum -c sha256.sum` invocations) depending on which checksum style is chosen from the dist config.

It's a new global artifact which is built after all the local artifacts, re-using the checksums computed earlier. The plan is to eventually stop publishing individual checksum files like `some-binary.sha256` and only publish the unified checksum file, which will reduce noise / make publishing faster, etc.