### PR TITLE
Fix typos and add typo checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,14 @@ jobs:
       - uses: swatinem/rust-cache@v2
       - run: cargo doc --workspace --no-deps
 
+  # Check for typos (exceptions are provided by the typos.toml)
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check spelling of entire workspace
+        uses: crate-ci/typos@v1.26.0
+
   # Build and run tests/doctests/examples on all platforms
   # FIXME: look into `cargo-hack` which lets you more aggressively
   # probe all your features and rust versions (see tracing's ci)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ This is a small patch release that incidentally includes some initial groundwork
 
 * @gankra [fix: give PATH update instructions for cmd too](https://github.com/axodotdev/cargo-dist/pull/1382)
 * @gankra [fix: make linkage truly infallible](https://github.com/axodotdev/cargo-dist/pull/1390)
-* @mistydemeo [feat: intial impl of Mac .pkg installer](https://github.com/axodotdev/cargo-dist/pull/1312)
+* @mistydemeo [feat: initial impl of Mac .pkg installer](https://github.com/axodotdev/cargo-dist/pull/1312)
 
 
 # Version 0.22.0 (2024-08-28)
@@ -90,7 +90,7 @@ We generate installers for our users- and then our *users' users* use those inst
 
 While we had implemented some environment variables that enable users to control the behavior of installers, previously they were largely designed for internal use, and therefore namespaced with `DIST`. However, we quickly realized that this isn't suitable for having our users communicate with their users- so we've enabled the generation of app-branded installer customization environment variables- so that installer users can leverage environment variables that are branded to the application they are trying to install.
 
-Right now, the only customization we allow for installers is the install directory- so instead of `CARGO_DIST_FORCE_INSTALL_DIR`, you can tell your users to use `AXOLOTLSAY_INSTALL_DIR` (if your app is named `axolotlsay`). If you have a name with hypens or other characters, we normalize it for you, and you can find this value at the `install_dir_env_var` field in the `dist-manifest.json` that is generated with each of your releases.
+Right now, the only customization we allow for installers is the install directory- so instead of `CARGO_DIST_FORCE_INSTALL_DIR`, you can tell your users to use `AXOLOTLSAY_INSTALL_DIR` (if your app is named `axolotlsay`). If you have a name with hyphens or other characters, we normalize it for you, and you can find this value at the `install_dir_env_var` field in the `dist-manifest.json` that is generated with each of your releases.
 
 * impl @mistydemeo [add app branded env var for custom dir to installers](https://github.com/axodotdev/cargo-dist/pull/1377)
 
@@ -109,7 +109,7 @@ This PR translates the SPDX expression to the Homebrew license DSL.
 
 Creating a personal tap with brew tap-new creates a default Github Actions workflow that runs a homebrew-specific style check (brew style <TAPNAME>) on the repo. Cargo-dist's generated homebrew formulas fail this style check. This does not block the core functionality of cargo-dist's homebrew publishing functionality (formula still functions), but does mean that users whorun `brew style` (which is a side effect of creating a tap with `brew tap-new`) would get frustrating errors.
 
-Rather than separately chasing formatting issues as they come up, this PR updates the homebrew publish workflow to install and run `brew style --fix` on each formula before commiting it.
+Rather than separately chasing formatting issues as they come up, this PR updates the homebrew publish workflow to install and run `brew style --fix` on each formula before committing it.
 
 * impl
   * @cxreiff [format homebrew formulas with brew style --fix](https://github.com/axodotdev/cargo-dist/pull/1340)
@@ -242,7 +242,7 @@ In the future we *may* just enable system certificates by default. We're being a
 ## Features
 
 
-### disabling the CI build cache when unecessary
+### disabling the CI build cache when unnecessary
 
 For a long time now we've had [`swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) as part of cargo-dist's CI build jobs. In fact, improving the configuration for that cache has been one of the most frequent new contributions!
 
@@ -422,7 +422,7 @@ When a shell or powershell installer runs successfully it will print out "everyt
 
 cargo-dist has traditionally parsed the version number of new releases and used this to determine if the new release is a prerelease or a stable release. We apply some special handling to prereleases, such as marking them as prereleases within GitHub Releases. In 0.15.0, we've added the new [`force-latest`](https://opensource.axo.dev/cargo-dist/book/reference/config.html#force-latest) configuration flag which makes it possible to instruct cargo-dist to treat every release as the latest release regardless of its version number.
 
-This mostly exists to support projects who only plan to produce prereleases for the forseeable future, so that GitHub properly shows them in its UI.
+This mostly exists to support projects who only plan to produce prereleases for the foreseeable future, so that GitHub properly shows them in its UI.
 
 * [docs](https://opensource.axo.dev/cargo-dist/book/reference/config.html#force-latest)
 * impl @mistydemeo [feat: allow always marking releases as stable](https://github.com/axodotdev/cargo-dist/pull/1054)
@@ -754,7 +754,7 @@ This release is a few minor improvements, and a new config for homebrew installe
 
 ## Features
 
-The name of your homebrew formula can now be overriden with `formula = "my-cool-formula"`.
+The name of your homebrew formula can now be overridden with `formula = "my-cool-formula"`.
 
 * [docs](opensource.axo.dev/cargo-dist/book/reference/config.html#formula)
 * @ashleygwilliams [impl](https://github.com/axodotdev/cargo-dist/pull/791)
@@ -1266,7 +1266,7 @@ Note that because these binaries are statically linked, they cannot dynamically 
 
 ### msvc-crt-static opt-out
 
-cargo-dist has [always forced +crt-static on, as it is considered more correct for targetting Windows with the typical statically linked Rust binary](https://github.com/rust-lang/rfcs/blob/master/text/1721-crt-static.md). However with the introduction of initial support for chocolatey as a system package manager, it's now very easy for our users to dynamically link other DLLs. Once you do, [it once again becomes more correct to dynamically link the windows crt, and to use systems like Visual C(++) Redistributables](https://github.com/axodotdev/cargo-dist/issues/496).
+cargo-dist has [always forced +crt-static on, as it is considered more correct for targeting Windows with the typical statically linked Rust binary](https://github.com/rust-lang/rfcs/blob/master/text/1721-crt-static.md). However with the introduction of initial support for chocolatey as a system package manager, it's now very easy for our users to dynamically link other DLLs. Once you do, [it once again becomes more correct to dynamically link the windows crt, and to use systems like Visual C(++) Redistributables](https://github.com/axodotdev/cargo-dist/issues/496).
 
 Although we [would like to teach cargo-dist to handle redistributables for you](https://github.com/axodotdev/cargo-dist/issues/496), we're starting with a simple escape hatch: if you set `msvc-crt-static = false` in `[workspace.metadata.dist]`, we'll revert to the typical Rust behaviour of dynamically linking the CRT.
 
@@ -1793,7 +1793,7 @@ You can now include persistent configuration for cargo-dist in `[workspace.metad
 
 Previously cargo-dist had some vague notions of what it was supposed to do when you invoked it, because there were platform-specific artifacts like executable-zips but also more platform-agnostic ones like installer scripts. This result in flags like `--no-builds` with messy semantics and hacks to filter out artifacts we "don't want right now" in the CI scripts (`--no-builds` was is removed in this release, it was busted).
 
-Now cargo-dist can produce well-defined subsets of all tne possible artifacts with the `--artifacts` flag:
+Now cargo-dist can produce well-defined subsets of all the possible artifacts with the `--artifacts` flag:
 
 > --artifacts = "local" | "global" | "all" | "host"
 >

--- a/axoproject/src/changelog.rs
+++ b/axoproject/src/changelog.rs
@@ -1,4 +1,4 @@
-//! Support for interpretting changelogs
+//! Support for interpreting changelogs
 
 use camino::Utf8Path;
 

--- a/axoproject/src/errors.rs
+++ b/axoproject/src/errors.rs
@@ -25,12 +25,12 @@ pub enum AxoprojectError {
     #[diagnostic(transparent)]
     Axoprocess(#[from] axoprocess::AxoprocessError),
 
-    /// An error occured in guppy/cargo-metadata when trying to find a cargo project
+    /// An error occurred in guppy/cargo-metadata when trying to find a cargo project
     #[cfg(feature = "cargo-projects")]
     #[error(transparent)]
     CargoMetadata(#[from] guppy::Error),
 
-    /// An error occured in parse_changelog
+    /// An error occurred in parse_changelog
     #[error(transparent)]
     ParseChangelog(#[from] parse_changelog::Error),
 
@@ -92,7 +92,7 @@ pub enum AxoprojectError {
         url2: String,
     },
 
-    /// An error that occured while trying to find READMEs and whatnot in your project dir
+    /// An error that occurred while trying to find READMEs and whatnot in your project dir
     #[error("couldn't search for files in\n{dir}")]
     AutoIncludeSearch {
         /// path to the dir we were searching

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -656,7 +656,7 @@ pub struct AutoIncludes {
 ///
 /// This includes:
 ///
-/// * reamde: `README*`
+/// * readme: `README*`
 /// * license: `LICENSE*` and `UNLICENSE*`
 /// * changelog: `CHANGELOG*` and `RELEASES*`
 ///

--- a/axoproject/src/tests.rs
+++ b/axoproject/src/tests.rs
@@ -658,7 +658,7 @@ fn generic_workspace_check<'a>(path: impl Into<&'a Utf8Path>) {
             package.changelog_file.as_deref().unwrap(),
             "inner fake changelog!",
         );
-        // repository should yield this one, so this should faile
+        // repository should yield this one, so this should fail
         assert_eq!(
             workspaces
                 .repository_url(Some(&[PackageIdx(0)]))
@@ -739,7 +739,7 @@ fn shared_workspace_check<'a>(path: impl Into<&'a Utf8Path>) {
             package.changelog_file.as_deref().unwrap(),
             "inner fake changelog!",
         );
-        // repository should yield this one, so this should faile
+        // repository should yield this one, so this should fail
         assert_eq!(
             workspaces
                 .repository_url(Some(&[PackageIdx(0)]))

--- a/book/src/ci/customizing.md
+++ b/book/src/ci/customizing.md
@@ -189,7 +189,7 @@ this as early in the build job as possible.
 Currently the use of [folding](https://yaml.org/spec/1.2.2/#813-folded-style) (`>`) and
 [chomping](https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator) (`-`) multi-line string
 modifiers will probably generate a surprising outputs. This is particularly important for any
-actions that use the `run` keyword and it is recomended to use the literal (`|`) string modifier for
+actions that use the `run` keyword and it is recommended to use the literal (`|`) string modifier for
 multi-line strings.
 
 ### Bring your own release

--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -136,7 +136,7 @@ This section represents all the configuration for how cargo-dist should build an
 
 This is a list of [`generate`][generate] tasks for cargo-dist to ignore when checking if generated configuration is up to date.
 
-**We recommend avoiding setting this, as it prevents cargo-dist from updating these files for you whenever you update or change your configuation. If you think you need this, please [do file an issue](https://github.com/axodotdev/cargo-dist/issues/new) or ask us about it, so we know what settings we're missing that necessitates this (or ideally, can point you to the existing settings).**
+**We recommend avoiding setting this, as it prevents cargo-dist from updating these files for you whenever you update or change your configuration. If you think you need this, please [do file an issue](https://github.com/axodotdev/cargo-dist/issues/new) or ask us about it, so we know what settings we're missing that necessitates this (or ideally, can point you to the existing settings).**
 
 Nevertheless, setting can be necessary for users who customize their own configuration beyond cargo-dist's generated defaults and want to avoid cargo-dist overwriting it.
 
@@ -175,7 +175,7 @@ The syntax must be a valid [Cargo-style SemVer Version][semver-version] (not a V
 > dist = true
 > ```
 
-Specifies whether cargo-dist [should distribute (build and publish) a package][distribute], overidding all other rules for deciding if a package is eligible.
+Specifies whether cargo-dist [should distribute (build and publish) a package][distribute], overriding all other rules for deciding if a package is eligible.
 
 There are 3 major cases where you might use this:
 
@@ -1104,7 +1104,7 @@ Also note that for legacy reasons a tarball is expected to have all the contents
 
 Determines whether CI will try to cache work between builds. Defaults false, unless [`release-branch`](#release-branch) or [`pr-run-mode = "upload"`](#pr-run-mode) are enabled.
 
-This is unlikely to be productive because for safety the cache agressively invalidates based on things like "Cargo.toml or Cargo.lock changed" (which is always true if you change the version of a Rust project), and a noop cache run can randomly take over 2 minutes (typically more like 10 seconds).
+This is unlikely to be productive because for safety the cache aggressively invalidates based on things like "Cargo.toml or Cargo.lock changed" (which is always true if you change the version of a Rust project), and a noop cache run can randomly take over 2 minutes (typically more like 10 seconds).
 
 The cases where we enable it by default are the only ones we know where you *might* want to enable it.
 
@@ -1706,7 +1706,7 @@ Throughout the above docs, different settings will have different rules for wher
 
 * global-only: this setting can only be set in the root workspace config ([dist-workspace.toml][js-guide] or [dist.toml][project-guide])
 * package-only: this setting can only be set in a package config ([dist.toml][project-guide])
-* package-local: this setting can be set in either, with the package overidding the workspace value if it provides one (and otherwise inheriting it).
+* package-local: this setting can be set in either, with the package overriding the workspace value if it provides one (and otherwise inheriting it).
 
 When you override a package-local setting, the workspace value will be discarded completely. So for instance if the workspace sets `features = ["feature1", "feature2"]` and a package sets `features = ["feature2", "feature3"]`, then that package will only get feature2 and feature3.
 

--- a/book/src/supplychain-security/index.md
+++ b/book/src/supplychain-security/index.md
@@ -1,7 +1,7 @@
 # Supply-chain security
 
 As software supplychain security concerns and requirements grow, `cargo-dist` is
-commited to making compliance with policies and regulations as turnkey as possible. 
+committed to making compliance with policies and regulations as turnkey as possible. 
 
 If you have an integration you are looking for [file an issue](https://github.com/axodotdev/cargo-dist/issues/new) or 
 [join our Discord](https://discord.gg/rW4JJ3Wa).

--- a/book/src/supplychain-security/signing/windows.md
+++ b/book/src/supplychain-security/signing/windows.md
@@ -41,7 +41,7 @@ Want support for another vendor? [Drop us a line](mailto:hello@axo.dev) or [file
 
     In the same "signing credentials" section as the previous step, you may want to disable the "malware blocker".
 
-    SSL.com's cloud signing provides an [optional malware checking service](https://www.ssl.com/guide/how-to-use-pre-signing-malware-scan-with-ssl-com-esigner/) which you may want to disable in your account settings. The purpose of this feature is to mitigate the risk of your infrastucture being compromised and being used to sign malware, by essentially giving SSL.com permission to refuse to sign suspicious-looking binaries.
+    SSL.com's cloud signing provides an [optional malware checking service](https://www.ssl.com/guide/how-to-use-pre-signing-malware-scan-with-ssl-com-esigner/) which you may want to disable in your account settings. The purpose of this feature is to mitigate the risk of your infrastructure being compromised and being used to sign malware, by essentially giving SSL.com permission to refuse to sign suspicious-looking binaries.
 
     When publishing from environments like GitHub CI, there isn't much room for such a compromise to occur that wouldn't just compromise your SSL.com account anyway, so the benefits are unclear compared to the risk of your releases randomly failing due to a false positive.
 

--- a/book/src/workspaces/structure.md
+++ b/book/src/workspaces/structure.md
@@ -13,7 +13,7 @@ Dist has two types of configuration:
 
 The vast majority of configuration for dist is workspace configuration. Because
 we understand language-specific config manifests like `Cargo.toml` and
-`package.json`, package configuration ususally does not require any additional
+`package.json`, package configuration usually does not require any additional
 files. Dedicated package configuration, in `dist.toml` files, is typically only needed when using dist's ["custom builds"][custom-builds] mode.
 
 ## Workspace configuration

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -192,7 +192,7 @@ pub enum BuildEnvironment {
     /// Linux-specific information
     #[serde(rename = "linux")]
     Linux {
-        /// The builder's glibc verison, relevant to glibc-based
+        /// The builder's glibc version, relevant to glibc-based
         /// builds.
         glibc_version: Option<GlibcVersion>,
     },

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -585,7 +585,7 @@ expression: json_schema
               "type": "object",
               "properties": {
                 "glibc_version": {
-                  "description": "The builder's glibc verison, relevant to glibc-based builds.",
+                  "description": "The builder's glibc version, relevant to glibc-based builds.",
                   "anyOf": [
                     {
                       "$ref": "#/definitions/GlibcVersion"

--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -138,7 +138,7 @@ pub struct GithubJobStep {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run: Option<String>,
 
-    /// The working directory this action sould run
+    /// The working directory this action should run
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_directory: Option<String>,
@@ -172,7 +172,7 @@ pub struct GithubJobStep {
 pub struct GithubCiJob {
     /// Name of the job
     pub name: String,
-    /// Permisions to give the job
+    /// Permissions to give the job
     pub permissions: Option<GithubPermissionMap>,
 }
 
@@ -252,7 +252,7 @@ impl GithubCiInfo {
         let tap = dist.global_homebrew_tap.clone();
 
         let mut job_permissions = ci_config.permissions.clone();
-        // user publish jobs default to elevated priviledges
+        // user publish jobs default to elevated privileges
         for JobStyle::User(name) in &ci_config.publish_jobs {
             job_permissions.entry(name.clone()).or_insert_with(|| {
                 GithubPermissionMap::from_iter([

--- a/cargo-dist/src/backend/mod.rs
+++ b/cargo-dist/src/backend/mod.rs
@@ -33,7 +33,7 @@ pub(crate) fn diff_source(existing: SourceFile, new_file_contents: &str) -> Dist
     // The timeout exists because essentially diff algorithms iteratively refine the results,
     // and can convince themselves to try way too hard for minimum benefit. Hitting the timeout
     // isn't fatal, it just tells the algorithm to call the result "good enough" if it hits
-    // something pathalogical.
+    // something pathological.
     let diff = similar::TextDiff::configure()
         .algorithm(similar::Algorithm::Patience)
         .timeout(Duration::from_millis(10))

--- a/cargo-dist/src/backend/templates.rs
+++ b/cargo-dist/src/backend/templates.rs
@@ -116,9 +116,9 @@ impl Templates {
                 let Some(value) = v.as_str() else {
                     return minijinja::escape_formatter(o, s, v);
                 };
-                // preserve exising behavior for single line strings not sure why but
+                // preserve existing behavior for single line strings not sure why but
                 // an empty string is being formatted when importing the homebrew publish
-                // job so also preserve this behvaior for whitespace only strings
+                // job so also preserve this behavior for whitespace only strings
                 if !value.trim().contains('\n') {
                     return minijinja::escape_formatter(o, s, v);
                 };

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -274,7 +274,7 @@ pub struct InitArgs {
 pub enum GenerateMode {
     /// Generate CI scripts for orchestrating dist
     Ci,
-    /// Generate .wxs tempaltes for msi installers
+    /// Generate .wxs templates for msi installers
     Msi,
 }
 

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -51,7 +51,7 @@ pub struct Config {
     pub artifact_mode: ArtifactMode,
     /// Whether local paths to files should be in the final dist json output
     pub no_local_paths: bool,
-    /// If true, override allow-dirty in the config and ignore all dirtyness
+    /// If true, override allow-dirty in the config and ignore all dirtiness
     pub allow_all_dirty: bool,
     /// Target triples we want to build for
     pub targets: Vec<TargetTriple>,

--- a/cargo-dist/src/config/v0.rs
+++ b/cargo-dist/src/config/v0.rs
@@ -86,7 +86,7 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub installers: Option<Vec<InstallerStyle>>,
 
-    /// Custom sucess message for installers
+    /// Custom success message for installers
     ///
     /// When an shell or powershell installer succeeds at installing your app it
     /// will out put a message to the user. This config allows a user to specify
@@ -189,7 +189,7 @@ pub struct DistMetadata {
     pub precise_builds: Option<bool>,
 
     /// Whether we should try to merge otherwise-parallelizable tasks onto the same machine,
-    /// sacrificing latency and fault-isolation for more the sake of minor effeciency gains.
+    /// sacrificing latency and fault-isolation for more the sake of minor efficiency gains.
     ///
     /// (defaults to false)
     ///

--- a/cargo-dist/src/config/v0_to_v1.rs
+++ b/cargo-dist/src/config/v0_to_v1.rs
@@ -369,7 +369,7 @@ where
     // Otherwise treat "is in the list" as a simple boolean
     let is_in_list = list.contains(&item);
     if is_global && !is_in_list {
-        // ... with the exception of an omited value in the global list.
+        // ... with the exception of an omitted value in the global list.
         // here None and Some(false) are the same, so Some(false) is Noise
         // we want to hide.
         None

--- a/cargo-dist/src/config/v1/ci/mod.rs
+++ b/cargo-dist/src/config/v1/ci/mod.rs
@@ -64,7 +64,7 @@ impl ApplyLayer for CiConfigInheritable {
 #[serde(rename_all = "kebab-case")]
 pub struct CommonCiLayer {
     /// Whether we should try to merge otherwise-parallelizable tasks onto the same machine,
-    /// sacrificing latency and fault-isolation for more the sake of minor effeciency gains.
+    /// sacrificing latency and fault-isolation for more the sake of minor efficiency gains.
     ///
     /// (defaults to false)
     ///

--- a/cargo-dist/src/config/v1/installers/mod.rs
+++ b/cargo-dist/src/config/v1/installers/mod.rs
@@ -231,7 +231,7 @@ pub struct CommonInstallerLayer {
     #[serde(default, with = "opt_string_or_vec")]
     pub install_path: Option<Vec<InstallPathStrategy>>,
 
-    /// Custom sucess message for installers
+    /// Custom success message for installers
     ///
     /// When an shell or powershell installer succeeds at installing your app it
     /// will out put a message to the user. This config allows a user to specify
@@ -262,7 +262,7 @@ pub struct CommonInstallerConfig {
     /// allow for the input to be an array of options to try in sequence.
     pub install_path: Vec<InstallPathStrategy>,
 
-    /// Custom sucess message for installers
+    /// Custom success message for installers
     ///
     /// When an shell or powershell installer succeeds at installing your app it
     /// will out put a message to the user. This config allows a user to specify

--- a/cargo-dist/src/config/v1/mod.rs
+++ b/cargo-dist/src/config/v1/mod.rs
@@ -207,7 +207,7 @@ impl WorkspaceConfigInheritable {
             allow_dirty: vec![],
         }
     }
-    /// Apply the inheritance to ge tthe final WorkspaceConfig
+    /// Apply the inheritance to get the final WorkspaceConfig
     pub fn apply_inheritance_for_workspace(self, workspaces: &WorkspaceGraph) -> WorkspaceConfig {
         let Self {
             artifacts,

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -91,7 +91,7 @@ pub enum DistError {
     Wix {
         /// The msi we were trying to build
         msi: String,
-        /// The underyling wix error
+        /// The underlying wix error
         #[source]
         details: wix::Error,
     },
@@ -209,7 +209,7 @@ pub enum DistError {
     },
 
     /// packages disagreed on publishers
-    #[error("different publisher setttings were in your workspace, this is currently unuspported")]
+    #[error("different publisher settings were in your workspace, this is currently unuspported")]
     #[diagnostic(help("these packages disagree:\n{packages:#?}"))]
     MismatchedPublishers {
         /// paths of problem manifests
@@ -217,7 +217,7 @@ pub enum DistError {
     },
 
     /// publishers disagreed on prereleases
-    #[error("different publisher 'prereleases' setttings were in your workspace, this is currently unsupported")]
+    #[error("different publisher 'prereleases' settings were in your workspace, this is currently unsupported")]
     MismatchedPrereleases,
 
     /// parse_tag concluded there was nothing to release
@@ -260,7 +260,7 @@ pub enum DistError {
     MultiPackage {
         /// Name of the artifact
         artifact_name: String,
-        /// One of the pacakges
+        /// One of the packages
         spec1: String,
         /// A different package
         spec2: String,
@@ -435,7 +435,7 @@ pub enum DistError {
     },
 
     /// Unknown permission specified in GitHub Actions config
-    #[error("One or more unrecognized permissons levels were specified: {levels:?}")]
+    #[error("One or more unrecognized permissions levels were specified: {levels:?}")]
     #[diagnostic(help("recognized values are: admin, write, read"))]
     GithubUnknownPermission {
         /// The input
@@ -481,7 +481,7 @@ pub enum DistError {
     GithubBuildSetupNotValid {
         /// The value from the configuration file
         file_path: Utf8PathBuf,
-        /// Error messsage details
+        /// Error message details
         message: String,
     },
 
@@ -529,7 +529,7 @@ pub enum DistError {
 
     /// cargo package with build-command
     #[error(
-        "cargo package was overriden with a build-command, which isn't supported yet\n{manifest}"
+        "cargo package was overridden with a build-command, which isn't supported yet\n{manifest}"
     )]
     UnexpectedBuildCommand {
         /// path to manifest
@@ -538,7 +538,7 @@ pub enum DistError {
 
     /// Failure to decode base64-encoded certificate
     #[error("We failed to decode the certificate stored in the CODESIGN_CERTIFICATE environment variable.")]
-    #[diagnostic(help("Is the value of this envirionment variable valid base64?"))]
+    #[diagnostic(help("Is the value of this environment variable valid base64?"))]
     CertificateDecodeError {},
 
     /// Missing configuration for a .pkg

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -545,7 +545,7 @@ fn write_checksum(checksum: &str, src_path: &Utf8Path, dest_path: &Utf8Path) -> 
     //
     // * checksum is the checksum in hex
     // * mode is ` ` for "text" and `*` for "binary" (we mostly have binaries)
-    // * path is a relative path to the thing being checksumed (usually just a filename)
+    // * path is a relative path to the thing being checksummed (usually just a filename)
     //
     // We also make sure there's a trailing newline as is traditional.
     //

--- a/cargo-dist/src/platform.rs
+++ b/cargo-dist/src/platform.rs
@@ -9,7 +9,7 @@
 //! The complexity of this module is trying to handle things like:
 //!
 //! * linux-musl-static binaries work on linux-gnu platforms
-//! * but linux-gnu binaries are preferrable if they're available
+//! * but linux-gnu binaries are preferable if they're available
 //! * but if the target system has a really old version of glibc, the linux-gnu binaries won't work
 //! * so the linux-musl-static binaries need to still be eligible as a fallback
 //!
@@ -163,7 +163,7 @@
 //! a "more native" option is available and unused).
 //!
 //! If this version is too old we will fail to error and/or fail to invoke musl fallback,
-//! and may claim to succesfully install linux-gnu binaries which will immediately error out
+//! and may claim to successfully install linux-gnu binaries which will immediately error out
 //! when run.
 //!
 //!

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1685,7 +1685,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             if let Some(symbol_kind) = target_symbol_kind(&binary.target) {
                 // FIXME: For some formats these won't be the same but for now stubbed out
 
-                // FIXME: rustc/cargo has so more complex logic to do platform-specifc name remapping
+                // FIXME: rustc/cargo has so more complex logic to do platform-specific name remapping
                 // (see should_replace_hyphens in src/cargo/core/compiler/build_context/target_info.rs)
 
                 // FIXME: feed info about the expected source symbol name down to build_cargo_target

--- a/cargo-dist/tests/gallery/dist/powershell.rs
+++ b/cargo-dist/tests/gallery/dist/powershell.rs
@@ -67,7 +67,7 @@ impl AppResult {
             assert!(!saved_path.trim().is_empty(), "failed to load path");
             eprintln!("backing up PATH: {saved_path}\n");
 
-            // on exit, retore the current PATH in the registry, even if we panic
+            // on exit, restore the current PATH in the registry, even if we panic
             struct RestorePath<'a> {
                 powershell: &'a CommandInfo,
                 tempdir: &'a Utf8Path,
@@ -151,7 +151,7 @@ impl AppResult {
                 // (note that "where" and "where.exe" are completely different things...)
                 //
                 // also note that HKCU:\Environment\PATH is not actually the full PATH
-                // a shell will have, so preprend it to the current PATH (if we don't do
+                // a shell will have, so prepend it to the current PATH (if we don't do
                 // this then where.exe won't be on PATH anymore!)
                 let empirical_path = run_ps1_script(
                     &powershell,

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -10,7 +10,7 @@
 //! * Run PSScriptAnalyzer on installer.ps1 (only if detected on the system)
 //! * Run installer.sh and check the results
 //!    * linux/macos only, must also set RUIN_MY_COMPUTER_WITH_INSTALLERS to opt in
-//!    * HOME, CARGO_HOME, and MY_ENV_VAR overriden to keep it scoped to a temp dir
+//!    * HOME, CARGO_HOME, and MY_ENV_VAR overridden to keep it scoped to a temp dir
 //!        * CARGO_HOME currently always deleted, should probably have a test where we set it
 //! * insta.rs snapshot the installers
 //!

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -197,7 +197,7 @@ Which type of configuration to generate
 
 Possible values:
 - ci:  Generate CI scripts for orchestrating dist
-- msi: Generate .wxs tempaltes for msi installers
+- msi: Generate .wxs templates for msi installers
 
 #### `--check`
 Check if the generated output differs from on-disk config without writing it

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,13 @@
+# https://github.com/crate-ci/typos # LSP: https://github.com/tekumara/typos-lsp
+# install:  cargo install typos-cli
+# run:      typos
+[default]
+extend-ignore-identifiers-re = [
+    # Allow all-caps words that are 2-letters or more and ends with 's'
+    "[A-Z]{2,}s",
+]
+# Ignore CLIENT_ID=<random letters>
+extend-ignore-re = ["CLIENT_ID=[A-Za-z0-9_-]+"]
+
+[default.extend-identifiers]
+PnP = "PnP"


### PR DESCRIPTION
### Description

- Fix typos found by the [typos](https://github.com/crate-ci/typos) tool.
- Add a few exceptions in a `typos.toml`.
- Add a CI job that runs the typos action

### Motivation

I don't know if I need to motivate typo-checking but in case I do, my major motivations would be:

- More readable and searchable docs
- More searchable code base