### PR TITLE
fix: tweak unified checksum format

### DIFF
--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -433,7 +433,11 @@ fn generate_unified_checksum(
                 continue;
             }
 
-            writeln!(&mut output, "{checksum} {artifact_name}").unwrap();
+            // We write with exactly two spaces to match the output of
+            // shasum. While sha256sum is tolerant of varying numbers of
+            // spaces, shasum itself will only match precisely two -
+            // we need to be precise here for compatibility.
+            writeln!(&mut output, "{checksum}  {artifact_name}").unwrap();
         }
     }
     axoasset::LocalAsset::write_new(&output, dest_path)?;

--- a/cargo-dist/tests/gallery/dist/snapshot.rs
+++ b/cargo-dist/tests/gallery/dist/snapshot.rs
@@ -169,12 +169,12 @@ pub fn snapshot_settings_with_gallery_filter() -> insta::Settings {
         r#""build_environment": "indeterminate""#,
     );
     settings.add_filter(
-        r"[0-9a-f]{64} ([a-zA-Z0-9-_]+)\.tar\.gz",
-        "CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz",
+        r"[0-9a-f]{64}  ([a-zA-Z0-9-_]+)\.tar\.gz",
+        "CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz",
     );
     settings.add_filter(
-        r"[0-9a-f]{64} ([a-zA-Z0-9-_]+)\.pkg",
-        "CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.pkg",
+        r"[0-9a-f]{64}  ([a-zA-Z0-9-_]+)\.pkg",
+        "CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.pkg",
     );
     settings
 }

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1778,7 +1778,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1214,7 +1214,7 @@ downloader() {
 download_binary_and_run_installer "$@" || exit 1
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1808,7 +1808,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1834,7 +1834,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1786,7 +1786,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3247,8 +3247,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3249,8 +3249,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3218,15 +3218,15 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.pkg
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.pkg
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 axolotlsay-x86_64-pc-windows-msvc.msi
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.pkg
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.pkg
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  axolotlsay-x86_64-pc-windows-msvc.msi
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -68,7 +68,7 @@ class AxolotlBrew < Formula
 end
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3215,7 +3215,7 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1777,7 +1777,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3555,7 +3555,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2644,8 +2644,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2624,8 +2624,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3253,8 +3253,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1713,7 +1713,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1713,7 +1713,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -3,7 +3,7 @@ source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
 ---
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3223,8 +3223,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3215,8 +3215,8 @@ const { run } = require("./binary");
 run("axolotlsay");
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1778,7 +1778,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1777,7 +1777,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1754,7 +1754,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1777,7 +1777,7 @@ try {
 }
 
 ================ sha256.sum ================
-CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477) CENSORED.tar.gz
+CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  CENSORED.tar.gz
 
 ================ dist-manifest.json ================
 {


### PR DESCRIPTION
shasum expects exactly two spaces between the hash and the filename. While sha256sum is tolerant of a single space, shasum will reject files that aren't in exactly its format.

Before:

```
$ shasum -a256 -c sha256.sum
shasum: sha256.sum: no properly formatted SHA checksum lines found
$ sha256sum --check sha256.sum
cargo-dist-npm-package.tar.gz: OK
source.tar.gz: OK
```

After:

```
$ shasum -a256 -c sha256.sum
cargo-dist-npm-package.tar.gz: OK
source.tar.gz: OK
$ sha256sum --check sha256.sum
cargo-dist-npm-package.tar.gz: OK
source.tar.gz: OK
```