### PR TITLE
Verify checksums in `install.sh`

### DIFF
--- a/cargo-dist/src/backend/installer/homebrew.rs
+++ b/cargo-dist/src/backend/installer/homebrew.rs
@@ -1,7 +1,7 @@
 //! Code for generating formula.rb
 
 use axoasset::LocalAsset;
-use cargo_dist_schema::DistManifest;
+use cargo_dist_schema::{ChecksumValue, DistManifest};
 use serde::Serialize;
 use spdx::{
     expression::{ExprNode, Operator},
@@ -119,7 +119,7 @@ struct HomebrewFragment {
     /// SHA256 sum of the fragment. When building "just the installers", like
     /// when running `dist build --artifacts global` locally, we don't have
     /// the SHA256 for the fragment, since we didn't actually build them.
-    sha256: Option<String>,
+    sha256: Option<ChecksumValue>,
 
     /// homebrew package dependencies
     dependencies: Vec<String>,

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -5,7 +5,7 @@
 use std::collections::BTreeMap;
 
 use camino::Utf8PathBuf;
-use cargo_dist_schema::{EnvironmentVariables, Hosting, TargetTriple};
+use cargo_dist_schema::{ArtifactId, EnvironmentVariables, Hosting, TargetTriple};
 use homebrew::HomebrewFragments;
 use macpkg::PkgInstallerInfo;
 use serde::Serialize;
@@ -99,7 +99,7 @@ pub struct InstallerInfo {
 #[derive(Debug, Clone, Serialize)]
 pub struct ExecutableZipFragment {
     /// The id of the artifact
-    pub id: String,
+    pub id: ArtifactId,
     /// The target the artifact supports
     pub target_triple: TargetTriple,
     /// The executables the artifact contains (name, assumed at root)
@@ -120,7 +120,7 @@ pub struct ExecutableZipFragment {
 #[derive(Debug, Clone, Serialize)]
 pub struct UpdaterFragment {
     /// The id of the artifact
-    pub id: String,
+    pub id: ArtifactId,
     /// The binary the artifact contains (name, assumed at root)
-    pub binary: String,
+    pub binary: ArtifactId,
 }

--- a/cargo-dist/src/backend/installer/npm.rs
+++ b/cargo-dist/src/backend/installer/npm.rs
@@ -2,7 +2,7 @@
 
 use axoasset::{LocalAsset, SourceFile};
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_dist_schema::{GlibcVersion, TargetTriple};
+use cargo_dist_schema::{ArtifactId, GlibcVersion, TargetTriple};
 use serde::Serialize;
 
 use super::InstallerInfo;
@@ -46,7 +46,7 @@ type PackageJsonPlatforms = SortedMap<TargetTriple, PackageJsonPlatform>;
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PackageJsonPlatform {
-    artifact_name: String,
+    artifact_name: ArtifactId,
     bins: SortedMap<String, String>,
     zip_ext: String,
 }

--- a/cargo-dist/src/backend/installer/shell.rs
+++ b/cargo-dist/src/backend/installer/shell.rs
@@ -1,14 +1,27 @@
 //! Code for generating installer.sh
 
 use axoasset::LocalAsset;
+use cargo_dist_schema::DistManifest;
 
 use crate::{backend::templates::TEMPLATE_INSTALLER_SH, errors::DistResult, DistGraph};
 
 use super::InstallerInfo;
 
-pub(crate) fn write_install_sh_script(dist: &DistGraph, info: &InstallerInfo) -> DistResult<()> {
+pub(crate) fn write_install_sh_script(
+    dist: &DistGraph,
+    info: &InstallerInfo,
+    manifest: &DistManifest,
+) -> DistResult<()> {
     let mut info = info.clone();
-    info.platform_support = Some(dist.release(info.release).platform_support.clone());
+    let platform_support = dist.release(info.release).platform_support.clone();
+
+    info.platform_support = Some(if dist.local_builds_are_lies {
+        // if local builds are lies, the artifacts that are "fake-built" have a different
+        // checksum every time, so we can't use those in the generated installer
+        platform_support
+    } else {
+        platform_support.with_checksums_from_manifest(manifest)
+    });
 
     let script = dist
         .templates

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use axoasset::{toml_edit, SourceFile};
 use axoproject::local_repo::LocalRepo;
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_dist_schema::{TargetTriple, TargetTripleRef};
+use cargo_dist_schema::{ChecksumExtensionRef, TargetTriple, TargetTripleRef};
 use serde::{Deserialize, Serialize};
 
 use crate::announce::TagSettings;
@@ -662,8 +662,8 @@ pub enum ChecksumStyle {
 
 impl ChecksumStyle {
     /// Get the extension of a checksum
-    pub fn ext(self) -> &'static str {
-        match self {
+    pub fn ext(self) -> &'static ChecksumExtensionRef {
+        ChecksumExtensionRef::from_str(match self {
             ChecksumStyle::Sha256 => "sha256",
             ChecksumStyle::Sha512 => "sha512",
             ChecksumStyle::Sha3_256 => "sha3-256",
@@ -671,7 +671,7 @@ impl ChecksumStyle {
             ChecksumStyle::Blake2s => "blake2s",
             ChecksumStyle::Blake2b => "blake2b",
             ChecksumStyle::False => "false",
-        }
+        })
     }
 }
 

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -9,7 +9,7 @@
 use axoproject::errors::AxoprojectError;
 use backtrace::Backtrace;
 use camino::Utf8PathBuf;
-use cargo_dist_schema::TargetTriple;
+use cargo_dist_schema::{ArtifactId, TargetTriple};
 use color_backtrace::BacktracePrinter;
 use console::style;
 use miette::{Diagnostic, SourceOffset, SourceSpan};
@@ -264,7 +264,7 @@ pub enum DistError {
     #[diagnostic(help("depends on {spec1} and {spec2}"))]
     MultiPackage {
         /// Name of the artifact
-        artifact_name: String,
+        artifact_name: ArtifactId,
         /// One of the packages
         spec1: String,
         /// A different package
@@ -276,7 +276,7 @@ pub enum DistError {
     #[diagnostic(help("This should be impossible, you did nothing wrong, please file an issue!"))]
     NoPackage {
         /// Name of the msi
-        artifact_name: String,
+        artifact_name: ArtifactId,
     },
 
     /// These GUIDs for msi's are required and enforced by `dist generate --check`

--- a/cargo-dist/src/host.rs
+++ b/cargo-dist/src/host.rs
@@ -14,7 +14,7 @@ use crate::{
     DistError, DistGraph, DistGraphBuilder, HostingInfo,
 };
 use axoproject::WorkspaceGraph;
-use cargo_dist_schema::{DistManifest, Hosting};
+use cargo_dist_schema::{ArtifactIdRef, DistManifest, Hosting};
 use gazenot::{AnnouncementKey, Gazenot};
 
 /// Do hosting
@@ -212,6 +212,8 @@ fn check_hosting(_dist: &DistGraph, _manifest: &DistManifest, _abyss: &Gazenot) 
 }
 
 fn upload_to_hosting(dist: &DistGraph, manifest: &DistManifest, abyss: &Gazenot) -> DistResult<()> {
+    const DIST_MANIFEST_ARTIFACT_ID: &ArtifactIdRef = ArtifactIdRef::from_str("dist-manifest.json");
+
     // Gather up the files to upload for each release
     let files = manifest.releases.iter().filter_map(|release| {
         // Github Releases only has semantics on Announce
@@ -224,8 +226,8 @@ fn upload_to_hosting(dist: &DistGraph, manifest: &DistManifest, abyss: &Gazenot)
             let files = manifest
                 .artifacts_for_release(release)
                 .filter_map(|(_id, artifact)| artifact.name.as_deref())
-                .chain(Some("dist-manifest.json"))
-                .map(|name| dist.dist_dir.join(name))
+                .chain(Some(DIST_MANIFEST_ARTIFACT_ID))
+                .map(|name| dist.dist_dir.join(name.as_str()))
                 .collect::<Vec<_>>();
             Some((set, files))
         } else {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1032,7 +1032,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         table,
         "checksum",
         "# Checksums to generate for each App\n",
-        checksum.map(|c| c.ext()),
+        checksum.map(|c| c.ext().as_str()),
     );
 
     apply_optional_value(

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -27,7 +27,7 @@ use build::{
     fake::{build_fake_cargo_target, build_fake_generic_target},
 };
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_dist_schema::{ArtifactId, DistManifest, TargetTriple};
+use cargo_dist_schema::{ArtifactId, ChecksumValue, ChecksumValueRef, DistManifest, TargetTriple};
 use config::{
     ArtifactMode, ChecksumStyle, CompressionImpl, Config, DirtyMode, GenerateMode, ZipStyle,
 };
@@ -399,7 +399,8 @@ fn generate_and_write_checksum(
 ) -> DistResult<()> {
     let output = generate_checksum(checksum, src_path)?;
     if let Some(dest_path) = dest_path {
-        write_checksum(&output, src_path, dest_path)?;
+        let name = src_path.file_name().expect("hashing file with no name!?");
+        write_checksum_file(&[(name, &output)], dest_path)?;
     }
     if let Some(artifact_id) = for_artifact {
         if let Some(artifact) = manifest.artifacts.get_mut(artifact_id) {
@@ -415,10 +416,8 @@ fn generate_unified_checksum(
     checksum: ChecksumStyle,
     dest_path: &Utf8Path,
 ) -> DistResult<()> {
-    let mut output = String::new();
-    use std::fmt::Write;
-
     let expected_checksum_ext = checksum.ext();
+    let mut entries: Vec<(&str, &ChecksumValueRef)> = vec![];
 
     for artifact in manifest.artifacts.values() {
         let artifact_name = if let Some(artifact_name) = artifact.name.as_deref() {
@@ -428,26 +427,18 @@ fn generate_unified_checksum(
         };
 
         for (checksum_ext, checksum) in &artifact.checksums {
-            if checksum_ext != expected_checksum_ext {
-                tracing::warn!(
-                    "Found checksum {checksum_ext} for {artifact_name}, expected only {expected_checksum_ext}"
-                );
-                continue;
+            if checksum_ext == expected_checksum_ext {
+                entries.push((artifact_name.as_str(), checksum));
             }
-
-            // We write with exactly two spaces to match the output of
-            // shasum. While sha256sum is tolerant of varying numbers of
-            // spaces, shasum itself will only match precisely two -
-            // we need to be precise here for compatibility.
-            writeln!(&mut output, "{checksum}  {artifact_name}").unwrap();
         }
     }
-    axoasset::LocalAsset::write_new(&output, dest_path)?;
+    write_checksum_file(&entries, dest_path)?;
+
     Ok(())
 }
 
 /// Generate a checksum for the src_path and return it as a string
-fn generate_checksum(checksum: &ChecksumStyle, src_path: &Utf8Path) -> DistResult<String> {
+fn generate_checksum(checksum: &ChecksumStyle, src_path: &Utf8Path) -> DistResult<ChecksumValue> {
     info!("generating {checksum:?} for {src_path}");
     use sha2::Digest;
     use std::fmt::Write;
@@ -489,11 +480,11 @@ fn generate_checksum(checksum: &ChecksumStyle, src_path: &Utf8Path) -> DistResul
             unreachable!()
         }
     };
-    let mut output = String::new();
+    let mut output = String::with_capacity(hash.len() * 2);
     for byte in hash {
         write!(&mut output, "{:02x}", byte).unwrap();
     }
-    Ok(output)
+    Ok(ChecksumValue::new(output))
 }
 
 /// Creates a source code tarball from the git archive from
@@ -541,20 +532,30 @@ fn generate_fake_source_tarball(
 }
 
 /// Write the checksum to dest_path
-fn write_checksum(checksum: &str, src_path: &Utf8Path, dest_path: &Utf8Path) -> DistResult<()> {
+fn write_checksum_file(
+    entries: &[(&str, &ChecksumValueRef)],
+    dest_path: &Utf8Path,
+) -> DistResult<()> {
     // Tools like sha256sum expect a new-line-delimited format of
     // <checksum> <mode><path>
     //
     // * checksum is the checksum in hex
-    // * mode is ` ` for "text" and `*` for "binary" (we mostly have binaries)
+    // * mode is ` ` for "text" and `*` for "binary" — "text" is for CRLF support, we don't want it.
     // * path is a relative path to the thing being checksummed (usually just a filename)
     //
     // We also make sure there's a trailing newline as is traditional.
     //
-    // By following this format we support commands like `sha256sum --check my-app.tar.gz.sha256`
-    let file_path = src_path.file_name().expect("hashing file with no name!?");
-    let line = format!("{checksum} *{file_path}\n");
-    axoasset::LocalAsset::write_new(&line, dest_path)?;
+    // By following this format we support commands like `sha256sum --check sha256.sum`,
+    // both the GNU coreutils and Darwin variants, and also Perl `shasum` utility.
+    let mut contents = String::new();
+    for (file_path, checksum) in entries {
+        use std::fmt::Write;
+        writeln!(&mut contents, "{checksum} *{file_path}",).unwrap();
+    }
+    // leave a trailing newline
+    contents.push('\n');
+
+    axoasset::LocalAsset::write_new(&contents, dest_path)?;
     Ok(())
 }
 
@@ -777,7 +778,9 @@ fn generate_installer(
     manifest: &DistManifest,
 ) -> DistResult<()> {
     match style {
-        InstallerImpl::Shell(info) => installer::shell::write_install_sh_script(dist, info)?,
+        InstallerImpl::Shell(info) => {
+            installer::shell::write_install_sh_script(dist, info, manifest)?
+        }
         InstallerImpl::Powershell(info) => {
             installer::powershell::write_install_ps_script(dist, info)?
         }

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -160,19 +160,25 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in {% for archive in platform_support.archives %}
         "{{ archive.id }}")
             _arch="{{ archive.target_triple }}"
             _zip_ext="{{ archive.zip_style }}"
+            {%- if archive.checksum %}
+            _checksum_style="{{ archive.checksum.style }}"
+            _checksum_value="{{ archive.checksum.value }}"
+            {%- endif %}
             _bins="{% for bin in archive.executables %}{{ bin }}{{ " " if not loop.last else "" }}{% endfor %}"
             _bins_js_array='{% for bin in archive.executables %}"{{ bin }}"{{ "," if not loop.last else ""}}{% endfor %}'
             {%- if "cdylib" in install_libraries %}
@@ -226,6 +232,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -335,6 +347,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in {% for target in platform_support.platforms %}
         "{{ target }}")
             {%- for option in platform_support.platforms[target] %}
@@ -1164,6 +1179,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 

--- a/cargo-dist/tests/gallery/dist/snapshot.rs
+++ b/cargo-dist/tests/gallery/dist/snapshot.rs
@@ -169,7 +169,7 @@ pub fn snapshot_settings_with_gallery_filter() -> insta::Settings {
         r#""build_environment": "indeterminate""#,
     );
     settings.add_filter(
-        r"[0-9a-f]{64}  (?<filename>([a-zA-Z0-9-_]+)(\.tar\.gz|\.pkg))",
+        r"[0-9a-f]{64} .(?<filename>([a-zA-Z0-9-_]+)(\.tar\.gz|\.pkg))",
         "CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  $filename",
     );
     settings

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "akaikatana-repack-aarch64-apple-darwin.tar.xz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="akaikatana-repack-aarch64-apple-darwin.tar.xz"
@@ -1214,6 +1225,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ akaikatana-repack.rb ================
@@ -1802,6 +1890,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "akaikatana-repack-aarch64-apple-darwin.tar.xz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -385,6 +393,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="akaikatana-repack-aarch64-apple-darwin.tar.xz"
@@ -1222,10 +1233,88 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "akaikatana-repack-aarch64-apple-darwin.tar.xz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -387,6 +395,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="akaikatana-repack-aarch64-apple-darwin.tar.xz"
@@ -1226,6 +1237,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ akaikatana-repack.rb ================
@@ -1832,6 +1920,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "akaikatana-repack-aarch64-apple-darwin.tar.xz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -399,6 +407,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="akaikatana-repack-aarch64-apple-darwin.tar.xz"
@@ -1238,6 +1249,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ akaikatana-repack.rb ================
@@ -1858,6 +1946,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "akaikatana-repack-aarch64-apple-darwin.tar.xz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="akaikatana-repack-aarch64-apple-darwin.tar.xz"
@@ -1214,6 +1225,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ akaikatana-repack.rb ================
@@ -1810,6 +1898,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -144,15 +144,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -231,6 +233,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -366,6 +374,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1202,6 +1213,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3223,6 +3311,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -144,15 +144,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -231,6 +233,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -366,6 +374,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1202,6 +1213,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3223,6 +3311,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -387,6 +395,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1223,6 +1234,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3272,6 +3360,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -387,6 +395,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1223,6 +1234,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3274,6 +3362,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3240,6 +3328,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3246,10 +3334,11 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-a
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-x86_64-apple-darwin.pkg
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-x86_64-apple-darwin.tar.gz
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  axolotlsay-x86_64-pc-windows-msvc.msi
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 *axolotlsay-x86_64-pc-windows-msvc.msi
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-x86_64-pc-windows-msvc.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-x86_64-unknown-linux-gnu.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3240,6 +3328,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -71,6 +71,7 @@ end
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -6,6 +6,7 @@ snapshot_kind: text
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3239,6 +3327,7 @@ run("axolotlsay");
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -6,6 +6,7 @@ snapshot_kind: text
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -6,6 +6,7 @@ snapshot_kind: text
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -6,6 +6,7 @@ snapshot_kind: text
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3240,6 +3328,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-js-aarch64-apple-darwin.tar.xz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-js-aarch64-apple-darwin.tar.xz"
@@ -1214,6 +1225,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay-js.rb ================
@@ -1802,6 +1890,7 @@ try {
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
+
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
 # shellcheck shell=dash
@@ -1952,15 +2041,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.xz")
             _arch="aarch64-apple-darwin"
@@ -2039,6 +2130,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -2174,6 +2271,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.xz"
@@ -3013,6 +3113,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -3601,6 +3778,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_linux_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_linux_only.snap
@@ -54,6 +54,7 @@ end
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_macos_x86_64_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_macos_x86_64_only.snap
@@ -56,6 +56,7 @@ end
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3240,6 +3328,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -385,6 +393,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1219,6 +1230,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -2657,6 +2745,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -228,6 +230,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -373,6 +381,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1199,6 +1210,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -2637,6 +2725,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3240,6 +3328,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -6,6 +6,7 @@ snapshot_kind: text
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -6,6 +6,7 @@ snapshot_kind: text
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -387,6 +395,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1223,6 +1234,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3278,6 +3366,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1214,6 +1225,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay-installer.ps1 ================
@@ -1737,6 +1825,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1214,6 +1225,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay-installer.ps1 ================
@@ -1737,6 +1825,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -6,6 +6,7 @@ snapshot_kind: text
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
+
 ================ dist-manifest.json ================
 {
   "dist_version": "CENSORED",

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3248,6 +3336,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3240,6 +3328,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3240,6 +3328,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3240,6 +3328,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3240,6 +3328,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1211,6 +1222,83 @@ downloader() {
     elif [ "$_dld" = wget ]
     then wget "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
+    fi
+}
+
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
     fi
 }
 
@@ -3240,6 +3328,7 @@ run("axolotlsay");
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-npm-package.tar.gz
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1214,6 +1225,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -1802,6 +1890,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1197,6 +1208,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -1778,6 +1866,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1197,6 +1208,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -1778,6 +1866,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1197,6 +1208,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -1778,6 +1866,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1197,6 +1208,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -1778,6 +1866,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -154,15 +154,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -241,6 +243,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -376,6 +384,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1210,6 +1221,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -1801,6 +1889,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1197,6 +1208,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -1778,6 +1866,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1197,6 +1208,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -1778,6 +1866,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1197,6 +1208,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -1778,6 +1866,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -153,15 +153,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -240,6 +242,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -375,6 +383,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1197,6 +1208,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -1778,6 +1866,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -154,15 +154,17 @@ download_binary_and_run_installer() {
     assert_nz "$_true_arch" "arch"
     local _cur_arch="$_true_arch"
 
-    # Lookup what archives support this platform
+
+    # look up what archives support this platform
     local _artifact_name
     _artifact_name="$(select_archive_for_arch "$_true_arch")" || return 1
     local _bins
     local _zip_ext
     local _arch
+    local _checksum_style
+    local _checksum_value
 
-    # try each archive, checking runtime conditions like libc versions
-    # accepting the first one that matches, as it's the best match
+    # destructure selected archive info into locals
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
@@ -241,6 +243,12 @@ download_binary_and_run_installer() {
       say "that $APP_NAME's release process is not working. When in doubt"
       say "please feel free to open an issue!"
       exit 1
+    fi
+
+    if [ -n "${_checksum_style:-}" ]; then
+        verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
+    else
+        say "no checksums to verify"
     fi
 
     # ...and then the updater, if it exists
@@ -376,6 +384,9 @@ aliases_for_binary() {
 select_archive_for_arch() {
     local _true_arch="$1"
     local _archive
+
+    # try each archive, checking runtime conditions like libc versions
+    # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
         "aarch64-apple-darwin")
             _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
@@ -1210,6 +1221,83 @@ downloader() {
     fi
 }
 
+verify_checksum() {
+    local _file="$1"
+    local _checksum_style="$2"
+    local _checksum_value="$3"
+    local _calculated_checksum
+
+    if [ -z "$_checksum_value" ]; then
+        return 0
+    fi
+    case "$_checksum_style" in
+        sha256)
+            if ! check_cmd sha256sum; then
+                say "skipping sha256 checksum verification (it requires the 'sha256sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha256sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha512)
+            if ! check_cmd sha512sum; then
+                say "skipping sha512 checksum verification (it requires the 'sha512sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(sha512sum -b "$_file" | awk '{printf $1}')"
+            ;;
+        sha3-256)
+            if ! check_cmd openssl; then
+                say "skipping sha3-256 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-256 "$_file" | awk '{printf $NF}')"
+            ;;
+        sha3-512)
+            if ! check_cmd openssl; then
+                say "skipping sha3-512 checksum verification (it requires the 'openssl' command)"
+                return 0
+            fi
+            _calculated_checksum="$(openssl dgst -sha3-512 "$_file" | awk '{printf $NF}')"
+            ;;
+        blake2s)
+            if ! check_cmd b2sum; then
+                say "skipping blake2s checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            # Test if we have official b2sum with blake2s support
+            local _well_known_blake2s_checksum="93314a61f470985a40f8da62df10ba0546dc5216e1d45847bf1dbaa42a0e97af"
+            local _test_blake2s
+            _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
+
+            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+                _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
+            else
+                say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"
+                return 0
+            fi
+            ;;
+        blake2b)
+            if ! check_cmd b2sum; then
+                say "skipping blake2b checksum verification (it requires the 'b2sum' command)"
+                return 0
+            fi
+            _calculated_checksum="$(b2sum "$_file" | awk '{printf $1}')"
+            ;;
+        false)
+            ;;
+        *)
+            say "skipping unknown checksum style: $_checksum_style"
+            return 0
+            ;;
+    esac
+
+    if [ "$_calculated_checksum" != "$_checksum_value" ]; then
+        err "checksum mismatch
+            want: $_checksum_value
+            got:  $_calculated_checksum"
+    fi
+}
+
 download_binary_and_run_installer "$@" || exit 1
 
 ================ axolotlsay.rb ================
@@ -1801,6 +1889,7 @@ try {
 
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
+
 
 ================ dist-manifest.json ================
 {


### PR DESCRIPTION
This is a WIP I'm pushing before stepping away from the computer — it includes making `ArtifactId` strongly-typed, which _could_ be extracted into its own PR (but I'd rather spend my time elsewhere).

Only the shell installer is doing checks for now, and I haven't tested all the codepaths (Or even a single one, as I'm pushing this) — this is just the result of research.

I have to say, most of the time was spent tracking down why/where PlatformSupport was supposed to magically gain checksums (spoiler: it wasn't! anywhere!).

I think we can tackle the powershell installer in a separate PR, probably. I have a minimal testing plan for this, but not a comprehensive one.