### PR TITLE
feat: allow installer domain to be overridden

### DIFF
--- a/axoproject/src/repo.rs
+++ b/axoproject/src/repo.rs
@@ -20,9 +20,20 @@ pub struct GithubRepo {
 }
 
 impl GithubRepo {
+    /// Returns the domain. At the moment this is hardcoded to github.com, but
+    /// it may support more options in the future.
+    pub fn domain(&self) -> String {
+        "https://github.com".to_owned()
+    }
+
+    /// Similar to `web_url`, but returns just the path component without the domain.
+    pub fn web_path(&self) -> String {
+        format!("/{}/{}", self.owner, self.name)
+    }
+
     /// Returns a URL suitable for web access to the repository.
     pub fn web_url(&self) -> String {
-        format!("https://github.com/{}/{}", self.owner, self.name)
+        format!("{}{}", self.domain(), self.web_path())
     }
 
     /// Constructs a new Github repository from a "owner/name" string. Notably, this does not check

--- a/axoproject/src/repo.rs
+++ b/axoproject/src/repo.rs
@@ -26,7 +26,7 @@ impl GithubRepo {
         "https://github.com".to_owned()
     }
 
-    /// Similar to `web_url`, but returns just the path component without the domain.
+    /// Path component. Used with `domain` to construct `web_url`.
     pub fn web_path(&self) -> String {
         format!("/{}/{}", self.owner, self.name)
     }

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -354,7 +354,7 @@ pub struct SystemInfo {
 }
 
 /// Release-specific environment variables
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct EnvironmentVariables {
     /// Environment variable to force an install location
     pub install_dir_env_var: String,

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -772,7 +772,14 @@ pub struct Hosting {
 /// Github Hosting
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct GithubHosting {
-    /// The URL of the Github Release's artifact downloads
+    /// The URL of the host for GitHub, usually `"https://github.com"`
+    /// (This can vary for GitHub Enterprise)
+    pub artifact_base_url: String,
+    /// The path of the release without the base URL
+    ///
+    /// e.g. `/myowner/myrepo/releases/download/v1.0.0/`
+    pub artifact_download_path: String,
+    /// The URL of the GitHub Release's artifact downloads
     ///
     /// e.g. `https://github.com/myowner/myrepo/releases/download/v1.0.0/`
     pub artifact_download_url: String,

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -758,7 +758,7 @@ impl DistManifest {
 
 impl Release {
     /// Get the base URL that artifacts should be downloaded from (append the artifact name to the URL)
-    pub fn artifact_download_url(&self) -> Option<&str> {
+    pub fn artifact_download_url(&self) -> Option<String> {
         self.hosting.artifact_download_url()
     }
 }
@@ -787,10 +787,6 @@ pub struct GithubHosting {
     ///
     /// e.g. `/myowner/myrepo/releases/download/v1.0.0/`
     pub artifact_download_path: String,
-    /// The URL of the GitHub Release's artifact downloads
-    ///
-    /// e.g. `https://github.com/myowner/myrepo/releases/download/v1.0.0/`
-    pub artifact_download_url: String,
     /// The owner of the repo
     pub owner: String,
     /// The name of the repo
@@ -799,14 +795,17 @@ pub struct GithubHosting {
 
 impl Hosting {
     /// Get the base URL that artifacts should be downloaded from (append the artifact name to the URL)
-    pub fn artifact_download_url(&self) -> Option<&str> {
+    pub fn artifact_download_url(&self) -> Option<String> {
         let Hosting { axodotdev, github } = &self;
         // Prefer axodotdev is present, otherwise github
         if let Some(host) = &axodotdev {
-            return host.set_download_url.as_deref();
+            return host.set_download_url.clone();
         }
         if let Some(host) = &github {
-            return Some(&host.artifact_download_url);
+            return Some(format!(
+                "{}{}",
+                host.artifact_base_url, host.artifact_download_path
+            ));
         }
         None
     }

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -367,7 +367,7 @@ pub struct EnvironmentVariables {
     /// Environment variable to set the GitHub base URL
     pub github_base_url_env_var: String,
     /// Environment variable to set the GitHub Enterprise base URL
-    pub github_enterprise_base_url_env_var: String,
+    pub ghe_base_url_env_var: String,
 }
 
 /// A Release of an Application
@@ -706,8 +706,7 @@ impl DistManifest {
             let disable_update_env_var = format!("{env_app_name}_DISABLE_UPDATE");
             let no_modify_path_env_var = format!("{env_app_name}_NO_MODIFY_PATH");
             let github_base_url_env_var = format!("{env_app_name}_INSTALLER_GITHUB_BASE_URL");
-            let github_enterprise_base_url_env_var =
-                format!("{env_app_name}_INSTALLER_GITHUB_ENTERPRISE_BASE_URL");
+            let ghe_base_url_env_var = format!("{env_app_name}_INSTALLER_GHE_BASE_URL");
 
             let environment_variables = EnvironmentVariables {
                 install_dir_env_var,
@@ -715,7 +714,7 @@ impl DistManifest {
                 disable_update_env_var,
                 no_modify_path_env_var,
                 github_base_url_env_var,
-                github_enterprise_base_url_env_var,
+                ghe_base_url_env_var,
             };
 
             self.releases.push(Release {

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -364,6 +364,10 @@ pub struct EnvironmentVariables {
     pub disable_update_env_var: String,
     /// Environment variable to disable modifying the path
     pub no_modify_path_env_var: String,
+    /// Environment variable to set the GitHub base URL
+    pub github_base_url_env_var: String,
+    /// Environment variable to set the GitHub Enterprise base URL
+    pub github_enterprise_base_url_env_var: String,
 }
 
 /// A Release of an Application
@@ -701,12 +705,17 @@ impl DistManifest {
             let unmanaged_dir_env_var = format!("{env_app_name}_UNMANAGED_INSTALL");
             let disable_update_env_var = format!("{env_app_name}_DISABLE_UPDATE");
             let no_modify_path_env_var = format!("{env_app_name}_NO_MODIFY_PATH");
+            let github_base_url_env_var = format!("{env_app_name}_INSTALLER_GITHUB_BASE_URL");
+            let github_enterprise_base_url_env_var =
+                format!("{env_app_name}_INSTALLER_GITHUB_ENTERPRISE_BASE_URL");
 
             let environment_variables = EnvironmentVariables {
                 install_dir_env_var,
                 unmanaged_dir_env_var,
                 disable_update_env_var,
                 no_modify_path_env_var,
+                github_base_url_env_var,
+                github_enterprise_base_url_env_var,
             };
 
             self.releases.push(Release {

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -354,7 +354,7 @@ pub struct SystemInfo {
 }
 
 /// Release-specific environment variables
-#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct EnvironmentVariables {
     /// Environment variable to force an install location
     pub install_dir_env_var: String,

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -660,6 +660,8 @@ expression: json_schema
       "type": "object",
       "required": [
         "disable_update_env_var",
+        "github_base_url_env_var",
+        "github_enterprise_base_url_env_var",
         "install_dir_env_var",
         "no_modify_path_env_var",
         "unmanaged_dir_env_var"
@@ -667,6 +669,14 @@ expression: json_schema
       "properties": {
         "disable_update_env_var": {
           "description": "Environment variable to disable updater features",
+          "type": "string"
+        },
+        "github_base_url_env_var": {
+          "description": "Environment variable to set the GitHub base URL",
+          "type": "string"
+        },
+        "github_enterprise_base_url_env_var": {
+          "description": "Environment variable to set the GitHub Enterprise base URL",
           "type": "string"
         },
         "install_dir_env_var": {

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -734,7 +734,6 @@ expression: json_schema
       "required": [
         "artifact_base_url",
         "artifact_download_path",
-        "artifact_download_url",
         "owner",
         "repo"
       ],
@@ -745,10 +744,6 @@ expression: json_schema
         },
         "artifact_download_path": {
           "description": "The path of the release without the base URL\n\ne.g. `/myowner/myrepo/releases/download/v1.0.0/`",
-          "type": "string"
-        },
-        "artifact_download_url": {
-          "description": "The URL of the GitHub Release's artifact downloads\n\ne.g. `https://github.com/myowner/myrepo/releases/download/v1.0.0/`",
           "type": "string"
         },
         "owner": {

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -660,8 +660,8 @@ expression: json_schema
       "type": "object",
       "required": [
         "disable_update_env_var",
+        "ghe_base_url_env_var",
         "github_base_url_env_var",
-        "github_enterprise_base_url_env_var",
         "install_dir_env_var",
         "no_modify_path_env_var",
         "unmanaged_dir_env_var"
@@ -671,12 +671,12 @@ expression: json_schema
           "description": "Environment variable to disable updater features",
           "type": "string"
         },
-        "github_base_url_env_var": {
-          "description": "Environment variable to set the GitHub base URL",
+        "ghe_base_url_env_var": {
+          "description": "Environment variable to set the GitHub Enterprise base URL",
           "type": "string"
         },
-        "github_enterprise_base_url_env_var": {
-          "description": "Environment variable to set the GitHub Enterprise base URL",
+        "github_base_url_env_var": {
+          "description": "Environment variable to set the GitHub base URL",
           "type": "string"
         },
         "install_dir_env_var": {

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -722,13 +722,23 @@ expression: json_schema
       "description": "Github Hosting",
       "type": "object",
       "required": [
+        "artifact_base_url",
+        "artifact_download_path",
         "artifact_download_url",
         "owner",
         "repo"
       ],
       "properties": {
+        "artifact_base_url": {
+          "description": "The URL of the host for GitHub, usually `\"https://github.com\"` (This can vary for GitHub Enterprise)",
+          "type": "string"
+        },
+        "artifact_download_path": {
+          "description": "The path of the release without the base URL\n\ne.g. `/myowner/myrepo/releases/download/v1.0.0/`",
+          "type": "string"
+        },
         "artifact_download_url": {
-          "description": "The URL of the Github Release's artifact downloads\n\ne.g. `https://github.com/myowner/myrepo/releases/download/v1.0.0/`",
+          "description": "The URL of the GitHub Release's artifact downloads\n\ne.g. `https://github.com/myowner/myrepo/releases/download/v1.0.0/`",
           "type": "string"
         },
         "owner": {

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -5,7 +5,7 @@
 use std::collections::BTreeMap;
 
 use camino::Utf8PathBuf;
-use cargo_dist_schema::TargetTriple;
+use cargo_dist_schema::{Hosting, TargetTriple};
 use macpkg::PkgInstallerInfo;
 use serde::Serialize;
 
@@ -58,6 +58,8 @@ pub struct InstallerInfo {
     pub app_version: String,
     /// URL of the directory where artifacts can be fetched from
     pub base_url: String,
+    /// Full information about configured hosting
+    pub hosting: Hosting,
     /// Artifacts this installer can fetch
     pub artifacts: Vec<ExecutableZipFragment>,
     /// Description of the installer (a good heading)

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -88,6 +88,10 @@ pub struct InstallerInfo {
     pub disable_update_env_var: String,
     /// Environment variable to disable modifying the path
     pub no_modify_path_env_var: String,
+    /// Environment variable to set the GitHub base URL
+    pub github_base_url_env_var: String,
+    /// Environment variable to set the GitHub Enterprise base URL
+    pub github_enterprise_base_url_env_var: String,
 }
 
 /// A fake fragment of an ExecutableZip artifact for installers

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -81,7 +81,7 @@ pub struct InstallerInfo {
     /// platform support matrix
     pub platform_support: Option<PlatformSupport>,
     /// Environment variables for installer customization
-    pub env_vars: EnvironmentVariables,
+    pub env_vars: Option<EnvironmentVariables>,
 }
 
 /// A fake fragment of an ExecutableZip artifact for installers

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -5,7 +5,7 @@
 use std::collections::BTreeMap;
 
 use camino::Utf8PathBuf;
-use cargo_dist_schema::{Hosting, TargetTriple};
+use cargo_dist_schema::{EnvironmentVariables, Hosting, TargetTriple};
 use macpkg::PkgInstallerInfo;
 use serde::Serialize;
 
@@ -80,18 +80,8 @@ pub struct InstallerInfo {
     pub runtime_conditions: RuntimeConditions,
     /// platform support matrix
     pub platform_support: Option<PlatformSupport>,
-    /// Environment variable to force an install location
-    pub install_dir_env_var: String,
-    /// Like the above, but for unmanaged installs
-    pub unmanaged_dir_env_var: String,
-    /// Environment variable to disable self-update features
-    pub disable_update_env_var: String,
-    /// Environment variable to disable modifying the path
-    pub no_modify_path_env_var: String,
-    /// Environment variable to set the GitHub base URL
-    pub github_base_url_env_var: String,
-    /// Environment variable to set the GitHub Enterprise base URL
-    pub github_enterprise_base_url_env_var: String,
+    /// Environment variables for installer customization
+    pub env_vars: EnvironmentVariables,
 }
 
 /// A fake fragment of an ExecutableZip artifact for installers

--- a/cargo-dist/src/host.rs
+++ b/cargo-dist/src/host.rs
@@ -185,12 +185,15 @@ impl<'a> DistGraphBuilder<'a> {
                 HostingStyle::Github => {
                     // CI currently impls this for us, all we need to know is the URL to download from
                     let repo_url = &hosting.repo_url;
+                    let repo_path = &hosting.repo_path;
                     for (name, version) in &releases_without_hosting {
                         let tag = &announcing.tag;
                         self.manifest
                             .ensure_release(name.clone(), version.clone())
                             .hosting
                             .github = Some(cargo_dist_schema::GithubHosting {
+                            artifact_base_url: hosting.domain.clone(),
+                            artifact_download_path: format!("{repo_path}/releases/download/{tag}"),
                             artifact_download_url: format!("{repo_url}/releases/download/{tag}"),
                             owner: hosting.owner.clone(),
                             repo: hosting.project.clone(),
@@ -350,11 +353,15 @@ pub(crate) fn select_hosting(
     let repo = raw_repository_url
         .github_repo()
         .map_err(|e| DistError::CantEnableGithubUrlNotGithub { inner: e })?;
+    let domain = repo.domain();
     let repo_url = repo.web_url();
+    let repo_path = repo.web_path();
 
     Ok(Some(HostingInfo {
         hosts: hosting_providers,
+        domain,
         repo_url: repo_url.clone(),
+        repo_path,
         source_host: "github".to_owned(),
         owner: repo.owner,
         project: repo.name,

--- a/cargo-dist/src/host.rs
+++ b/cargo-dist/src/host.rs
@@ -184,7 +184,6 @@ impl<'a> DistGraphBuilder<'a> {
                 }
                 HostingStyle::Github => {
                     // CI currently impls this for us, all we need to know is the URL to download from
-                    let repo_url = &hosting.repo_url;
                     let repo_path = &hosting.repo_path;
                     for (name, version) in &releases_without_hosting {
                         let tag = &announcing.tag;
@@ -194,7 +193,6 @@ impl<'a> DistGraphBuilder<'a> {
                             .github = Some(cargo_dist_schema::GithubHosting {
                             artifact_base_url: hosting.domain.clone(),
                             artifact_download_path: format!("{repo_path}/releases/download/{tag}"),
-                            artifact_download_url: format!("{repo_url}/releases/download/{tag}"),
                             owner: hosting.owner.clone(),
                             repo: hosting.project.clone(),
                         })
@@ -354,13 +352,11 @@ pub(crate) fn select_hosting(
         .github_repo()
         .map_err(|e| DistError::CantEnableGithubUrlNotGithub { inner: e })?;
     let domain = repo.domain();
-    let repo_url = repo.web_url();
     let repo_path = repo.web_path();
 
     Ok(Some(HostingInfo {
         hosts: hosting_providers,
         domain,
-        repo_url: repo_url.clone(),
         repo_path,
         source_host: "github".to_owned(),
         owner: repo.owner,

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1758,6 +1758,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let unmanaged_dir_env_var = env_vars.unmanaged_dir_env_var.to_owned();
         let disable_update_env_var = env_vars.disable_update_env_var.to_owned();
         let no_modify_path_env_var = env_vars.no_modify_path_env_var.to_owned();
+        let github_base_url_env_var = env_vars.github_base_url_env_var.to_owned();
+        let github_enterprise_base_url_env_var =
+            env_vars.github_enterprise_base_url_env_var.to_owned();
 
         let download_url = schema_release
             .artifact_download_url()
@@ -1821,6 +1824,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 unmanaged_dir_env_var,
                 disable_update_env_var,
                 no_modify_path_env_var,
+                github_base_url_env_var,
+                github_enterprise_base_url_env_var,
             })),
             is_global: true,
         };
@@ -1990,6 +1995,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     unmanaged_dir_env_var: String::new(),
                     disable_update_env_var: String::new(),
                     no_modify_path_env_var: String::new(),
+                    github_base_url_env_var: String::new(),
+                    github_enterprise_base_url_env_var: String::new(),
                 },
                 install_libraries: config.install_libraries.clone(),
             })),
@@ -2025,6 +2032,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let unmanaged_dir_env_var = env_vars.unmanaged_dir_env_var.to_owned();
         let disable_update_env_var = env_vars.disable_update_env_var.to_owned();
         let no_modify_path_env_var = env_vars.no_modify_path_env_var.to_owned();
+        let github_base_url_env_var = env_vars.github_base_url_env_var.to_owned();
+        let github_enterprise_base_url_env_var =
+            env_vars.github_enterprise_base_url_env_var.to_owned();
 
         let download_url = schema_release
             .artifact_download_url()
@@ -2084,6 +2094,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 unmanaged_dir_env_var,
                 disable_update_env_var,
                 no_modify_path_env_var,
+                github_base_url_env_var,
+                github_enterprise_base_url_env_var,
             })),
             is_global: true,
         };
@@ -2205,6 +2217,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     unmanaged_dir_env_var: String::new(),
                     disable_update_env_var: String::new(),
                     no_modify_path_env_var: String::new(),
+                    github_base_url_env_var: String::new(),
+                    github_enterprise_base_url_env_var: String::new(),
                 },
             })),
             is_global: true,

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1750,10 +1750,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             .release_by_name(&release.app_name)
             .expect("couldn't find the release!?");
 
-        let env_vars = schema_release
-            .env
-            .clone()
-            .expect("couldn't determine app-specific environment variable!?");
+        let env_vars = schema_release.env.clone();
 
         let download_url = schema_release
             .artifact_download_url()
@@ -1979,7 +1976,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     runtime_conditions,
                     platform_support: None,
                     // Not actually needed for this installer type
-                    env_vars: cargo_dist_schema::EnvironmentVariables::default(),
+                    env_vars: None,
                 },
                 install_libraries: config.install_libraries.clone(),
             })),
@@ -2007,10 +2004,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             .release_by_name(&release.app_name)
             .expect("couldn't find the release!?");
 
-        let env_vars = schema_release
-            .env
-            .clone()
-            .expect("couldn't determine app-specific environment variable!?");
+        let env_vars = schema_release.env.clone();
 
         let download_url = schema_release
             .artifact_download_url()
@@ -2184,7 +2178,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     runtime_conditions,
                     platform_support: None,
                     // Not actually needed for this installer type
-                    env_vars: cargo_dist_schema::EnvironmentVariables::default(),
+                    env_vars: None,
                 },
             })),
             is_global: true,

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1752,15 +1752,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
 
         let env_vars = schema_release
             .env
-            .as_ref()
+            .clone()
             .expect("couldn't determine app-specific environment variable!?");
-        let install_dir_env_var = env_vars.install_dir_env_var.to_owned();
-        let unmanaged_dir_env_var = env_vars.unmanaged_dir_env_var.to_owned();
-        let disable_update_env_var = env_vars.disable_update_env_var.to_owned();
-        let no_modify_path_env_var = env_vars.no_modify_path_env_var.to_owned();
-        let github_base_url_env_var = env_vars.github_base_url_env_var.to_owned();
-        let github_enterprise_base_url_env_var =
-            env_vars.github_enterprise_base_url_env_var.to_owned();
 
         let download_url = schema_release
             .artifact_download_url()
@@ -1820,12 +1813,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 install_libraries: config.install_libraries.clone(),
                 runtime_conditions,
                 platform_support: None,
-                install_dir_env_var,
-                unmanaged_dir_env_var,
-                disable_update_env_var,
-                no_modify_path_env_var,
-                github_base_url_env_var,
-                github_enterprise_base_url_env_var,
+                env_vars,
             })),
             is_global: true,
         };
@@ -1991,12 +1979,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     runtime_conditions,
                     platform_support: None,
                     // Not actually needed for this installer type
-                    install_dir_env_var: String::new(),
-                    unmanaged_dir_env_var: String::new(),
-                    disable_update_env_var: String::new(),
-                    no_modify_path_env_var: String::new(),
-                    github_base_url_env_var: String::new(),
-                    github_enterprise_base_url_env_var: String::new(),
+                    env_vars: cargo_dist_schema::EnvironmentVariables::default(),
                 },
                 install_libraries: config.install_libraries.clone(),
             })),
@@ -2026,15 +2009,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
 
         let env_vars = schema_release
             .env
-            .as_ref()
+            .clone()
             .expect("couldn't determine app-specific environment variable!?");
-        let install_dir_env_var = env_vars.install_dir_env_var.to_owned();
-        let unmanaged_dir_env_var = env_vars.unmanaged_dir_env_var.to_owned();
-        let disable_update_env_var = env_vars.disable_update_env_var.to_owned();
-        let no_modify_path_env_var = env_vars.no_modify_path_env_var.to_owned();
-        let github_base_url_env_var = env_vars.github_base_url_env_var.to_owned();
-        let github_enterprise_base_url_env_var =
-            env_vars.github_enterprise_base_url_env_var.to_owned();
 
         let download_url = schema_release
             .artifact_download_url()
@@ -2090,12 +2066,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 install_libraries: config.install_libraries.clone(),
                 runtime_conditions: RuntimeConditions::default(),
                 platform_support: None,
-                install_dir_env_var,
-                unmanaged_dir_env_var,
-                disable_update_env_var,
-                no_modify_path_env_var,
-                github_base_url_env_var,
-                github_enterprise_base_url_env_var,
+                env_vars,
             })),
             is_global: true,
         };
@@ -2213,12 +2184,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     runtime_conditions,
                     platform_support: None,
                     // Not actually needed for this installer type
-                    install_dir_env_var: String::new(),
-                    unmanaged_dir_env_var: String::new(),
-                    disable_update_env_var: String::new(),
-                    no_modify_path_env_var: String::new(),
-                    github_base_url_env_var: String::new(),
-                    github_enterprise_base_url_env_var: String::new(),
+                    env_vars: cargo_dist_schema::EnvironmentVariables::default(),
                 },
             })),
             is_global: true,

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -247,8 +247,12 @@ pub struct DistGraph {
 pub struct HostingInfo {
     /// Hosting backends
     pub hosts: Vec<HostingStyle>,
+    /// The domain at which the repo is hosted, (e.g. `"https://github.com"`)
+    pub domain: String,
     /// Repo url
     pub repo_url: String,
+    /// Path at the domain
+    pub repo_path: String,
     /// Source hosting provider (e.g. "github")
     pub source_host: String,
     /// Project owner
@@ -1758,6 +1762,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let download_url = schema_release
             .artifact_download_url()
             .expect("couldn't compute a URL to download artifacts from!?");
+        let hosting = schema_release.hosting.clone();
         let artifact_name = format!("{release_id}-installer.sh");
         let artifact_path = self.inner.dist_dir.join(&artifact_name);
         let installer_url = format!("{download_url}/{artifact_name}");
@@ -1803,6 +1808,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     .collect(),
                 install_success_msg: config.install_success_msg.to_owned(),
                 base_url: download_url.to_owned(),
+                hosting,
                 artifacts,
                 hint,
                 desc,
@@ -1837,11 +1843,14 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         } else {
             &release.id
         };
-        let download_url = self
+        let schema_release = self
             .manifest
             .release_by_name(&release.id)
-            .and_then(|r| r.artifact_download_url())
+            .expect("couldn't find the release!?");
+        let download_url = schema_release
+            .artifact_download_url()
             .expect("couldn't compute a URL to download artifacts from!?");
+        let hosting = schema_release.hosting.clone();
 
         let artifact_name = format!("{formula}.rb");
         let artifact_path = self.inner.dist_dir.join(&artifact_name);
@@ -1967,6 +1976,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                         .collect(),
                     install_success_msg: config.install_success_msg.to_owned(),
                     base_url: download_url.to_owned(),
+                    hosting,
                     artifacts,
                     hint,
                     desc,
@@ -2019,6 +2029,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let download_url = schema_release
             .artifact_download_url()
             .expect("couldn't compute a URL to download artifacts from!?");
+        let hosting = schema_release.hosting.clone();
         let artifact_name = format!("{release_id}-installer.ps1");
         let artifact_path = self.inner.dist_dir.join(&artifact_name);
         let installer_url = format!("{download_url}/{artifact_name}");
@@ -2060,6 +2071,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     .collect(),
                 install_success_msg: config.install_success_msg.to_owned(),
                 base_url: download_url.to_owned(),
+                hosting,
                 artifacts,
                 hint,
                 desc,
@@ -2090,11 +2102,14 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         };
         require_nonempty_installer(release, config)?;
         let release_id = &release.id;
-        let download_url = self
+        let schema_release = self
             .manifest
             .release_by_name(&release.app_name)
-            .and_then(|r| r.artifact_download_url())
+            .expect("couldn't find the release!?");
+        let download_url = schema_release
+            .artifact_download_url()
             .expect("couldn't compute a URL to download artifacts from!?");
+        let hosting = schema_release.hosting.clone();
 
         let app_name = config.package.clone();
         let npm_package_name = if let Some(scope) = &config.scope {
@@ -2176,6 +2191,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                         .collect(),
                     install_success_msg: config.install_success_msg.to_owned(),
                     base_url: download_url.to_owned(),
+                    hosting,
                     artifacts,
                     hint,
                     desc,

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -249,8 +249,6 @@ pub struct HostingInfo {
     pub hosts: Vec<HostingStyle>,
     /// The domain at which the repo is hosted, (e.g. `"https://github.com"`)
     pub domain: String,
-    /// Repo url
-    pub repo_url: String,
     /// Path at the domain
     pub repo_path: String,
     /// Source hosting provider (e.g. "github")

--- a/cargo-dist/src/tests/host.rs
+++ b/cargo-dist/src/tests/host.rs
@@ -41,7 +41,6 @@ fn github_simple() {
     let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
 
     let hosting = hosting.unwrap().unwrap();
-    assert_eq!(hosting.repo_url, REPO_URL);
     assert_eq!(hosting.hosts, &[HostingStyle::Github]);
     assert_eq!(hosting.owner, REPO_OWNER);
     assert_eq!(hosting.project, REPO_PROJECT);
@@ -59,7 +58,6 @@ fn github_and_axo_simple() {
     let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
 
     let hosting = hosting.unwrap().unwrap();
-    assert_eq!(hosting.repo_url, REPO_URL);
     assert_eq!(
         hosting.hosts,
         &[HostingStyle::Github, HostingStyle::Axodotdev]
@@ -80,7 +78,6 @@ fn github_implicit() {
     let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
 
     let hosting = hosting.unwrap().unwrap();
-    assert_eq!(hosting.repo_url, REPO_URL);
     assert_eq!(hosting.hosts, &[HostingStyle::Github]);
     assert_eq!(hosting.owner, REPO_OWNER);
     assert_eq!(hosting.project, REPO_PROJECT);
@@ -106,7 +103,6 @@ fn github_diff_repository_on_non_distables() {
     let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
 
     let hosting = hosting.unwrap().unwrap();
-    assert_eq!(hosting.repo_url, REPO_URL);
     assert_eq!(hosting.hosts, &[HostingStyle::Github]);
     assert_eq!(hosting.owner, REPO_OWNER);
     assert_eq!(hosting.project, REPO_PROJECT);
@@ -236,7 +232,6 @@ fn github_dot_git() {
     let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
 
     let hosting = hosting.unwrap().unwrap();
-    assert_eq!(hosting.repo_url, REPO_URL);
     assert_eq!(hosting.hosts, &[HostingStyle::Github]);
     assert_eq!(hosting.owner, REPO_OWNER);
     assert_eq!(hosting.project, REPO_PROJECT);
@@ -262,7 +257,6 @@ fn github_trail_slash() {
     let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
 
     let hosting = hosting.unwrap().unwrap();
-    assert_eq!(hosting.repo_url, REPO_URL);
     assert_eq!(hosting.hosts, &[HostingStyle::Github]);
     assert_eq!(hosting.owner, REPO_OWNER);
     assert_eq!(hosting.project, REPO_PROJECT);

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -55,10 +55,10 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
   $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
 }
 {% else %}
-if ($env:{{ github_enterprise_base_url_env_var }}) {
-  $installer_base_url = $env:{{ github_enterprise_base_url_env_var }}
-} elseif ($env:{{ github_base_url_env_var }}) {
-  $installer_base_url = $env:{{ github_base_url_env_var }}
+if ($env:{{ env_vars.github_enterprise_base_url_env_var }}) {
+  $installer_base_url = $env:{{ env_vars.github_enterprise_base_url_env_var }}
+} elseif ($env:{{ env_vars.github_base_url_env_var }}) {
+  $installer_base_url = $env:{{ env_vars.github_base_url_env_var }}
 } else {
   $installer_base_url = "{{ hosting.github.artifact_base_url }}"
 }
@@ -74,21 +74,21 @@ $receipt = @"
 "@
 $receipt_home = "${env:LOCALAPPDATA}\{{ app_name }}"
 
-if ($env:{{ disable_update_env_var }}) {
+if ($env:{{ env_vars.disable_update_env_var }}) {
   $install_updater = $false
 } else {
   $install_updater = $true
 }
 
 if ($NoModifyPath) {
-    Write-Information "-NoModifyPath has been deprecated; please set {{ no_modify_path_env_var }}=1 in the environment"
+    Write-Information "-NoModifyPath has been deprecated; please set {{ env_vars.no_modify_path_env_var }}=1 in the environment"
 }
 
-if ($env:{{ no_modify_path_env_var }}) {
+if ($env:{{ env_vars.no_modify_path_env_var }}) {
     $NoModifyPath = $true
 }
 
-$unmanaged_install = $env:{{ unmanaged_dir_env_var }}
+$unmanaged_install = $env:{{ env_vars.unmanaged_dir_env_var }}
 
 if ($unmanaged_install) {
   $NoModifyPath = $true
@@ -291,8 +291,8 @@ function Invoke-Installer($artifacts, $platforms) {
   $install_layout = "unspecified"
   # Check the newer app-specific variable before falling back
   # to the older generic one
-  if (($env:{{ install_dir_env_var }})) {
-    $force_install_dir = $env:{{ install_dir_env_var }}
+  if (($env:{{ env_vars.install_dir_env_var }})) {
+    $force_install_dir = $env:{{ env_vars.install_dir_env_var }}
     $install_layout = {% if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "cargo-home" {%- else -%} "flat" {%- endif %}
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -55,8 +55,8 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
   $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
 }
 {% else %}
-if ($env:{{ env_vars.github_enterprise_base_url_env_var }}) {
-  $installer_base_url = $env:{{ env_vars.github_enterprise_base_url_env_var }}
+if ($env:{{ env_vars.ghe_base_url_env_var }}) {
+  $installer_base_url = $env:{{ env_vars.ghe_base_url_env_var }}
 } elseif ($env:{{ env_vars.github_base_url_env_var }}) {
   $installer_base_url = $env:{{ env_vars.github_base_url_env_var }}
 } else {

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -50,6 +50,25 @@ param (
 $app_name = '{{ app_name }}'
 $app_version = '{{ app_version }}'
 
+{%- if hosting.axodotdev %}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+}
+{% else %}
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "{{ hosting.github.artifact_base_url }}"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url{{ hosting.github.artifact_download_path }}"
+}
+{%- endif %}
+
 $receipt = @"
 {{ receipt | tojson }}
 "@

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -55,10 +55,10 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
   $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
 }
 {% else %}
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:{{ github_enterprise_base_url_env_var }}) {
+  $installer_base_url = $env:{{ github_enterprise_base_url_env_var }}
+} elseif ($env:{{ github_base_url_env_var }}) {
+  $installer_base_url = $env:{{ github_base_url_env_var }}
 } else {
   $installer_base_url = "{{ hosting.github.artifact_base_url }}"
 }

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -22,8 +22,8 @@ APP_VERSION="{{ app_version }}"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-{{ base_url }}}"
 {% else %}
 # Look for GitHub Enterprise-style base URL first
-if [ -n "{{ '${' }}{{ env_vars.github_enterprise_base_url_env_var }}:-}" ]; then
-    INSTALLER_BASE_URL="${{ env_vars.github_enterprise_base_url_env_var }}"
+if [ -n "{{ '${' }}{{ env_vars.ghe_base_url_env_var }}:-}" ]; then
+    INSTALLER_BASE_URL="${{ env_vars.ghe_base_url_env_var }}"
 else
     INSTALLER_BASE_URL="{{ '${' }}{{ env_vars.github_base_url_env_var }}:-{{ hosting.github.artifact_base_url }}}"
 fi

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -22,10 +22,10 @@ APP_VERSION="{{ app_version }}"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-{{ base_url }}}"
 {% else %}
 # Look for GitHub Enterprise-style base URL first
-if [ -n "{{ '${' }}{{ github_enterprise_base_url_env_var }}:-}" ]; then
-    INSTALLER_BASE_URL="${{ github_enterprise_base_url_env_var }}"
+if [ -n "{{ '${' }}{{ env_vars.github_enterprise_base_url_env_var }}:-}" ]; then
+    INSTALLER_BASE_URL="${{ env_vars.github_enterprise_base_url_env_var }}"
 else
-    INSTALLER_BASE_URL="{{ '${' }}{{ github_base_url_env_var }}:-{{ hosting.github.artifact_base_url }}}"
+    INSTALLER_BASE_URL="{{ '${' }}{{ env_vars.github_base_url_env_var }}:-{{ hosting.github.artifact_base_url }}}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -35,17 +35,17 @@ fi
 {%- endif %}
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
-if [ -n "{{ '${' }}{{ no_modify_path_env_var }}:-}" ]; then
-    NO_MODIFY_PATH="${{ no_modify_path_env_var }}"
+if [ -n "{{ '${' }}{{ env_vars.no_modify_path_env_var }}:-}" ]; then
+    NO_MODIFY_PATH="${{ env_vars.no_modify_path_env_var }}"
 else
     NO_MODIFY_PATH=${INSTALLER_NO_MODIFY_PATH:-0}
 fi
-if [ "{{ '${' }}{{ disable_update_env_var }}:-0}" = "1" ]; then
+if [ "{{ '${' }}{{ env_vars.disable_update_env_var }}:-0}" = "1" ]; then
     INSTALL_UPDATER=0
 else
     INSTALL_UPDATER=1
 fi
-UNMANAGED_INSTALL="{{ '${' }}{{ unmanaged_dir_env_var }}:-}"
+UNMANAGED_INSTALL="{{ '${' }}{{ env_vars.unmanaged_dir_env_var }}:-}"
 if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
@@ -122,7 +122,7 @@ download_binary_and_run_installer() {
                 PRINT_VERBOSE=1
                 ;;
             --no-modify-path)
-                say "--no-modify-path has been deprecated; please set {{ no_modify_path_env_var }}=1 in the environment"
+                say "--no-modify-path has been deprecated; please set {{ env_vars.no_modify_path_env_var }}=1 in the environment"
                 NO_MODIFY_PATH=1
                 ;;
             *)
@@ -435,8 +435,8 @@ install() {
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
-    if [ -n "{{ '${' }}{{ install_dir_env_var }}:-}" ]; then
-        _force_install_dir="${{ install_dir_env_var }}"
+    if [ -n "{{ '${' }}{{ env_vars.install_dir_env_var }}:-}" ]; then
+        _force_install_dir="${{ env_vars.install_dir_env_var }}"
         _install_layout={%- if install_paths | selectattr("kind", "equalto", "CargoHome") -%} "cargo-home" {%- else -%} "flat" {%- endif %}
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -18,7 +18,21 @@ set -u
 
 APP_NAME="{{ app_name }}"
 APP_VERSION="{{ app_version }}"
+{%- if hosting.axodotdev %}
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-{{ base_url }}}"
+{% else %}
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-{{ hosting.github.artifact_base_url }}}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}{{ hosting.github.artifact_download_path }}"
+fi
+{%- endif %}
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "{{ '${' }}{{ no_modify_path_env_var }}:-}" ]; then

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -22,10 +22,10 @@ APP_VERSION="{{ app_version }}"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-{{ base_url }}}"
 {% else %}
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "{{ '${' }}{{ github_enterprise_base_url_env_var }}:-}" ]; then
+    INSTALLER_BASE_URL="${{ github_enterprise_base_url_env_var }}"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-{{ hosting.github.artifact_base_url }}}"
+    INSTALLER_BASE_URL="{{ '${' }}{{ github_base_url_env_var }}:-{{ hosting.github.artifact_base_url }}}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1844,7 +1844,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
-          "artifact_download_url": "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "owner": "mistydemeo",
           "repo": "akaikatana-repack"
         }

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1818,7 +1818,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
         "unmanaged_dir_env_var": "AKAIKATANA_REPACK_UNMANAGED_INSTALL",
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
-if ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL
 } elseif ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1820,7 +1820,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
         "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
         "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AKAIKATANA_REPACK_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1818,6 +1840,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "artifact_download_url": "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "owner": "mistydemeo",
           "repo": "akaikatana-repack"

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1242,7 +1242,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
         "unmanaged_dir_env_var": "AKAIKATANA_REPACK_UNMANAGED_INSTALL",
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1266,7 +1266,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
-          "artifact_download_url": "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "owner": "mistydemeo",
           "repo": "akaikatana-repack"
         }

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1244,7 +1244,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
         "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
         "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AKAIKATANA_REPACK_NO_MODIFY_PATH:-}" ]; then
@@ -1252,6 +1262,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "artifact_download_url": "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "owner": "mistydemeo",
           "repo": "akaikatana-repack"

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1874,7 +1874,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
-          "artifact_download_url": "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "owner": "mistydemeo",
           "repo": "akaikatana-repack"
         }

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1351,8 +1351,8 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
-if ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL
 } elseif ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1850,7 +1850,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
         "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
         "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1351,10 +1351,10 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1848,7 +1848,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
         "unmanaged_dir_env_var": "AKAIKATANA_REPACK_UNMANAGED_INSTALL",
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AKAIKATANA_REPACK_NO_MODIFY_PATH:-}" ]; then
@@ -1341,6 +1351,18 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1848,6 +1870,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "artifact_download_url": "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "owner": "mistydemeo",
           "repo": "akaikatana-repack"

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1375,8 +1375,8 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
-if ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL
 } elseif ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1876,7 +1876,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
         "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
         "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1375,10 +1375,10 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1874,7 +1874,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
         "unmanaged_dir_env_var": "AKAIKATANA_REPACK_UNMANAGED_INSTALL",
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AKAIKATANA_REPACK_NO_MODIFY_PATH:-}" ]; then
@@ -1365,6 +1375,18 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1874,6 +1896,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "artifact_download_url": "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "owner": "mistydemeo",
           "repo": "akaikatana-repack"

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1900,7 +1900,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
-          "artifact_download_url": "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "owner": "mistydemeo",
           "repo": "akaikatana-repack"
         }

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
-if ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL
 } elseif ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1828,7 +1828,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
         "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
         "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1856,7 +1856,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
-          "artifact_download_url": "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "owner": "mistydemeo",
           "repo": "akaikatana-repack"
         }

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AKAIKATANA_REPACK_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1830,6 +1852,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "artifact_download_url": "https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0",
           "owner": "mistydemeo",
           "repo": "akaikatana-repack"

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="akaikatana-repack"
 APP_VERSION="0.2.0"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'akaikatana-repack'
 $app_version = '0.2.0'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1826,7 +1826,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AKAIKATANA_REPACK_INSTALL_DIR",
         "unmanaged_dir_env_var": "AKAIKATANA_REPACK_UNMANAGED_INSTALL",
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3273,7 +3273,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         },

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -24,6 +24,7 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload}"
+
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1314,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+}
+
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
@@ -3264,6 +3269,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3242,7 +3242,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3240,7 +3240,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3241,7 +3241,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3239,7 +3239,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -24,6 +24,7 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload}"
+
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1314,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+}
+
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3322,7 +3322,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1341,6 +1351,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3296,6 +3318,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1351,8 +1351,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3291,7 +3291,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1351,10 +1351,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3289,7 +3289,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1355,10 +1355,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3291,7 +3291,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1345,6 +1355,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3298,6 +3320,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1355,8 +1355,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3293,7 +3293,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3324,7 +3324,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -25,10 +25,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1324,10 +1324,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3258,7 +3258,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -25,8 +25,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1324,8 +1324,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3260,7 +3260,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3291,7 +3291,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -24,7 +24,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1314,6 +1324,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3265,6 +3287,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1326,8 +1326,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3269,7 +3269,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1326,10 +1326,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3267,7 +3267,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3300,7 +3300,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1316,6 +1326,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3274,6 +3296,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -3290,7 +3290,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3257,7 +3257,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3259,7 +3259,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3264,6 +3286,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1232,7 +1232,9 @@ download_binary_and_run_installer "$@" || exit 1
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1242,6 +1252,8 @@ download_binary_and_run_installer "$@" || exit 1
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1234,7 +1234,7 @@ download_binary_and_run_installer "$@" || exit 1
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1256,7 +1256,6 @@ download_binary_and_run_installer "$@" || exit 1
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1232,7 +1232,9 @@ download_binary_and_run_installer "$@" || exit 1
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1242,6 +1252,8 @@ download_binary_and_run_installer "$@" || exit 1
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1234,7 +1234,7 @@ download_binary_and_run_installer "$@" || exit 1
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1256,7 +1256,6 @@ download_binary_and_run_installer "$@" || exit 1
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1232,7 +1232,9 @@ download_binary_and_run_installer "$@" || exit 1
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1242,6 +1252,8 @@ download_binary_and_run_installer "$@" || exit 1
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1234,7 +1234,7 @@ download_binary_and_run_installer "$@" || exit 1
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1256,7 +1256,6 @@ download_binary_and_run_installer "$@" || exit 1
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1232,7 +1232,9 @@ download_binary_and_run_installer "$@" || exit 1
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1242,6 +1252,8 @@ download_binary_and_run_installer "$@" || exit 1
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1234,7 +1234,7 @@ download_binary_and_run_installer "$@" || exit 1
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1256,7 +1256,6 @@ download_binary_and_run_installer "$@" || exit 1
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -111,7 +111,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -89,7 +89,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -107,6 +107,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -87,7 +87,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -45,7 +45,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -41,6 +41,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -24,7 +24,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -22,7 +22,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3287,7 +3287,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-n
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3256,7 +3256,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-n
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3258,7 +3258,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-n
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3261,6 +3283,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-n
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -45,7 +45,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -41,6 +41,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -24,7 +24,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -22,7 +22,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -45,7 +45,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         },

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -41,6 +41,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -24,7 +24,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -22,7 +22,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -23,7 +23,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -21,7 +21,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3284,7 +3284,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3257,7 +3257,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3259,7 +3259,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3258,6 +3280,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -3643,7 +3643,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2",
           "owner": "axodotdev",
           "repo": "axolotlsay-hybrid"
         }
@@ -3682,7 +3681,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2",
           "owner": "axodotdev",
           "repo": "axolotlsay-hybrid"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay-js"
 APP_VERSION="0.10.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_JS_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_JS_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_JS_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1322,10 +1322,10 @@ param (
 
 $app_name = 'axolotlsay-js'
 $app_version = '0.10.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_JS_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_JS_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_JS_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_JS_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1823,10 +1823,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.10.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -3122,10 +3122,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.10.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3617,7 +3617,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,
@@ -3654,7 +3656,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_JS_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_JS_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_JS_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_JS_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_JS_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_JS_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_JS_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay-js",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay-js"
 APP_VERSION="0.10.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_JS_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_JS_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_JS_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_JS_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_JS_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1322,8 +1322,8 @@ param (
 
 $app_name = 'axolotlsay-js'
 $app_version = '0.10.2'
-if ($env:AXOLOTLSAY_JS_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_JS_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_JS_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_JS_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_JS_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_JS_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1823,8 +1823,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.10.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -3122,8 +3122,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.10.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3619,7 +3619,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,
@@ -3658,7 +3658,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_JS_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_JS_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_JS_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_JS_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_JS_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay-js",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay-js"
 APP_VERSION="0.10.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_JS_NO_MODIFY_PATH:-}" ]; then
@@ -1312,6 +1322,18 @@ param (
 
 $app_name = 'axolotlsay-js'
 $app_version = '0.10.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1800,7 +1822,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.10.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -3090,6 +3122,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.10.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3595,6 +3639,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2",
           "owner": "axodotdev",
           "repo": "axolotlsay-hybrid"
@@ -3630,6 +3676,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2",
           "owner": "axodotdev",
           "repo": "axolotlsay-hybrid"

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3290,7 +3290,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3257,7 +3257,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3259,7 +3259,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3264,6 +3286,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2699,7 +2699,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -2685,6 +2695,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -2674,7 +2674,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -2676,7 +2676,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -2654,7 +2654,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2677,7 +2677,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -2663,6 +2673,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -2656,7 +2656,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3284,7 +3284,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3257,7 +3257,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3259,7 +3259,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3258,6 +3280,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -45,7 +45,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -41,6 +41,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -24,7 +24,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -22,7 +22,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -45,7 +45,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -41,6 +41,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -24,7 +24,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -22,7 +22,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1345,6 +1355,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3302,6 +3324,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1355,10 +1355,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3295,7 +3295,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3328,7 +3328,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1355,8 +1355,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3297,7 +3297,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1248,6 +1258,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1759,6 +1781,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1785,7 +1785,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1258,8 +1258,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1756,7 +1756,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1258,10 +1258,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1754,7 +1754,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1248,6 +1258,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1759,6 +1781,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1785,7 +1785,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1258,8 +1258,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1756,7 +1756,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1258,10 +1258,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1754,7 +1754,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -45,7 +45,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -41,6 +41,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -24,7 +24,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -22,7 +22,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3302,7 +3302,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3276,6 +3298,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3267,7 +3267,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3265,7 +3265,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3284,7 +3284,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3257,7 +3257,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3259,7 +3259,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3258,6 +3280,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3284,7 +3284,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3257,7 +3257,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3259,7 +3259,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3258,6 +3280,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3284,7 +3284,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3257,7 +3257,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3259,7 +3259,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3258,6 +3280,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3284,7 +3284,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3257,7 +3257,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3259,7 +3259,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3258,6 +3280,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3284,7 +3284,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -3257,7 +3257,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -3259,7 +3259,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3258,6 +3280,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1845,7 +1845,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1313,6 +1323,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1819,6 +1841,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1323,10 +1323,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1819,7 +1819,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1323,8 +1323,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1821,7 +1821,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1296,6 +1306,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1795,6 +1817,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1306,10 +1306,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1795,7 +1795,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1821,7 +1821,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1306,8 +1306,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1797,7 +1797,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1296,6 +1306,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1795,6 +1817,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1306,10 +1306,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1795,7 +1795,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1821,7 +1821,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1306,8 +1306,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1797,7 +1797,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1296,6 +1306,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1795,6 +1817,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1306,10 +1306,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1795,7 +1795,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1821,7 +1821,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1306,8 +1306,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1797,7 +1797,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1296,6 +1306,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1795,6 +1817,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1306,10 +1306,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1795,7 +1795,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1821,7 +1821,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1306,8 +1306,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1797,7 +1797,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1310,6 +1320,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1818,6 +1840,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1320,10 +1320,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1818,7 +1818,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1844,7 +1844,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1320,8 +1320,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1820,7 +1820,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1296,6 +1306,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1795,6 +1817,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1306,10 +1306,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1795,7 +1795,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1821,7 +1821,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1306,8 +1306,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1797,7 +1797,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1296,6 +1306,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1795,6 +1817,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1306,10 +1306,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1795,7 +1795,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1821,7 +1821,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1306,8 +1306,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1797,7 +1797,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1296,6 +1306,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1795,6 +1817,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1306,10 +1306,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1795,7 +1795,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1821,7 +1821,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1306,8 +1306,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1797,7 +1797,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1296,6 +1306,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1795,6 +1817,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1306,10 +1306,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1795,7 +1795,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1821,7 +1821,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1306,8 +1306,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1797,7 +1797,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -23,7 +23,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2}"
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -1310,6 +1320,18 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
+if ($env:INSTALLER_DOWNLOAD_URL) {
+  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
+}
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1818,6 +1840,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
           "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -24,10 +24,10 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
 else
-    INSTALLER_BASE_URL="${INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
 if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
     ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
@@ -1320,10 +1320,10 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_ENTERPRISE_BASE_URL
-} elseif ($env:INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:INSTALLER_GITHUB_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
   $installer_base_url = "https://github.com"
 }
@@ -1818,7 +1818,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "install_dir_env_var": "AXOLOTLSAY_INSTALL_DIR",
         "unmanaged_dir_env_var": "AXOLOTLSAY_UNMANAGED_INSTALL",
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
-        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
+        "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1844,7 +1844,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/axolotlsay/releases/download/v0.2.2",
-          "artifact_download_url": "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2",
           "owner": "axodotdev",
           "repo": "axolotlsay"
         }

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -24,8 +24,8 @@ set -u
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
 # Look for GitHub Enterprise-style base URL first
-if [ -n "${AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL:-}" ]; then
-    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
 else
     INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
 fi
@@ -1320,8 +1320,8 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
 } elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
   $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
 } else {
@@ -1820,7 +1820,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -25,6 +25,8 @@ stdout:
       "display": true,
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/cargo-dist/releases/download/cargo-dist-schema-v1.0.0-FAKEVERSION",
           "artifact_download_url": "https://github.com/axodotdev/cargo-dist/releases/download/cargo-dist-schema-v1.0.0-FAKEVERSION",
           "owner": "axodotdev",
           "repo": "cargo-dist"

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -29,7 +29,6 @@ stdout:
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/cargo-dist/releases/download/cargo-dist-schema-v1.0.0-FAKEVERSION",
-          "artifact_download_url": "https://github.com/axodotdev/cargo-dist/releases/download/cargo-dist-schema-v1.0.0-FAKEVERSION",
           "owner": "axodotdev",
           "repo": "cargo-dist"
         },

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -19,7 +19,9 @@ stdout:
         "install_dir_env_var": "CARGO_DIST_SCHEMA_INSTALL_DIR",
         "unmanaged_dir_env_var": "CARGO_DIST_SCHEMA_UNMANAGED_INSTALL",
         "disable_update_env_var": "CARGO_DIST_SCHEMA_DISABLE_UPDATE",
-        "no_modify_path_env_var": "CARGO_DIST_SCHEMA_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "CARGO_DIST_SCHEMA_NO_MODIFY_PATH",
+        "github_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "cargo-dist-schema",
       "display": true,

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -21,7 +21,7 @@ stdout:
         "disable_update_env_var": "CARGO_DIST_SCHEMA_DISABLE_UPDATE",
         "no_modify_path_env_var": "CARGO_DIST_SCHEMA_NO_MODIFY_PATH",
         "github_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "cargo-dist-schema",
       "display": true,

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -25,6 +25,8 @@ stdout:
       "display": true,
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/cargo-dist/releases/download/cargo-dist-schema/v1.0.0-FAKEVERSION",
           "artifact_download_url": "https://github.com/axodotdev/cargo-dist/releases/download/cargo-dist-schema/v1.0.0-FAKEVERSION",
           "owner": "axodotdev",
           "repo": "cargo-dist"

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -19,7 +19,9 @@ stdout:
         "install_dir_env_var": "CARGO_DIST_SCHEMA_INSTALL_DIR",
         "unmanaged_dir_env_var": "CARGO_DIST_SCHEMA_UNMANAGED_INSTALL",
         "disable_update_env_var": "CARGO_DIST_SCHEMA_DISABLE_UPDATE",
-        "no_modify_path_env_var": "CARGO_DIST_SCHEMA_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "CARGO_DIST_SCHEMA_NO_MODIFY_PATH",
+        "github_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "cargo-dist-schema",
       "display": true,

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -21,7 +21,7 @@ stdout:
         "disable_update_env_var": "CARGO_DIST_SCHEMA_DISABLE_UPDATE",
         "no_modify_path_env_var": "CARGO_DIST_SCHEMA_NO_MODIFY_PATH",
         "github_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "cargo-dist-schema",
       "display": true,

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -29,7 +29,6 @@ stdout:
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/cargo-dist/releases/download/cargo-dist-schema/v1.0.0-FAKEVERSION",
-          "artifact_download_url": "https://github.com/axodotdev/cargo-dist/releases/download/cargo-dist-schema/v1.0.0-FAKEVERSION",
           "owner": "axodotdev",
           "repo": "cargo-dist"
         },

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -49,6 +49,8 @@ stdout:
       ],
       "hosting": {
         "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION",
           "artifact_download_url": "https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION",
           "owner": "axodotdev",
           "repo": "cargo-dist"

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -19,7 +19,9 @@ stdout:
         "install_dir_env_var": "CARGO_DIST_INSTALL_DIR",
         "unmanaged_dir_env_var": "CARGO_DIST_UNMANAGED_INSTALL",
         "disable_update_env_var": "CARGO_DIST_DISABLE_UPDATE",
-        "no_modify_path_env_var": "CARGO_DIST_NO_MODIFY_PATH"
+        "no_modify_path_env_var": "CARGO_DIST_NO_MODIFY_PATH",
+        "github_base_url_env_var": "CARGO_DIST_INSTALLER_GITHUB_BASE_URL",
+        "github_enterprise_base_url_env_var": "CARGO_DIST_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
       },
       "display_name": "cargo-dist",
       "display": true,

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -53,7 +53,6 @@ stdout:
         "github": {
           "artifact_base_url": "https://github.com",
           "artifact_download_path": "/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION",
-          "artifact_download_url": "https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION",
           "owner": "axodotdev",
           "repo": "cargo-dist"
         },

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -21,7 +21,7 @@ stdout:
         "disable_update_env_var": "CARGO_DIST_DISABLE_UPDATE",
         "no_modify_path_env_var": "CARGO_DIST_NO_MODIFY_PATH",
         "github_base_url_env_var": "CARGO_DIST_INSTALLER_GITHUB_BASE_URL",
-        "github_enterprise_base_url_env_var": "CARGO_DIST_INSTALLER_GITHUB_ENTERPRISE_BASE_URL"
+        "ghe_base_url_env_var": "CARGO_DIST_INSTALLER_GHE_BASE_URL"
       },
       "display_name": "cargo-dist",
       "display": true,


### PR DESCRIPTION
Previously, we allowed overriding the full URL to the installer path - that is, everything prior to the actual installer filename. This isn't flexible enough for people who are mirroring or proxying github.com, and who want to be able to set a single environment variable that can work for any version of a program.

This adds two environment variables, `INSTALLER_GITHUB_BASE_URL` and `INSTALLER_GITHUB_ENTERPRISE_BASE_URL`, which allow overriding just the domain. They do the same thing for these installers, but will have slightly different behaviour for axoupdater.

Implementation wise, this updates our hosting types a little bit. axoproject's `GithubRepo`[^1] hardcodes `github.com` slightly less - instead of being inlined in a bunch of strings, it provides a `domain()` method that itself returns a hardcoded string, which will give us some room to eventually stop hardcoding it without changing a bunch of occurrences of `github.com`. In addition to our methods that return fully-qualified URLs, I've added a method that allows retrieving just the path component of a URL with the domain omitted so we can do the domain substitution in the installers. I've also had us pipe the hosting data right through to the installers so that the full hosting data, and not just the computed URL, can be accessed.

Fixes #1495.

[^1]: Trademark-noncompliant struct name 