### PR TITLE
tests: disable cargo-dist-schema doctests

### DIFF
--- a/cargo-dist-schema/Cargo.toml
+++ b/cargo-dist-schema/Cargo.toml
@@ -13,6 +13,9 @@ exclude = [
   "tests/",
 ]
 
+[lib]
+doctest = false
+
 [dependencies]
 # would be nice to inherit this from workspace but we don't want to pull in
 # a full http client for the schema crate!


### PR DESCRIPTION
We don't run any of these; 17 lines just saying "ignored" is distracting from the test content we actually care about. eg

```
   Doc-tests cargo_dist_schema

running 17 tests
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 110) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 12) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 126) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 138) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 155) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 170) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 184) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 20) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 202) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 212) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 236) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 255) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 26) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 35) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 48) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 61) ... ignored
test cargo-dist-schema/src/macros.rs - macros::declare_strongly_typed_string (line 71) ... ignored
```