### PR TITLE
Have snapshots files be collapsed in GitHub by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,6 @@
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary
+
+# All snapshots files are generated, collapsed them by default in the diff view
+*.snap linguist-generated


### PR DESCRIPTION
See https://github.com/github-linguist/linguist/blob/main/docs/overrides.md

When looking at a PR like https://github.com/axodotdev/cargo-dist/pull/1503/files there's a _lot_ of scrolling involved just for .snap files —  sure we probably should open up a couple and check what's in there, but having 60+ of them opened by default just makes the GitHub UI sluggish and makes the review experience poorer.