### PR TITLE
Add cargo-auditable config option.

### DIFF
--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -313,6 +313,9 @@ pub struct GithubMatrixEntry {
     /// what cache provider to use
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_provider: Option<String>,
+    /// Expression to execute to install cargo-auditable
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install_cargo_auditable: Option<String>,
 }
 
 /// Type of job to run on pull request

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist-schema/src/lib.rs
 expression: json_schema
+snapshot_kind: text
 ---
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -782,6 +783,13 @@ expression: json_schema
         },
         "dist_args": {
           "description": "Arguments to pass to dist",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "install_cargo_auditable": {
+          "description": "Expression to execute to install cargo-auditable",
           "type": [
             "string",
             "null"

--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -313,8 +313,11 @@ impl GithubCiInfo {
             use std::fmt::Write;
             let install_dist =
                 install_dist_for_targets(&targets, &install_dist_sh, &install_dist_ps1);
-            let install_cargo_auditable =
-                install_dist_for_targets(&targets, &install_cargo_auditable_sh, &install_cargo_auditable_ps1);
+            let install_cargo_auditable = install_dist_for_targets(
+                &targets,
+                &install_cargo_auditable_sh,
+                &install_cargo_auditable_ps1,
+            );
             let mut dist_args = String::from("--artifacts=local");
             for target in &targets {
                 write!(dist_args, " --target={target}").unwrap();

--- a/cargo-dist/src/backend/ci/mod.rs
+++ b/cargo-dist/src/backend/ci/mod.rs
@@ -11,7 +11,8 @@ const SELF_DIST_VERSION: &str = env!("CARGO_PKG_VERSION");
 const BASE_DIST_FETCH_URL: &str = "https://github.com/axodotdev/cargo-dist/releases/download";
 
 // NOTE: This is hard-coded to download latest.
-const BASE_CARGO_AUDITABLE_FETCH_LATEST_URL: &str = "https://github.com/rust-secure-code/cargo-auditable/releases/download";
+const BASE_CARGO_AUDITABLE_FETCH_LATEST_URL: &str =
+    "https://github.com/rust-secure-code/cargo-auditable/releases/download";
 
 /// Info about all the enabled CI backends
 #[derive(Debug, Default)]
@@ -72,12 +73,14 @@ fn install_dist_git(version: &Version) -> Option<String> {
 
 /// Get the command to invoke to install cargo-auditable via sh script
 fn install_cargo_auditable_sh_latest() -> String {
-    let installer_url = format!("{BASE_CARGO_AUDITABLE_FETCH_LATEST_URL}/cargo-auditable-installer.sh");
+    let installer_url =
+        format!("{BASE_CARGO_AUDITABLE_FETCH_LATEST_URL}/cargo-auditable-installer.sh");
     format!("curl --proto '=https' --tlsv1.2 -LsSf {installer_url} | sh")
 }
 
 /// Get the command to invoke to install cargo-auditable via ps1 script
 fn install_cargo_auditable_ps1_latest() -> String {
-    let installer_url = format!("{BASE_CARGO_AUDITABLE_FETCH_LATEST_URL}/cargo-auditable-installer.ps1");
+    let installer_url =
+        format!("{BASE_CARGO_AUDITABLE_FETCH_LATEST_URL}/cargo-auditable-installer.ps1");
     format!(r#"powershell -c "irm {installer_url} | iex""#)
 }

--- a/cargo-dist/src/backend/ci/mod.rs
+++ b/cargo-dist/src/backend/ci/mod.rs
@@ -10,6 +10,9 @@ pub mod github;
 const SELF_DIST_VERSION: &str = env!("CARGO_PKG_VERSION");
 const BASE_DIST_FETCH_URL: &str = "https://github.com/axodotdev/cargo-dist/releases/download";
 
+// NOTE: This is hard-coded to download latest.
+const BASE_CARGO_AUDITABLE_FETCH_LATEST_URL: &str = "https://github.com/rust-secure-code/cargo-auditable/releases/download";
+
 /// Info about all the enabled CI backends
 #[derive(Debug, Default)]
 pub struct CiInfo {
@@ -65,4 +68,16 @@ fn install_dist_git(version: &Version) -> Option<String> {
     version.pre.strip_prefix("github-").map(|branch| {
         format!("cargo install --git https://github.com/axodotdev/cargo-dist/ --branch={branch} cargo-dist")
     })
+}
+
+/// Get the command to invoke to install cargo-auditable via sh script
+fn install_cargo_auditable_sh_latest() -> String {
+    let installer_url = format!("{BASE_CARGO_AUDITABLE_FETCH_LATEST_URL}/cargo-auditable-installer.sh");
+    format!("curl --proto '=https' --tlsv1.2 -LsSf {installer_url} | sh")
+}
+
+/// Get the command to invoke to install cargo-auditable via ps1 script
+fn install_cargo_auditable_ps1_latest() -> String {
+    let installer_url = format!("{BASE_CARGO_AUDITABLE_FETCH_LATEST_URL}/cargo-auditable-installer.ps1");
+    format!(r#"powershell -c "irm {installer_url} | iex""#)
 }

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -312,7 +312,7 @@ mod tests {
         };
         let target = CargoBuildStep {
             expected_binaries: vec![],
-            features: features,
+            features,
             package: CargoTargetPackages::Workspace,
             profile: "release".to_string(),
             rustflags: "--this-rust-flag-gets-ignored".to_string(),
@@ -340,7 +340,7 @@ mod tests {
         };
         let target = CargoBuildStep {
             expected_binaries: vec![],
-            features: features,
+            features,
             package: CargoTargetPackages::Workspace,
             profile: "release".to_string(),
             rustflags: "--this-rust-flag-gets-ignored".to_string(),

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -181,6 +181,12 @@ pub fn build_cargo_target(
     }
 
     let mut command = Cmd::new(&cargo.cmd, "build your app with Cargo");
+
+    if dist_graph.config.builds.cargo.cargo_auditable {
+        eprint!(" auditable");
+        command.arg("auditable");
+    }
+
     command
         .arg("build")
         .arg("--profile")

--- a/cargo-dist/src/config/v0.rs
+++ b/cargo-dist/src/config/v0.rs
@@ -442,6 +442,11 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub minimum_glibc_version: Option<LibcVersion>,
+
+    /// Whether to embed dependency information in the executable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub cargo_auditable: Option<bool>,
 }
 
 impl DistMetadata {
@@ -511,6 +516,7 @@ impl DistMetadata {
             github_build_setup: _,
             mac_pkg_config: _,
             minimum_glibc_version: _,
+            cargo_auditable: _,
         } = self;
         if let Some(include) = include {
             for include in include {
@@ -608,6 +614,7 @@ impl DistMetadata {
             github_build_setup,
             mac_pkg_config,
             minimum_glibc_version,
+            cargo_auditable,
         } = self;
 
         // Check for global settings on local packages
@@ -794,6 +801,9 @@ impl DistMetadata {
         }
         if minimum_glibc_version.is_none() {
             minimum_glibc_version.clone_from(&workspace_config.minimum_glibc_version);
+        }
+        if cargo_auditable.is_none() {
+            cargo_auditable.clone_from(&workspace_config.cargo_auditable);
         }
 
         // This was historically implemented as extend, but I'm not convinced the

--- a/cargo-dist/src/config/v0_to_v1.rs
+++ b/cargo-dist/src/config/v0_to_v1.rs
@@ -83,6 +83,7 @@ impl DistMetadata {
             install_libraries,
             github_build_setup,
             minimum_glibc_version,
+            cargo_auditable,
         } = self.clone();
 
         // Archives
@@ -114,7 +115,8 @@ impl DistMetadata {
             || precise_builds.is_some()
             || features.is_some()
             || default_features.is_some()
-            || all_features.is_some();
+            || all_features.is_some()
+            || cargo_auditable.is_some();
         let cargo_layer = needs_cargo_build_layer.then_some(BoolOr::Val(CargoBuildLayer {
             common: CommonBuildLayer::default(),
             rust_toolchain_version,
@@ -123,6 +125,7 @@ impl DistMetadata {
             default_features,
             all_features,
             msvc_crt_static,
+            cargo_auditable,
         }));
         let needs_build_layer = cargo_layer.is_some()
             || system_dependencies.is_some()

--- a/cargo-dist/src/config/v1/builds/cargo.rs
+++ b/cargo-dist/src/config/v1/builds/cargo.rs
@@ -15,6 +15,9 @@ pub struct WorkspaceCargoBuildConfig {
 
     /// Build only the required packages, and individually
     pub precise_builds: Option<bool>,
+
+    /// Whether to embed dependency information in the executable.
+    pub cargo_auditable: bool,
 }
 
 /// cargo build config for a specific app
@@ -33,6 +36,10 @@ pub struct AppCargoBuildConfig {
     ///
     /// (defaults to false)
     pub all_features: bool,
+    /// Whether to embed dependency information in the executable.
+    ///
+    /// (defaults to false)
+    pub cargo_auditable: bool,
 }
 
 /// cargo build config (raw)
@@ -95,6 +102,11 @@ pub struct CargoBuildLayer {
     /// (defaults to false)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub all_features: Option<bool>,
+    /// Whether to embed dependency information in the executable.
+    ///
+    /// (defaults to false)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cargo_auditable: Option<bool>,
 }
 
 impl WorkspaceCargoBuildConfig {
@@ -107,6 +119,7 @@ impl WorkspaceCargoBuildConfig {
             rust_toolchain_version: None,
             precise_builds: None,
             msvc_crt_static: true,
+            cargo_auditable: false,
         }
     }
 }
@@ -123,6 +136,7 @@ impl AppCargoBuildConfig {
             features: vec![],
             default_features: true,
             all_features: false,
+            cargo_auditable: false,
         }
     }
 }
@@ -134,6 +148,7 @@ impl ApplyLayer for WorkspaceCargoBuildConfig {
         Self::Layer {
             rust_toolchain_version,
             precise_builds,
+            cargo_auditable,
             // local-only
             common: _,
             msvc_crt_static: _,
@@ -145,6 +160,7 @@ impl ApplyLayer for WorkspaceCargoBuildConfig {
         self.rust_toolchain_version
             .apply_opt(rust_toolchain_version);
         self.precise_builds.apply_opt(precise_builds);
+        self.cargo_auditable.apply_val(cargo_auditable);
     }
 }
 impl ApplyLayer for AppCargoBuildConfig {
@@ -156,6 +172,7 @@ impl ApplyLayer for AppCargoBuildConfig {
             features,
             default_features,
             all_features,
+            cargo_auditable,
 
             // global-only
             rust_toolchain_version: _,
@@ -167,6 +184,7 @@ impl ApplyLayer for AppCargoBuildConfig {
         self.features.apply_val(features);
         self.default_features.apply_val(default_features);
         self.all_features.apply_val(all_features);
+        self.cargo_auditable.apply_val(cargo_auditable);
     }
 }
 impl ApplyLayer for CargoBuildLayer {
@@ -181,6 +199,7 @@ impl ApplyLayer for CargoBuildLayer {
             features,
             default_features,
             all_features,
+            cargo_auditable,
         }: Self::Layer,
     ) {
         self.common.apply_layer(common);
@@ -191,6 +210,7 @@ impl ApplyLayer for CargoBuildLayer {
         self.features.apply_opt(features);
         self.default_features.apply_opt(default_features);
         self.all_features.apply_opt(all_features);
+        self.cargo_auditable.apply_opt(cargo_auditable);
     }
 }
 

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -420,6 +420,7 @@ fn get_new_dist_metadata(
             github_build_setup: None,
             mac_pkg_config: None,
             minimum_glibc_version: None,
+            cargo_auditable: None,
         }
     };
 
@@ -894,6 +895,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         install_libraries,
         mac_pkg_config,
         minimum_glibc_version,
+        cargo_auditable,
         // These settings are complex enough that we don't support editing them in init
         extra_artifacts: _,
         github_custom_runners: _,
@@ -1299,6 +1301,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "minimum-glibc-version",
         "# The minimum glibc version supported by the package (overrides auto-detection)\n",
         minimum_glibc_version.as_ref().map(|v| v.to_string()),
+    );
+
+    apply_optional_value(
+        table,
+        "cargo-auditable",
+        "# Whether to embed dependency information using cargo-auditable\n",
+        *cargo_auditable,
     );
 
     // Finalize the table

--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -133,6 +133,13 @@ jobs:
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
+      {{%- if need_cargo_auditable %}}
+      - name: Install cargo-auditable
+        # we specify bash to get pipefail; it guards against the `curl` command
+        # failing. otherwise `sh` won't catch that `curl` return non-0
+        run: {{{ install_cargo_auditable_sh }}}
+        shell: bash
+      {{%- endif %}}
       # sure would be cool if github gave us proper conditionals...
       # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
       # functionality based on whether this is a pull_request, and whether it's from a fork.

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -44,6 +44,7 @@ unix-archive = ".tar.gz"
 windows-archive = ".tar.gz"
 npm-scope ="@axodotdev"
 minimum-glibc-version = "2.18"
+cargo-auditable = true
 
 [package.metadata.wix]
 upgrade-guid = "B36177BE-EA4D-44FB-B05C-EDDABDAA95CA"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ akaikatana-repack-installer.sh ================
 #!/bin/sh
@@ -2099,7 +2100,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2108,7 +2110,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2117,7 +2120,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2126,7 +2130,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ akaikatana-repack-installer.sh ================
 #!/bin/sh
@@ -1500,7 +1501,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -1509,7 +1511,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -1518,7 +1521,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -1528,7 +1532,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
             "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ akaikatana-repack-installer.sh ================
 #!/bin/sh
@@ -2129,7 +2130,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2138,7 +2140,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2147,7 +2150,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2156,7 +2160,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ akaikatana-repack-installer.sh ================
 #!/bin/sh
@@ -2155,7 +2156,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2164,7 +2166,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2173,7 +2176,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2182,7 +2186,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ akaikatana-repack-installer.sh ================
 #!/bin/sh
@@ -2139,7 +2140,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2148,7 +2150,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2157,7 +2160,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2166,7 +2170,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3671,7 +3672,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3680,7 +3682,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3689,7 +3692,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3698,7 +3702,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3664,7 +3665,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3673,7 +3675,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3682,7 +3685,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3691,7 +3695,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3712,7 +3713,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3721,7 +3723,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3730,7 +3733,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3739,7 +3743,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3714,7 +3715,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3723,7 +3725,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3732,7 +3735,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3741,7 +3745,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3795,6 +3795,11 @@ jobs:
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
+      - name: Install cargo-auditable
+        # we specify bash to get pipefail; it guards against the `curl` command
+        # failing. otherwise `sh` won't catch that `curl` return non-0
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
+        shell: bash
       # sure would be cool if github gave us proper conditionals...
       # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
       # functionality based on whether this is a pull_request, and whether it's from a fork.

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3681,7 +3681,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3690,7 +3691,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3699,7 +3701,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3708,7 +3711,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3783,7 +3784,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3792,7 +3794,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3801,7 +3804,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3810,7 +3814,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3680,7 +3681,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3689,7 +3691,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3698,7 +3701,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3707,7 +3711,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -1481,7 +1482,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -1490,7 +1492,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -1499,7 +1502,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -1508,7 +1512,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -1481,7 +1482,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -1490,7 +1492,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -1499,7 +1502,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -1508,7 +1512,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -1481,7 +1482,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -1490,7 +1492,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -1499,7 +1502,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -1508,7 +1512,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -1481,7 +1482,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -1490,7 +1492,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -1499,7 +1502,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -1508,7 +1512,8 @@ download_binary_and_run_installer "$@" || exit 1
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotl-brew.rb ================
 class AxolotlBrew < Formula
@@ -336,7 +337,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -345,7 +347,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -354,7 +357,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -363,7 +367,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -258,7 +259,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "buildjet-8vcpu-ubuntu-2204-arm",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
-            "cache_provider": "buildjet"
+            "cache_provider": "buildjet",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -268,7 +270,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
             "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
-            "cache_provider": "buildjet"
+            "cache_provider": "buildjet",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -277,7 +280,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "buildjet-8vcpu-ubuntu-2204",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "buildjet"
+            "cache_provider": "buildjet",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -287,7 +291,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
             "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
-            "cache_provider": "buildjet"
+            "cache_provider": "buildjet",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3668,7 +3669,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-n
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3677,7 +3679,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-n
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3686,7 +3689,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-n
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3695,7 +3699,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-n
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -258,7 +259,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -267,7 +269,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -276,7 +279,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -285,7 +289,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -266,7 +267,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -275,7 +277,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -284,7 +287,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -293,7 +297,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -259,7 +260,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -268,7 +270,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -277,7 +280,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -286,7 +290,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3602,7 +3603,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3611,7 +3613,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3620,7 +3623,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3629,7 +3633,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-js-installer.sh ================
 #!/bin/sh
@@ -4114,7 +4115,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -4123,7 +4125,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -4132,7 +4135,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -4141,7 +4145,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3681,7 +3682,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "packages_install": "cat << EOF >Brewfile\ncask \"homebrew/cask/macfuse\"\nbrew \"libcue\"\nEOF\n\nbrew bundle install",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3691,7 +3693,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "packages_install": "cat << EOF >Brewfile\ncask \"homebrew/cask/macfuse\"\nbrew \"libcue\"\nEOF\n\nbrew bundle install",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3700,7 +3703,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3709,7 +3713,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2995,7 +2996,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3004,7 +3006,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3013,7 +3016,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3023,7 +3027,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
             "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2930,7 +2931,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2939,7 +2941,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2949,7 +2952,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
             "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3602,7 +3603,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3611,7 +3613,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3620,7 +3623,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3629,7 +3633,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -258,7 +259,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -267,7 +269,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -276,7 +279,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -285,7 +289,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -258,7 +259,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -267,7 +269,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -276,7 +279,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -285,7 +289,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3718,7 +3719,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3727,7 +3729,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3736,7 +3739,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3745,7 +3749,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2092,7 +2093,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2101,7 +2103,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2110,7 +2113,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2119,7 +2123,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2092,7 +2093,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2101,7 +2103,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2110,7 +2113,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2119,7 +2123,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -258,7 +259,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -267,7 +269,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -276,7 +279,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -285,7 +289,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3720,7 +3721,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3729,7 +3731,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3738,7 +3741,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3747,7 +3751,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3602,7 +3603,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3611,7 +3613,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3620,7 +3623,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3629,7 +3633,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3602,7 +3603,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3611,7 +3613,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3620,7 +3623,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3629,7 +3633,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3602,7 +3603,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3611,7 +3613,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3620,7 +3623,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3629,7 +3633,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3602,7 +3603,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3611,7 +3613,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3620,7 +3623,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3629,7 +3633,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -3602,7 +3603,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3611,7 +3613,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -3620,7 +3623,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -3629,7 +3633,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2092,7 +2093,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2101,7 +2103,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2110,7 +2113,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2119,7 +2123,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2068,7 +2069,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2077,7 +2079,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2086,7 +2089,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2095,7 +2099,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2068,7 +2069,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2077,7 +2079,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2086,7 +2089,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2095,7 +2099,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2068,7 +2069,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2077,7 +2079,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2086,7 +2089,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2095,7 +2099,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2068,7 +2069,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2077,7 +2079,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2086,7 +2089,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2095,7 +2099,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2091,7 +2092,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2100,7 +2102,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2109,7 +2112,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2118,7 +2122,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2068,7 +2069,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2077,7 +2079,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2086,7 +2089,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2095,7 +2099,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2068,7 +2069,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2077,7 +2079,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2086,7 +2089,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2095,7 +2099,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2068,7 +2069,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2077,7 +2079,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2086,7 +2089,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2095,7 +2099,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2068,7 +2069,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2077,7 +2079,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2086,7 +2089,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2095,7 +2099,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -2091,7 +2092,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2100,7 +2102,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -2109,7 +2112,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -2118,7 +2122,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/cli-tests.rs
 expression: format_outputs(&output)
+snapshot_kind: text
 ---
 stdout:
 {
@@ -527,7 +528,8 @@ stdout:
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -536,7 +538,8 @@ stdout:
             "runner": "buildjet-8vcpu-ubuntu-2204-arm",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
-            "cache_provider": "buildjet"
+            "cache_provider": "buildjet",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -546,7 +549,8 @@ stdout:
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
             "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
-            "cache_provider": "buildjet"
+            "cache_provider": "buildjet",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -555,7 +559,8 @@ stdout:
             "runner": "macos-13",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -564,7 +569,8 @@ stdout:
             "runner": "windows-2019",
             "install_dist": "powershell -c \"irm https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.ps1 | iex\"",
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.ps1 | iex\""
           },
           {
             "targets": [
@@ -573,7 +579,8 @@ stdout:
             "runner": "ubuntu-20.04",
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           },
           {
             "targets": [
@@ -583,7 +590,8 @@ stdout:
             "install_dist": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh",
             "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
             "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
-            "cache_provider": "github"
+            "cache_provider": "github",
+            "install_cargo_auditable": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/download/cargo-auditable-installer.sh | sh"
           }
         ]
       },


### PR DESCRIPTION
Moved to #1528 because the slash in the `duckinator/auditable-builds` branch name is incompatible with testing dist from a GitHub branch.

----

deferred:
- local auto-installation of cargo-auditable (moved to #1527)
- throw error when using cargo-auditable=true with non-rust projects (moved to #1526)

complete:
- [x] use `cargo auditable build` instead of `cargo build` if `cargo-auditable=true`
- [x] install cargo-auditable in workflows if `cargo-auditable=true`
- [x] tests for both of those
- [x] real-world local test
- [ ] real-world CI test