### PR TITLE
Add cross-compilation support via cargo-zigbuild and cargo-xwin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,6 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
-    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -122,13 +121,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Install Rust non-interactively if not already installed
-        if: ${{ matrix.container }}
-        run: |
-          if ! command -v cargo > /dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -121,6 +122,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ cargo-dist/wix
 oranda-debug.log
 /public
 cargo-dist/public
+
+# Samply: <https://crates.io/crates/samply>
+/profile.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -2829,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.14"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-spec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "0.25.2-prerelease.3"
+version = "0.26.0-prerelease.1"
 dependencies = [
  "axoasset",
  "axoprocess",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.25.2-prerelease.3"
+version = "0.26.0-prerelease.1"
 dependencies = [
  "axoasset",
  "axocli",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.25.2-prerelease.3"
+version = "0.26.0-prerelease.1"
 dependencies = [
  "camino",
  "gazenot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
 homepage = "https://opensource.axo.dev/cargo-dist/"
-version = "0.25.2-prerelease.3"
+version = "0.26.0-prerelease.1"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!
-cargo-dist-schema = { version = "=0.25.2-prerelease.3", path = "cargo-dist-schema" }
-axoproject = { version = "=0.25.2-prerelease.3", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
+cargo-dist-schema = { version = "=0.26.0-prerelease.1", path = "cargo-dist-schema" }
+axoproject = { version = "=0.26.0-prerelease.1", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
 
 # first-party deps
 axocli = { version = "0.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ lazy_static = "1.5.0"
 current_platform = "0.2.0"
 color-backtrace = "0.6.1"
 backtrace = "0.3.74"
+target-lexicon = "0.12.16"
 
 [workspace.metadata.release]
 shared-version = true

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 
-build-all-plaforms:
+build-all-platforms:
   #!/bin/bash -eux
   export AXOASSET_XZ_LEVEL=1
   cargo build
@@ -74,7 +74,7 @@ patch-ps1-installer:
 
 dump:
   #!/bin/bash -eux
-  just build-all-plaforms
+  just build-all-platforms
   just patch-sh-installer
   just patch-ps1-installer
   mc mirror --overwrite ./target/distrib ${DIST_TARGET:-bearcove/dump/dist-cross}

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,80 @@
+
+build-all-plaforms:
+  #!/bin/bash -eux
+  export AXOASSET_XZ_LEVEL=1
+  cargo build
+  ./target/debug/dist init --yes
+  ./target/debug/dist build --artifacts all --target aarch64-apple-darwinx,x86_64-apple-darwin,x86_64-pc-windows-msvc,x86_64-unknown-linux-musl
+
+patch-sh-installer:
+  #!/usr/bin/env node
+  const fs = require('fs');
+  const installerUrl = process.env.INSTALLER_DOWNLOAD_URL || 'https://dl.bearcove.cloud/dump/dist-cross';
+  const installerPath = './target/distrib/cargo-dist-installer.sh';
+
+  const content = fs.readFileSync(installerPath, 'utf8');
+  const lines = content.split('\n');
+  let modified = false;
+
+  const newLines = [];
+  for (const line of lines) {
+    if (line.includes('export INSTALLER_DOWNLOAD_URL')) {
+      continue;
+    }
+    if (line.includes('set -u') && !modified) {
+      modified = true;
+      newLines.push(line);
+      newLines.push(`export INSTALLER_DOWNLOAD_URL=${installerUrl} # patched by Justfile in dist repo, using dist_url_override feature`);
+      continue;
+    }
+    newLines.push(line);
+  }
+
+  fs.writeFileSync(installerPath, newLines.join('\n'));
+
+  if (modified) {
+    console.log('\x1b[32m%s\x1b[0m', `✅ ${installerPath} patched successfully!`);
+    console.log('\x1b[36m%s\x1b[0m', `🔗 Pointing to: ${installerUrl}`);
+  } else {
+    console.log('\x1b[31m%s\x1b[0m', '❌ Error: Could not find line with "set -u" in installer script');
+  }
+
+patch-ps1-installer:
+  #!/usr/bin/env node
+  const fs = require('fs');
+  const installerUrl = process.env.INSTALLER_DOWNLOAD_URL || 'https://dl.bearcove.cloud/dump/dist-cross';
+  const installerPath = './target/distrib/cargo-dist-installer.ps1';
+
+  const content = fs.readFileSync(installerPath, 'utf8');
+  const lines = content.split('\n');
+  let modified = false;
+
+  const newLines = [];
+  for (const line of lines) {
+    if (line.includes('$env:INSTALLER_DOWNLOAD_URL = ')) {
+      continue;
+    }
+    if (line.includes('$app_name = ') && !modified) {
+      modified = true;
+      newLines.push(`$env:INSTALLER_DOWNLOAD_URL = "${installerUrl}" # patched by Justfile in dist repo, using dist_url_override feature`);
+      newLines.push(line);
+      continue;
+    }
+    newLines.push(line);
+  }
+
+  fs.writeFileSync(installerPath, newLines.join('\n'));
+
+  if (modified) {
+    console.log('\x1b[32m%s\x1b[0m', `✅ ${installerPath} patched successfully!`);
+    console.log('\x1b[36m%s\x1b[0m', `🔗 Pointing to: ${installerUrl}`);
+  } else {
+    console.log('\x1b[31m%s\x1b[0m', '❌ Error: Could not find line with "cargo-dist = " in installer script');
+  }
+
+dump:
+  #!/bin/bash -eux
+  just build-all-plaforms
+  just patch-sh-installer
+  just patch-ps1-installer
+  mc mirror --overwrite ./target/distrib ${DIST_TARGET:-bearcove/dump/dist-cross}

--- a/book/src/ci/customizing.md
+++ b/book/src/ci/customizing.md
@@ -232,7 +232,7 @@ container = { image = "quay.io/pypa/manylinux_2_28_x86_64", host = "x86_64-unkno
 container = { image = "quay.io/pypa/manylinux_2_28_x86_64", host = "x86_64-unknown-linux-musl" }
 ```
 
-Note that here, the host triple for those container images is overriden to be `x86_64-unknown-linux-musl`, because dist itself (which must run in the container) might be using a too-recent version of glibc.
+Note that here, the host triple for those container images is overridden to be `x86_64-unknown-linux-musl`, because dist itself (which must run in the container) might be using a too-recent version of glibc.
 
 Because of dist's cross-compilation support, if you have both `cargo-zigbuild` and `cargo-xwin`
 installed on a macOS machine, you can build pretty much every target dist supports, by running

--- a/cargo-dist-schema/Cargo.toml
+++ b/cargo-dist-schema/Cargo.toml
@@ -26,7 +26,7 @@ schemars.workspace = true
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-
+target-lexicon.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -403,7 +403,7 @@ impl GithubRunnerConfig {
         }
     }
 
-    /// cf. [`Self::GithubRunnerConfig`], but parsed
+    /// cf. [`Self::real_triple_name`], but parsed
     pub fn real_triple(&self) -> Triple {
         self.real_triple_name().parse().unwrap()
     }

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -9,19 +9,26 @@
 //! The root type of the schema is [`DistManifest`][].
 
 pub mod macros;
+pub use target_lexicon;
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, str::FromStr};
 
 use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
+use target_lexicon::Triple;
 
 declare_strongly_typed_string! {
-    /// A rust target-triple (e.g. "x86_64-pc-windows-msvc")
-    pub struct TargetTriple => &TargetTripleRef;
+    /// A rustc-like target triple/tuple (e.g. "x86_64-pc-windows-msvc")
+    pub struct TripleName => &TripleNameRef;
 }
 
-impl TargetTripleRef {
+impl TripleNameRef {
+    /// Parse as a [`Triple`]
+    pub fn parse(&self) -> Result<Triple, <Triple as FromStr>::Err> {
+        Triple::from_str(self.as_str())
+    }
+
     /// Returns true if this target triple contains the word "musl"
     pub fn is_musl(&self) -> bool {
         self.0.contains("musl")
@@ -70,16 +77,47 @@ impl TargetTripleRef {
         self.0.contains("windows-msvc")
     }
 }
-
 declare_strongly_typed_string! {
     /// The name of a Github Actions Runner, like `ubuntu-20.04` or `macos-13`
     pub struct GithubRunner => &GithubRunnerRef;
+
+    /// A container image, like `quay.io/pypa/manylinux_2_28_x86_64`
+    pub struct ContainerImage => &ContainerImageRef;
 }
+
+/// Github runners configuration (which github image/container should be used
+/// to build which target).
+pub type GithubRunners = BTreeMap<TripleName, GithubRunnerConfig>;
 
 impl GithubRunnerRef {
     /// Does the runner name contain the word "buildjet"?
     pub fn is_buildjet(&self) -> bool {
         self.as_str().contains("buildjet")
+    }
+}
+
+/// A value or just a string
+///
+/// This allows us to have a simple string-based version of a config while still
+/// allowing for a more advanced version to exist.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(untagged)]
+pub enum StringLikeOr<S, T> {
+    /// They gave the simple string-like value (see `declare_strongly_typed_string!`)
+    StringLike(S),
+    /// They gave a more interesting value
+    Val(T),
+}
+
+impl<S, T> StringLikeOr<S, T> {
+    /// Constructs a new `StringLikeOr` from the string-like value `s`
+    pub fn from_s(s: S) -> Self {
+        Self::StringLike(s)
+    }
+
+    /// Constructs a new `StringLikeOr` from the more interesting value `t`
+    pub fn from_t(t: T) -> Self {
+        Self::Val(t)
     }
 }
 
@@ -249,7 +287,7 @@ pub struct AssetInfo {
     /// * length 0: not a meaningful question, maybe some static file
     /// * length 1: typical of binaries
     /// * length 2+: some kind of universal binary
-    pub target_triples: Vec<TargetTriple>,
+    pub target_triples: Vec<TripleName>,
     /// the linkage of this Asset
     pub linkage: Option<Linkage>,
 }
@@ -284,7 +322,7 @@ pub struct GithubMatrix {
     /// define each task manually rather than doing cross-product stuff
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub include: Vec<GithubMatrixEntry>,
+    pub include: Vec<GithubLocalJobConfig>,
 }
 
 impl GithubMatrix {
@@ -296,29 +334,149 @@ impl GithubMatrix {
     }
 }
 
-/// Entry for a github matrix
+declare_strongly_typed_string! {
+    /// A bit of shell script to install brew/apt/chocolatey/etc. packages
+    pub struct PackageInstallScript => &PackageInstallScriptRef;
+}
+
+/// The version of `GithubRunnerConfig` that's deserialized from the config file: it
+/// has optional fields that are computed later.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct GithubMatrixEntry {
-    /// Targets to build for
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub targets: Option<Vec<TargetTriple>>,
-    /// Github Runner to user
-    #[serde(skip_serializing_if = "Option::is_none")]
+pub struct GithubRunnerConfigInput {
+    /// GHA's `runs-on` key: Github Runner image to use, see <https://github.com/actions/runner-images>
+    /// and <https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job>
+    ///
+    /// This is not necessarily a well-known runner, it could be something self-hosted, it
+    /// could be from BuildJet, Namespace, etc.
+    ///
+    /// If not specified, `container` has to be set.
     pub runner: Option<GithubRunner>,
+
+    /// Host triple of the runner (well-known, custom, or best guess).
+    /// If the runner is one of GitHub's official runner images, the platform
+    /// is hardcoded. If it's custom, then we have a `target_triple => runner` in the config
+    pub host: Option<TripleName>,
+
+    /// Container image to run the job in, using GitHub's builtin
+    /// container support, see <https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container>
+    ///
+    /// This doesn't allow mounting volumes, or anything, because we're only able
+    /// to set the `container` key to something stringy
+    ///
+    /// If not specified, `runner` has to be set.
+    pub container: Option<StringLikeOr<ContainerImage, ContainerConfigInput>>,
+}
+
+/// GitHub config that's common between different kinds of jobs (global, local)
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+pub struct GithubRunnerConfig {
+    /// GHA's `runs-on` key: Github Runner image to use, see <https://github.com/actions/runner-images>
+    /// and <https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job>
+    ///
+    /// This is not necessarily a well-known runner, it could be something self-hosted, it
+    /// could be from BuildJet, Namespace, etc.
+    pub runner: GithubRunner,
+
+    /// Host triple of the runner (well-known, custom, or best guess).
+    /// If the runner is one of GitHub's official runner images, the platform
+    /// is hardcoded. If it's custom, then we have a `target_triple => runner` in the config
+    pub host: TripleName,
+
+    /// Container image to run the job in, using GitHub's builtin
+    /// container support, see <https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container>
+    ///
+    /// This doesn't allow mounting volumes, or anything, because we're only able
+    /// to set the `container` key to something stringy
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container: Option<ContainerConfig>,
+}
+
+impl GithubRunnerConfig {
+    /// If the container runs through a container, that container might have a different
+    /// architecture than the outer VM — this returns the container's triple if any,
+    /// and falls back to the "machine"'s triple if not.
+    pub fn real_triple_name(&self) -> &TripleNameRef {
+        if let Some(container) = &self.container {
+            &container.host
+        } else {
+            &self.host
+        }
+    }
+
+    /// cf. [`Self::GithubRunnerConfig`], but parsed
+    pub fn real_triple(&self) -> Triple {
+        self.real_triple_name().parse().unwrap()
+    }
+}
+
+/// GitHub config that's common between different kinds of jobs (global, local)
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ContainerConfigInput {
+    /// The container image to run, something like `ubuntu:20.04` or
+    /// `quay.io/pypa/manylinux_2_28_x86_64`
+    pub image: ContainerImage,
+
+    /// The host triple of the container, something like `x86_64-unknown-linux-gnu`
+    /// or `aarch64-unknown-linux-musl` or whatever.
+    pub host: Option<TripleName>,
+}
+
+/// GitHub config that's common between different kinds of jobs (global, local)
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ContainerConfig {
+    /// The container image to run, something like `ubuntu:20.04` or
+    /// `quay.io/pypa/manylinux_2_28_x86_64`
+    pub image: ContainerImage,
+
+    /// The host triple of the container, something like `x86_64-unknown-linux-gnu`
+    /// or `aarch64-unknown-linux-musl` or whatever.
+    pub host: TripleName,
+}
+
+/// Used in `github/release.yml.j2` to template out "global" build jobs
+/// (plan, global assets, announce, etc)
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GithubGlobalJobConfig {
+    /// Where to run this job?
+    #[serde(flatten)]
+    pub runner: GithubRunnerConfig,
+
     /// Expression to execute to install dist
     pub install_dist: GhaRunStep,
-    /// Expression to execute to install cargo-auditable
-    pub install_cargo_auditable: GhaRunStep,
+
+    /// Arguments to pass to dist
+    pub dist_args: String,
+
     /// Expression to execute to install cargo-cyclonedx
     #[serde(skip_serializing_if = "Option::is_none")]
     pub install_cargo_cyclonedx: Option<GhaRunStep>,
+}
+
+/// Used in `github/release.yml.j2` to template out "local" build jobs
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GithubLocalJobConfig {
+    /// Where to run this job?
+    #[serde(flatten)]
+    pub runner: GithubRunnerConfig,
+
+    /// Expression to execute to install dist
+    pub install_dist: GhaRunStep,
+
     /// Arguments to pass to dist
+    pub dist_args: String,
+
+    /// Target triples to build for
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dist_args: Option<String>,
+    pub targets: Option<Vec<TripleName>>,
+
+    /// Expression to execute to install cargo-auditable
+    pub install_cargo_auditable: GhaRunStep,
+
     /// Command to run to install dependencies
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub packages_install: Option<String>,
-    /// what cache provider to use
+    pub packages_install: Option<PackageInstallScript>,
+
+    /// What cache provider to use
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_provider: Option<String>,
 }
@@ -475,7 +633,7 @@ pub struct Artifact {
     /// The target triple of the bundle
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
-    pub target_triples: Vec<TargetTriple>,
+    pub target_triples: Vec<TripleName>,
     /// The location of the artifact on the local system
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
@@ -911,6 +1069,23 @@ pub enum PackageManager {
     Apt,
 }
 
+declare_strongly_typed_string! {
+    /// A homebrew package name, cf. <https://formulae.brew.sh/>
+    pub struct HomebrewPackageName => &HomebrewPackageNameRef;
+
+    /// An APT package name, cf. <https://en.wikipedia.org/wiki/APT_(software)>
+    pub struct AptPackageName => &AptPackageNameRef;
+
+    /// A chocolatey package name, cf. <https://community.chocolatey.org/packages>
+    pub struct ChocolateyPackageName => &ChocolateyPackageNameRef;
+
+    /// A pip package name
+    pub struct PipPackageName => &PipPackageNameRef;
+
+    /// A package version
+    pub struct PackageVersion => &PackageVersionRef;
+}
+
 /// Represents a dynamic library located somewhere on the system
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Library {
@@ -921,6 +1096,9 @@ pub struct Library {
     pub source: Option<String>,
     /// Which package manager provided this library
     pub package_manager: Option<PackageManager>,
+    // FIXME: `HomebrewPackageName` and others are now strongly-typed, which makes having this
+    // source/packagemanager thingy problematic. Maybe we could just have an enum, with Apt,
+    // Homebrew, and Chocolatey variants? That would change the schema though.
 }
 
 impl Linkage {
@@ -939,31 +1117,6 @@ impl Linkage {
             .extend(public_unmanaged.iter().cloned());
         self.other.extend(other.iter().cloned());
         self.frameworks.extend(frameworks.iter().cloned());
-    }
-
-    /// Returns a flat list of packages that come from the specific package manager
-    pub fn packages_from(&self, package_manager: PackageManager) -> Vec<String> {
-        let mut packages = vec![];
-        packages.extend(
-            self.system
-                .iter()
-                .filter(|l| l.package_manager == Some(package_manager))
-                .filter_map(|l| l.source.clone()),
-        );
-        packages.extend(
-            self.homebrew
-                .iter()
-                .filter(|l| l.package_manager == Some(package_manager))
-                .filter_map(|l| l.source.clone()),
-        );
-        packages.extend(
-            self.other
-                .iter()
-                .filter(|l| l.package_manager == Some(package_manager))
-                .filter_map(|l| l.source.clone()),
-        );
-
-        packages
     }
 }
 

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -419,6 +419,10 @@ pub struct ContainerConfigInput {
     /// The host triple of the container, something like `x86_64-unknown-linux-gnu`
     /// or `aarch64-unknown-linux-musl` or whatever.
     pub host: Option<TripleName>,
+
+    /// The package manager to use within the container, like `apt`.
+    #[serde(rename = "package-manager")]
+    pub package_manager: Option<PackageManager>,
 }
 
 /// GitHub config that's common between different kinds of jobs (global, local)
@@ -431,6 +435,9 @@ pub struct ContainerConfig {
     /// The host triple of the container, something like `x86_64-unknown-linux-gnu`
     /// or `aarch64-unknown-linux-musl` or whatever.
     pub host: TripleName,
+
+    /// The package manager to use within the container, like `apt`.
+    pub package_manager: Option<PackageManager>,
 }
 
 /// Used in `github/release.yml.j2` to template out "global" build jobs
@@ -1062,6 +1069,7 @@ pub struct Linkage {
 #[derive(
     Clone, Copy, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord,
 )]
+#[serde(rename_all = "lowercase")]
 pub enum PackageManager {
     /// Homebrew (usually for Mac)
     Homebrew,

--- a/cargo-dist-schema/src/macros.rs
+++ b/cargo-dist-schema/src/macros.rs
@@ -110,7 +110,7 @@
 /// ```rust,ignore
 /// declare_strongly_typed_string! {
 ///   /// TargetTriple docs go here
-///   pub const TargetTriple => &TargetTripleRef;
+///   pub const TargetTriple => &TripleNameRef;
 ///
 ///   /// GithubRunner docs go here
 ///   pub const GithubRunner => &GithubRunner;
@@ -133,14 +133,14 @@
 /// }
 /// ```
 ///
-/// If you're only reading from it, then maybe you can take a `&TargetTripleRef` instead:
+/// If you're only reading from it, then maybe you can take a `&TripleNameRef` instead:
 ///
 /// ```rust,ignore
 /// fn is_target_triple_funny(target: &str) -> bool {
 ///   target.contains("loong") // let's be honest: it's kinda funny
 /// }
 /// // 👇 becomes
-/// fn is_target_triple_funny(target: &TargetTripleRef) -> bool {
+/// fn is_target_triple_funny(target: &TripleNameRef) -> bool {
 ///   target.as_str().contains("loong")
 /// }
 /// ```
@@ -173,8 +173,8 @@
 /// let target = TargetTriple::new("x86_64-unknown-linux-gnu");
 /// ```
 ///
-/// What you're getting here is a `&'static TargetTripleRef` — no allocations
-/// involved, and if your functions take `&TargetTripleRef`, then you're already
+/// What you're getting here is a `&'static TripleNameRef` — no allocations
+/// involved, and if your functions take `&TripleNameRef`, then you're already
 /// all set.
 ///
 /// ### Treating it as a string anyway
@@ -234,14 +234,14 @@
 /// This will not work:
 ///
 /// ```rust,ignore
-/// fn i_take_a_slice(targets: &[TargetTripleRef]) { todo!(targets) }
+/// fn i_take_a_slice(targets: &[TripleNameRef]) { todo!(targets) }
 ///
 /// let targets = vec![TargetTriple::new("x86_64-unknown-linux-gnu")];
 /// i_take_a_slice(&targets);
 /// ```
 ///
 /// Because you have a `&Vec<TargetTriple>`, and `Deref` only takes you
-/// as far as `&[TargetTriple]`, but not `&[TargetTripleRef]`. If you
+/// as far as `&[TargetTriple]`, but not `&[TripleNameRef]`. If you
 /// encounter that case, it's probably fine to just take a `&[TargetTriple]`.
 ///
 /// Note that you would have the same problem with `Vec<String>`: it would give
@@ -253,7 +253,7 @@
 /// This will not work:
 ///
 /// ```rust,ignore
-/// fn match_on_target(target: &TargetTripleRef) => &str {
+/// fn match_on_target(target: &TripleNameRef) => &str {
 ///   match target {
 ///     TARGET_X64_WINDOWS => "what's up gamers",
 ///     _ => "good morning",
@@ -261,7 +261,7 @@
 /// }
 /// ```
 ///
-/// Even if `TARGET_X64_WINDOWS` is a `&'static TargetTripleRef` and
+/// Even if `TARGET_X64_WINDOWS` is a `&'static TripleNameRef` and
 /// a `const`. Doesn't matter. rustc says no. Maybe in the future.
 ///
 /// For now, just stick it in a `HashMap`, or use an if-else chain or something. Sorry!

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -686,6 +686,17 @@ snapshot_kind: text
         "image": {
           "description": "The container image to run, something like `ubuntu:20.04` or `quay.io/pypa/manylinux_2_28_x86_64`",
           "type": "string"
+        },
+        "package_manager": {
+          "description": "The package manager to use within the container, like `apt`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PackageManager"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -1056,14 +1067,14 @@ snapshot_kind: text
           "description": "Homebrew (usually for Mac)",
           "type": "string",
           "enum": [
-            "Homebrew"
+            "homebrew"
           ]
         },
         {
           "description": "Apt (Debian, Ubuntu, etc)",
           "type": "string",
           "enum": [
-            "Apt"
+            "apt"
           ]
         }
       ]

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -671,6 +671,24 @@ snapshot_kind: text
         }
       }
     },
+    "ContainerConfig": {
+      "description": "GitHub config that's common between different kinds of jobs (global, local)",
+      "type": "object",
+      "required": [
+        "host",
+        "image"
+      ],
+      "properties": {
+        "host": {
+          "description": "The host triple of the container, something like `x86_64-unknown-linux-gnu` or `aarch64-unknown-linux-musl` or whatever.",
+          "type": "string"
+        },
+        "image": {
+          "description": "The container image to run, something like `ubuntu:20.04` or `quay.io/pypa/manylinux_2_28_x86_64`",
+          "type": "string"
+        }
+      }
+    },
     "EnvironmentVariables": {
       "description": "Release-specific environment variables",
       "type": "object",
@@ -815,57 +833,48 @@ snapshot_kind: text
         }
       }
     },
-    "GithubMatrix": {
-      "description": "Github CI Matrix",
-      "type": "object",
-      "properties": {
-        "include": {
-          "description": "define each task manually rather than doing cross-product stuff",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/GithubMatrixEntry"
-          }
-        }
-      }
-    },
-    "GithubMatrixEntry": {
-      "description": "Entry for a github matrix",
+    "GithubLocalJobConfig": {
+      "description": "Used in `github/release.yml.j2` to template out \"local\" build jobs",
       "type": "object",
       "required": [
+        "dist_args",
+        "host",
         "install_cargo_auditable",
-        "install_dist"
+        "install_dist",
+        "runner"
       ],
       "properties": {
         "cache_provider": {
-          "description": "what cache provider to use",
+          "description": "What cache provider to use",
           "type": [
             "string",
             "null"
           ]
         },
+        "container": {
+          "description": "Container image to run the job in, using GitHub's builtin container support, see <https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container>\n\nThis doesn't allow mounting volumes, or anything, because we're only able to set the `container` key to something stringy",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ContainerConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "dist_args": {
           "description": "Arguments to pass to dist",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
+        },
+        "host": {
+          "description": "Host triple of the runner (well-known, custom, or best guess). If the runner is one of GitHub's official runner images, the platform is hardcoded. If it's custom, then we have a `target_triple => runner` in the config",
+          "type": "string"
         },
         "install_cargo_auditable": {
           "description": "Expression to execute to install cargo-auditable",
           "allOf": [
             {
               "$ref": "#/definitions/GhaRunStep"
-            }
-          ]
-        },
-        "install_cargo_cyclonedx": {
-          "description": "Expression to execute to install cargo-cyclonedx",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/GhaRunStep"
-            },
-            {
-              "type": "null"
             }
           ]
         },
@@ -885,20 +894,30 @@ snapshot_kind: text
           ]
         },
         "runner": {
-          "description": "Github Runner to user",
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "GHA's `runs-on` key: Github Runner image to use, see <https://github.com/actions/runner-images> and <https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job>\n\nThis is not necessarily a well-known runner, it could be something self-hosted, it could be from BuildJet, Namespace, etc.",
+          "type": "string"
         },
         "targets": {
-          "description": "Targets to build for",
+          "description": "Target triples to build for",
           "type": [
             "array",
             "null"
           ],
           "items": {
             "type": "string"
+          }
+        }
+      }
+    },
+    "GithubMatrix": {
+      "description": "Github CI Matrix",
+      "type": "object",
+      "properties": {
+        "include": {
+          "description": "define each task manually rather than doing cross-product stuff",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GithubLocalJobConfig"
           }
         }
       }

--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -90,7 +90,7 @@ use std::fmt::Display;
 
 use axoproject::PackageIdx;
 use axotag::{parse_tag, Package, PartialAnnouncementTag, ReleaseType};
-use cargo_dist_schema::{DistManifest, GithubHosting, TargetTriple, TargetTripleRef};
+use cargo_dist_schema::{DistManifest, GithubHosting, TripleName, TripleNameRef};
 use itertools::Itertools;
 use semver::Version;
 use tracing::info;
@@ -977,7 +977,7 @@ pub fn announcement_github(manifest: &mut DistManifest) {
 }
 
 /// Create a key for Properly sorting a list of target triples
-fn sortable_triples(triples: &[TargetTriple]) -> Vec<Vec<String>> {
+fn sortable_triples(triples: &[TripleName]) -> Vec<Vec<String>> {
     // Make each triple sortable, and then sort the list of triples by those
     // (usually there's only one triple but DETERMINISM)
     let mut output: Vec<Vec<String>> = triples.iter().map(|t| sortable_triple(t)).collect();
@@ -986,7 +986,7 @@ fn sortable_triples(triples: &[TargetTriple]) -> Vec<Vec<String>> {
 }
 
 /// Create a key for Properly sorting target triples
-fn sortable_triple(triple: &TargetTripleRef) -> Vec<String> {
+fn sortable_triple(triple: &TripleNameRef) -> Vec<String> {
     // We want to sort lexically by: os, abi, arch
     // We are given arch, vendor, os, abi
     //
@@ -1018,7 +1018,7 @@ fn sortable_triple(triple: &TargetTripleRef) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use cargo_dist_schema::TargetTripleRef;
+    use cargo_dist_schema::TripleNameRef;
 
     use super::sortable_triple;
     #[test]
@@ -1045,7 +1045,7 @@ mod tests {
             "x86_64-unknown-linux-gnu.2.31",
             "x86_64-unknown-linux-musl-static",
         ];
-        targets.sort_by_cached_key(|t| sortable_triple(TargetTripleRef::from_str(t)));
+        targets.sort_by_cached_key(|t| sortable_triple(TripleNameRef::from_str(t)));
         assert_eq!(
             targets,
             vec![

--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -751,8 +751,11 @@ fn system_deps_install_script(
         lines.push(brew_bundle_command(brew_packages.iter()))
     }
 
+    // If we're crossing, we'll most likely be running from a container with
+    // no sudo. We should avoid calling sudo in that case.
+    let sudo = if rc.container.is_some() { "" } else { "sudo " };
     if !apt_packages.is_empty() {
-        lines.push("sudo apt-get update".to_owned());
+        lines.push(format!("{sudo}apt-get update"));
         let args = apt_packages
             .iter()
             .map(|(pkg, version)| {
@@ -763,7 +766,7 @@ fn system_deps_install_script(
                 }
             })
             .join(" ");
-        lines.push(format!("sudo apt-get install {args}"));
+        lines.push(format!("{sudo}apt-get install {args}"));
     }
 
     for (pkg, version) in &chocolatey_packages {

--- a/cargo-dist/src/backend/installer/homebrew.rs
+++ b/cargo-dist/src/backend/installer/homebrew.rs
@@ -1,7 +1,7 @@
 //! Code for generating formula.rb
 
 use axoasset::LocalAsset;
-use cargo_dist_schema::{ChecksumValue, DistManifest};
+use cargo_dist_schema::{ChecksumValue, DistManifest, HomebrewPackageName};
 use serde::Serialize;
 use spdx::{
     expression::{ExprNode, Operator},
@@ -35,7 +35,7 @@ pub struct HomebrewInstallerInfo {
     /// Generic installer info
     pub inner: InstallerInfo,
     /// Additional packages to specify as dependencies
-    pub dependencies: Vec<String>,
+    pub dependencies: Vec<HomebrewPackageName>,
     /// Whether to install packaged C dynamic libraries
     pub install_libraries: Vec<LibraryStyle>,
 }

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -5,7 +5,7 @@
 use std::collections::BTreeMap;
 
 use camino::Utf8PathBuf;
-use cargo_dist_schema::{ArtifactId, EnvironmentVariables, Hosting, TargetTriple};
+use cargo_dist_schema::{ArtifactId, EnvironmentVariables, Hosting, TripleName};
 use homebrew::HomebrewFragments;
 use macpkg::PkgInstallerInfo;
 use serde::Serialize;
@@ -84,7 +84,7 @@ pub struct InstallerInfo {
     /// Install receipt to write, if any
     pub receipt: Option<InstallReceipt>,
     /// Aliases to install binaries under
-    pub bin_aliases: BTreeMap<TargetTriple, BTreeMap<String, Vec<String>>>,
+    pub bin_aliases: BTreeMap<TripleName, BTreeMap<String, Vec<String>>>,
     /// Whether to install generated C dynamic libraries
     pub install_libraries: Vec<LibraryStyle>,
     /// Platform-specific runtime conditions
@@ -101,7 +101,7 @@ pub struct ExecutableZipFragment {
     /// The id of the artifact
     pub id: ArtifactId,
     /// The target the artifact supports
-    pub target_triple: TargetTriple,
+    pub target_triple: TripleName,
     /// The executables the artifact contains (name, assumed at root)
     pub executables: Vec<String>,
     /// The dynamic libraries the artifact contains (name, assumed at root)

--- a/cargo-dist/src/backend/installer/msi.rs
+++ b/cargo-dist/src/backend/installer/msi.rs
@@ -2,7 +2,7 @@
 
 use axoasset::{toml_edit, LocalAsset};
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_dist_schema::TargetTriple;
+use cargo_dist_schema::TripleName;
 use tracing::info;
 use wix::print::{wxs::WxsRenders, RenderOutput};
 
@@ -18,7 +18,7 @@ pub struct MsiInstallerInfo {
     /// An ideally unambiguous way to refer to a package for the purpose of cargo -p flags.
     pub pkg_spec: String,
     /// Binaries we'll be baking into the msi
-    pub target: TargetTriple,
+    pub target: TripleName,
     /// Final file path of the msi
     pub file_path: Utf8PathBuf,
     /// Dir stuff goes to

--- a/cargo-dist/src/backend/installer/npm.rs
+++ b/cargo-dist/src/backend/installer/npm.rs
@@ -2,7 +2,7 @@
 
 use axoasset::{LocalAsset, SourceFile};
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_dist_schema::{ArtifactId, GlibcVersion, TargetTriple};
+use cargo_dist_schema::{ArtifactId, GlibcVersion, TripleName};
 use serde::Serialize;
 
 use super::InstallerInfo;
@@ -42,7 +42,7 @@ const RUN_JS: &str = "run.js";
 const PACKAGE_JSON: &str = "package.json";
 const PACKAGE_LOCK: &str = "npm-shrinkwrap.json";
 
-type PackageJsonPlatforms = SortedMap<TargetTriple, PackageJsonPlatform>;
+type PackageJsonPlatforms = SortedMap<TripleName, PackageJsonPlatform>;
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PackageJsonPlatform {

--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -69,7 +69,7 @@ impl<'a> DistGraphBuilder<'a> {
 
         let mut builds = vec![];
         for (target_triple, binaries) in targets {
-            let target = target_triple.parse().unwrap();
+            let target = target_triple.parse()?;
             let mut rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
 
             // FIXME: is there a more principled way for us to add things to RUSTFLAGS
@@ -104,7 +104,7 @@ impl<'a> DistGraphBuilder<'a> {
                 rustflags.push_str(" -Ctarget-feature=+crt-static -Clink-self-contained=yes");
             }
 
-            let host = cargo.host_target.parse().unwrap();
+            let host = cargo.host_target.parse()?;
 
             // If we're trying to cross-compile, ensure the rustup toolchain is set up!
             if target != host {
@@ -170,7 +170,7 @@ pub fn make_build_cargo_target_command(
     step: &CargoBuildStep,
     auditable: bool,
 ) -> DistResult<Cmd> {
-    let target: Triple = step.target_triple.parse().unwrap();
+    let target: Triple = step.target_triple.parse()?;
 
     eprint!("building {target} target");
     let wrapper = build_wrapper_for_cross(host, &target)?;

--- a/cargo-dist/src/build/generic.rs
+++ b/cargo-dist/src/build/generic.rs
@@ -5,7 +5,7 @@ use std::{env, process::ExitStatus};
 use axoprocess::Cmd;
 use axoproject::WorkspaceIdx;
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_dist_schema::{DistManifest, TargetTriple, TargetTripleRef};
+use cargo_dist_schema::{DistManifest, TripleName, TripleNameRef};
 
 use crate::{
     build::{package_id_string, BuildExpectations},
@@ -19,7 +19,7 @@ impl<'a> DistGraphBuilder<'a> {
     pub(crate) fn compute_generic_builds(&mut self, workspace_idx: WorkspaceIdx) -> Vec<BuildStep> {
         // For now we can be really simplistic and just do a workspace build for every
         // target-triple we have a binary-that-needs-a-real-build for.
-        let mut targets = SortedMap::<TargetTriple, Vec<BinaryIdx>>::new();
+        let mut targets = SortedMap::<TripleName, Vec<BinaryIdx>>::new();
         for (binary_idx, binary) in self.inner.binaries.iter().enumerate() {
             // Only bother with binaries owned by this workspace
             if self.workspaces.workspace_for_package(binary.pkg_idx) != workspace_idx {
@@ -95,7 +95,7 @@ impl<'a> DistGraphBuilder<'a> {
     }
 }
 
-fn platform_appropriate_cc(target: &TargetTripleRef) -> &str {
+fn platform_appropriate_cc(target: &TripleNameRef) -> &str {
     if target.is_darwin() {
         "clang"
     } else if target.is_linux() {
@@ -107,7 +107,7 @@ fn platform_appropriate_cc(target: &TargetTripleRef) -> &str {
     }
 }
 
-fn platform_appropriate_cxx(target: &TargetTripleRef) -> &str {
+fn platform_appropriate_cxx(target: &TripleNameRef) -> &str {
     if target.is_darwin() {
         "clang++"
     } else if target.is_linux() {
@@ -123,7 +123,7 @@ fn run_build(
     dist_graph: &DistGraph,
     build_command: &[String],
     working_dir: &Utf8Path,
-    target: Option<&TargetTriple>,
+    target: Option<&TripleName>,
 ) -> DistResult<ExitStatus> {
     let mut command_string = build_command.to_owned();
 

--- a/cargo-dist/src/build/mod.rs
+++ b/cargo-dist/src/build/mod.rs
@@ -2,7 +2,7 @@
 
 use axoproject::PackageId;
 use camino::Utf8PathBuf;
-use cargo_dist_schema::{AssetInfo, DistManifest, TargetTripleRef};
+use cargo_dist_schema::{AssetInfo, DistManifest, TripleNameRef};
 use tracing::info;
 
 use crate::{
@@ -195,7 +195,7 @@ impl BuildExpectations {
         dist: &DistGraph,
         manifest: &mut DistManifest,
         src: &ExpectedBinary,
-        target: &TargetTripleRef,
+        target: &TripleNameRef,
     ) -> DistResult<()> {
         let src_path = src
             .src_path

--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -2,7 +2,7 @@
 
 use camino::Utf8PathBuf;
 use cargo_dist::announce::{TagMode, TagSettings};
-use cargo_dist_schema::TargetTriple;
+use cargo_dist_schema::TripleName;
 use clap::{
     builder::{PossibleValuesParser, TypedValueParser},
     Args, Parser, Subcommand, ValueEnum,
@@ -49,7 +49,7 @@ pub struct Cli {
     /// except for `dist init` which will select some "good defaults" for you.
     #[clap(long, short, value_delimiter(','))]
     #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
-    pub target: Vec<TargetTriple>,
+    pub target: Vec<TripleName>,
 
     /// Installers we want to build
     ///
@@ -111,6 +111,12 @@ pub enum Commands {
     /// Build artifacts
     #[clap(disable_version_flag = true)]
     Build(BuildArgs),
+
+    /// Print the upload files from a manifest (useful in GitHub Actions to avoid relying on jq)
+    #[clap(disable_version_flag = true)]
+    #[clap(hide = true)]
+    PrintUploadFilesFromManifest(PrintUploadFilesFromManifestArgs),
+
     /// Setup or update dist
     ///
     /// This will interactively guide you through the process of selecting configuration options
@@ -436,6 +442,13 @@ pub struct ManifestSchemaArgs {
     /// Write the manifest schema to the named file instead of stdout
     #[clap(long)]
     pub output: Option<String>,
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct PrintUploadFilesFromManifestArgs {
+    /// The manifest to print upload files from
+    #[clap(long)]
+    pub manifest: String,
 }
 
 #[derive(Args, Clone, Debug)]

--- a/cargo-dist/src/config/v0.rs
+++ b/cargo-dist/src/config/v0.rs
@@ -1,7 +1,9 @@
 //! v0 config
 
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_dist_schema::{declare_strongly_typed_string, GithubRunner};
+use cargo_dist_schema::{
+    declare_strongly_typed_string, GithubRunner, GithubRunnerConfigInput, StringLikeOr,
+};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use tracing::log::warn;
@@ -130,7 +132,7 @@ pub struct DistMetadata {
     ///
     /// FIXME: Allow higher level requests like "[macos, windows, linux] x [x86_64, aarch64]"?
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub targets: Option<Vec<TargetTriple>>,
+    pub targets: Option<Vec<TripleName>>,
 
     /// Include the following static files in bundles like archives.
     ///
@@ -404,7 +406,8 @@ pub struct DistMetadata {
 
     /// Custom GitHub runners, mapped by triple target
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub github_custom_runners: Option<SortedMap<TargetTriple, GithubRunner>>,
+    pub github_custom_runners:
+        Option<SortedMap<TripleName, StringLikeOr<GithubRunner, GithubRunnerConfigInput>>>,
 
     /// Custom permissions for jobs
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cargo-dist/src/config/v1/ci/github.rs
+++ b/cargo-dist/src/config/v1/ci/github.rs
@@ -1,6 +1,11 @@
 //! github ci config
 
-use cargo_dist_schema::{GithubRunner, TargetTriple};
+use cargo_dist_schema::{
+    ContainerConfig, GithubRunner, GithubRunnerConfig, GithubRunnerConfigInput, StringLikeOr,
+    TripleName,
+};
+
+use crate::platform::{github_runners::target_for_github_runner, targets};
 
 use super::*;
 
@@ -14,7 +19,7 @@ pub struct GithubCiLayer {
 
     /// Custom GitHub runners, mapped by triple target
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub runners: Option<SortedMap<TargetTriple, GithubRunner>>,
+    pub runners: Option<SortedMap<TripleName, StringLikeOr<GithubRunner, GithubRunnerConfigInput>>>,
 
     /// Custom permissions for jobs
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -24,15 +29,19 @@ pub struct GithubCiLayer {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_setup: Option<String>,
 }
+
 /// github ci config (final)
 #[derive(Debug, Default, Clone)]
 pub struct GithubCiConfig {
     /// Common options
     pub common: CommonCiConfig,
+
     /// Custom GitHub runners, mapped by triple target
-    pub runners: SortedMap<TargetTriple, GithubRunner>,
+    pub runners: SortedMap<TripleName, GithubRunnerConfig>,
+
     /// Custom permissions for jobs
     pub permissions: SortedMap<String, GithubPermissionMap>,
+
     /// Custom permissions for jobs
     pub build_setup: Option<String>,
 }
@@ -61,7 +70,66 @@ impl ApplyLayer for GithubCiConfig {
         }: Self::Layer,
     ) {
         self.common.apply_layer(common);
-        self.runners.apply_val(runners);
+
+        let mk_default_github_runner = || GithubRunner::new("ubuntu-20.04".to_owned());
+        self.runners.apply_val(runners.map(|runners| {
+            runners
+                .into_iter()
+                .map(|(target_triple, runner)| {
+                    (
+                        target_triple.clone(),
+                        match runner {
+                            StringLikeOr::StringLike(runner) => {
+                                let host = target_for_github_runner(&runner)
+                                    .map(|t| t.to_owned())
+                                    .unwrap_or_else(|| target_triple.clone());
+                                GithubRunnerConfig {
+                                    host,
+                                    runner,
+                                    container: None,
+                                }
+                            }
+                            StringLikeOr::Val(runner_config) => {
+                                let runner = runner_config
+                                    .runner
+                                    .unwrap_or_else(mk_default_github_runner);
+                                let host = runner_config
+                                    .host
+                                    .or_else(|| {
+                                        target_for_github_runner(&runner).map(|t| t.to_owned())
+                                    })
+                                    .unwrap_or_else(|| {
+                                        // if not specified, then assume the custom github runner is
+                                        // the right platform (host == target)
+                                        target_triple.clone()
+                                    });
+                                let container =
+                                    runner_config.container.map(|container| match container {
+                                        StringLikeOr::StringLike(image_name) => {
+                                            ContainerConfig {
+                                                image: image_name,
+                                                // assume x86_64-unknown-linux-musl if not specified
+                                                host: targets::TARGET_X64_LINUX_MUSL.to_owned(),
+                                            }
+                                        }
+                                        StringLikeOr::Val(container_config) => ContainerConfig {
+                                            image: container_config.image,
+                                            host: container_config.host.unwrap_or_else(|| {
+                                                targets::TARGET_X64_LINUX_MUSL.to_owned()
+                                            }),
+                                        },
+                                    });
+                                GithubRunnerConfig {
+                                    runner,
+                                    host,
+                                    container,
+                                }
+                            }
+                        },
+                    )
+                })
+                .collect()
+        }));
         self.permissions.apply_val(permissions);
         self.build_setup.apply_opt(build_setup);
     }

--- a/cargo-dist/src/config/v1/ci/github.rs
+++ b/cargo-dist/src/config/v1/ci/github.rs
@@ -110,6 +110,7 @@ impl ApplyLayer for GithubCiConfig {
                                                 image: image_name,
                                                 // assume x86_64-unknown-linux-musl if not specified
                                                 host: targets::TARGET_X64_LINUX_MUSL.to_owned(),
+                                                package_manager: None,
                                             }
                                         }
                                         StringLikeOr::Val(container_config) => ContainerConfig {
@@ -117,6 +118,7 @@ impl ApplyLayer for GithubCiConfig {
                                             host: container_config.host.unwrap_or_else(|| {
                                                 targets::TARGET_X64_LINUX_MUSL.to_owned()
                                             }),
+                                            package_manager: container_config.package_manager,
                                         },
                                     });
                                 GithubRunnerConfig {

--- a/cargo-dist/src/config/v1/mod.rs
+++ b/cargo-dist/src/config/v1/mod.rs
@@ -283,7 +283,7 @@ pub struct AppConfig {
     /// Whether the package should be distributed/built by dist
     pub dist: Option<bool>,
     /// The full set of target triples to build for.
-    pub targets: Vec<TargetTriple>,
+    pub targets: Vec<TripleName>,
 }
 /// Config scoped to a particular App
 ///
@@ -303,7 +303,7 @@ pub struct AppConfigInheritable {
     /// Whether the package should be distributed/built by dist
     pub dist: Option<bool>,
     /// The full set of target triples to build for.
-    pub targets: Vec<TargetTriple>,
+    pub targets: Vec<TripleName>,
 }
 impl AppConfigInheritable {
     /// Get the defaults for the given package
@@ -419,7 +419,7 @@ pub struct TomlLayer {
     ///
     /// FIXME: Allow higher level requests like "[macos, windows, linux] x [x86_64, aarch64]"?
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub targets: Option<Vec<TargetTriple>>,
+    pub targets: Option<Vec<TripleName>>,
 
     /// artifact config
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -595,6 +595,18 @@ pub enum DistError {
         /// Version the project uses
         your_version: semver::Version,
     },
+
+    /// axoupdater can't be built for this target from this host
+    #[error("You've requested a cross-compile from {host} to {target}, but axoupdater can't be built for this target")]
+    #[diagnostic(help(
+        "Please either disable this target, or set `install-updater' to `false' in your config."
+    ))]
+    AxoupdaterInvalidCross {
+        /// The host this build is on
+        host: TripleName,
+        /// The target this build is for
+        target: TripleName,
+    },
 }
 
 /// This error indicates we tried to deserialize some YAML with serde_yml

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -9,7 +9,7 @@
 use axoproject::errors::AxoprojectError;
 use backtrace::Backtrace;
 use camino::Utf8PathBuf;
-use cargo_dist_schema::{ArtifactId, TargetTriple};
+use cargo_dist_schema::{target_lexicon::Triple, ArtifactId, TripleName};
 use color_backtrace::BacktracePrinter;
 use console::style;
 use miette::{Diagnostic, SourceOffset, SourceSpan};
@@ -322,9 +322,9 @@ pub enum DistError {
     #[error("unable to run linkage report for {target} on {host}")]
     LinkageCheckInvalidOS {
         /// The OS the check was run on
-        host: TargetTriple,
+        host: String,
         /// The OS being checked
-        target: TargetTriple,
+        target: TripleName,
     },
 
     /// Linkage report can't be run for this target
@@ -410,7 +410,7 @@ pub enum DistError {
     #[diagnostic(help("try adding --target={host_target}"))]
     CliMissingTargets {
         /// Current host target
-        host_target: TargetTriple,
+        host_target: TripleName,
     },
 
     /// Workspace isn't init
@@ -452,7 +452,7 @@ pub enum DistError {
     #[diagnostic(help("The full list of supported targets can be found here: https://opensource.axo.dev/cargo-dist/book/reference/config.html#targets"))]
     UnrecognizedTarget {
         /// The target in question
-        target: TargetTriple,
+        target: TripleName,
     },
 
     /// Installers requested despite having nothing to install
@@ -520,6 +520,30 @@ pub enum DistError {
     NoDistScript {
         /// path to package.json
         manifest: Utf8PathBuf,
+    },
+
+    /// Unsupported cross-compilation host/target combination
+    #[error("Cross-compilation from {host} to {target} is not supported")]
+    #[diagnostic(help("{details}"))]
+    UnsupportedCrossCompile {
+        /// The host system
+        host: Triple,
+        /// The target system
+        target: Triple,
+        /// Additional details about why this combination is unsupported
+        details: String,
+    },
+
+    /// Cannot use cross-compilation with cargo-auditable
+    #[error(
+        "Cross-compilation builds from {host} to {target} cannot be used with cargo-auditable"
+    )]
+    #[diagnostic(help("set cargo-auditable to false or don't do cross-compilation"))]
+    CannotDoCargoAuditableAndCrossCompile {
+        /// The host system
+        host: Triple,
+        /// The target system
+        target: Triple,
     },
 
     /// missing "build-command" for a package that needs one

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -74,6 +74,10 @@ pub enum DistError {
     #[error(transparent)]
     ParseIntError(#[from] std::num::ParseIntError),
 
+    /// random triple parse error
+    #[error(transparent)]
+    TripleError(#[from] cargo_dist_schema::target_lexicon::ParseError),
+
     /// A problem with a jinja template, which is always a dist bug
     #[error("Failed to render template")]
     #[diagnostic(

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1,7 +1,7 @@
 use axoasset::toml_edit;
 use axoproject::{WorkspaceGraph, WorkspaceInfo, WorkspaceKind};
 use camino::Utf8PathBuf;
-use cargo_dist_schema::TargetTripleRef;
+use cargo_dist_schema::TripleNameRef;
 use semver::Version;
 use serde::Deserialize;
 
@@ -491,7 +491,7 @@ fn get_new_dist_metadata(
         }
 
         // Prettify/sort things
-        let desc = move |triple: &TargetTripleRef| -> String {
+        let desc = move |triple: &TripleNameRef| -> String {
             let pretty = triple_to_display_name(triple).unwrap_or("[unknown]");
             format!("{pretty} ({triple})")
         };

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -21,7 +21,10 @@ use backend::{
         self, macpkg::PkgInstallerInfo, msi::MsiInstallerInfo, HomebrewImpl, InstallerImpl,
     },
 };
-use build::generic::{build_generic_target, run_extra_artifacts_build};
+use build::{
+    cargo::make_build_cargo_target_command,
+    generic::{build_generic_target, run_extra_artifacts_build},
+};
 use build::{
     cargo::{build_cargo_target, rustup_toolchain},
     fake::{build_fake_cargo_target, build_fake_generic_target},
@@ -32,6 +35,7 @@ use config::{
     ArtifactMode, ChecksumStyle, CompressionImpl, Config, DirtyMode, GenerateMode, ZipStyle,
 };
 use console::Term;
+use platform::targets::TARGET_ARM64_WINDOWS;
 use semver::Version;
 use temp_dir::TempDir;
 use tracing::info;
@@ -172,6 +176,7 @@ fn run_build_step(
 const AXOUPDATER_ASSET_ROOT: &str =
     "https://github.com/axodotdev/axoupdater/releases/latest/download";
 const AXOUPDATER_MINIMUM_VERSION: &str = "0.7.0";
+const AXOUPDATER_GIT_URL: &str = "https://github.com/axodotdev/axoupdater.git";
 
 /// Fetches an installer executable and installs it in the expected target path.
 pub fn fetch_updater(dist_graph: &DistGraph, updater: &UpdaterStep) -> DistResult<()> {
@@ -206,27 +211,49 @@ pub fn fetch_updater(dist_graph: &DistGraph, updater: &UpdaterStep) -> DistResul
 pub fn fetch_updater_from_source(dist_graph: &DistGraph, updater: &UpdaterStep) -> DistResult<()> {
     let (_tmp_dir, tmp_root) = create_tmp()?;
 
-    // Update this to work from releases, and to fetch prebuilt binaries,
-    // once this has been released at least once.
-    let mut cmd = Cmd::new(
-        "cargo",
-        format!("Fetch installer for {}", updater.target_triple),
-    );
+    // cargo-xwin can't currently build one of axoupdater's dependencies:
+    // https://github.com/rust-cross/cargo-xwin/issues/76
+    let host = cargo_dist_schema::target_lexicon::HOST;
+    let target = updater.target_triple.parse().unwrap();
+    if host != target && updater.target_triple == TARGET_ARM64_WINDOWS {
+        return Err(DistError::AxoupdaterInvalidCross {
+            host: TripleName::new(host.to_string()),
+            target: updater.target_triple.to_owned(),
+        });
+    }
 
-    // Install to a temporary path before moving it to the destination
-    cmd.arg("install")
-        .arg("axoupdater-cli")
-        .arg("--features=tls_native_roots")
-        .arg("--root")
-        .arg(&tmp_root)
-        .current_dir(&tmp_root)
-        .arg("--bin")
-        .arg("axoupdater");
+    let Some(git) = &dist_graph.tools.git else {
+        return Err(DistError::ToolMissing {
+            tool: "git".to_owned(),
+        });
+    };
+    // We can't use `cargo install` due to the cross-compile wrappers,
+    // so fetch the repo ahead of time.
+    let mut cmd = Cmd::new(&git.cmd, "fetch axoupdater");
+    cmd.arg("clone").arg(AXOUPDATER_GIT_URL).arg(&tmp_root);
+    cmd.run()?;
+
+    let features = CargoTargetFeatures {
+        default_features: true,
+        features: CargoTargetFeatureList::List(vec!["tls_native_roots".to_owned()]),
+    };
+    let step = CargoBuildStep {
+        target_triple: updater.target_triple.to_owned(),
+        features,
+        package: CargoTargetPackages::Workspace,
+        profile: "dist".to_string(),
+        rustflags: "".to_owned(),
+        expected_binaries: vec![],
+        working_dir: tmp_root.clone(),
+    };
+    let cargo = dist_graph.tools.cargo()?;
+    let mut cmd = make_build_cargo_target_command(&host, &cargo.cmd, "", &step, false)?;
+    cmd.arg("--bin").arg("axoupdater");
 
     cmd.run()?;
 
     // OK, now we have a binary in the tempdir
-    let mut source = tmp_root.join("bin").join("axoupdater");
+    let mut source = tmp_root.join("target").join("release").join("axoupdater");
     if updater.target_triple.is_windows() {
         source.set_extension("exe");
     }

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -27,7 +27,7 @@ use build::{
     fake::{build_fake_cargo_target, build_fake_generic_target},
 };
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_dist_schema::{ArtifactId, ChecksumValue, ChecksumValueRef, DistManifest, TargetTriple};
+use cargo_dist_schema::{ArtifactId, ChecksumValue, ChecksumValueRef, DistManifest, TripleName};
 use config::{
     ArtifactMode, ChecksumStyle, CompressionImpl, Config, DirtyMode, GenerateMode, ZipStyle,
 };
@@ -799,7 +799,7 @@ fn generate_installer(
 }
 
 /// Get the default list of targets
-pub fn default_desktop_targets() -> Vec<TargetTriple> {
+pub fn default_desktop_targets() -> Vec<TripleName> {
     use crate::platform::targets as t;
 
     vec![
@@ -807,16 +807,15 @@ pub fn default_desktop_targets() -> Vec<TargetTriple> {
         t::TARGET_X64_LINUX_GNU.to_owned(),
         t::TARGET_X64_WINDOWS.to_owned(),
         t::TARGET_X64_MAC.to_owned(),
-        // Apple is really easy to cross from Apple
         t::TARGET_ARM64_MAC.to_owned(),
-        // other cross-compiles not yet supported
-        // targets::TARGET_ARM64_LINUX_GNU.to_owned(),
-        // targets::TARGET_ARM64_WINDOWS.to_owned(),
+        t::TARGET_ARM64_LINUX_GNU.to_owned(),
+        // that one requires a bit of config (use the `messense/cargo-xwin` image)
+        // t::TARGET_ARM64_WINDOWS.to_owned(),
     ]
 }
 
 /// Get the list of all known targets
-pub fn known_desktop_targets() -> Vec<TargetTriple> {
+pub fn known_desktop_targets() -> Vec<TripleName> {
     use crate::platform::targets as t;
 
     vec![
@@ -825,10 +824,8 @@ pub fn known_desktop_targets() -> Vec<TargetTriple> {
         t::TARGET_X64_LINUX_MUSL.to_owned(),
         t::TARGET_X64_WINDOWS.to_owned(),
         t::TARGET_X64_MAC.to_owned(),
-        // Apple is really easy to cross from Apple
         t::TARGET_ARM64_MAC.to_owned(),
-        // other cross-compiles not yet supported
-        // t::TARGET_ARM64_LINUX_GNU.to_owned(),
-        // t::TARGET_ARM64_WINDOWS.to_owned(),
+        t::TARGET_ARM64_LINUX_GNU.to_owned(),
+        t::TARGET_ARM64_WINDOWS.to_owned(),
     ]
 }

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -214,7 +214,7 @@ pub fn fetch_updater_from_source(dist_graph: &DistGraph, updater: &UpdaterStep) 
     // cargo-xwin can't currently build one of axoupdater's dependencies:
     // https://github.com/rust-cross/cargo-xwin/issues/76
     let host = cargo_dist_schema::target_lexicon::HOST;
-    let target = updater.target_triple.parse().unwrap();
+    let target = updater.target_triple.parse()?;
     if host != target && updater.target_triple == TARGET_ARM64_WINDOWS {
         return Err(DistError::AxoupdaterInvalidCross {
             host: TripleName::new(host.to_string()),

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -246,10 +246,8 @@ fn cmd_print_upload_files_from_manifest(
         .map_err(|err| miette!("Failed to parse manifest as JSON: {}", err))?;
 
     let mut out = Term::stdout();
-    for artifact in manifest.artifacts.values() {
-        if let Some(path) = &artifact.path {
-            writeln!(out, "{}", path).into_diagnostic()?;
-        }
+    for path in manifest.upload_files {
+        writeln!(out, "{}", path).into_diagnostic()?;
     }
     Ok(())
 }

--- a/cargo-dist/src/platform.rs
+++ b/cargo-dist/src/platform.rs
@@ -870,7 +870,7 @@ fn get_glibc_override(dist: &DistGraphBuilder, artifact: &Artifact) -> Option<Li
             .target_triples
             .first()
             // if the target triple has a min-glibc-version specified, use it.
-            .and_then(|t: &TargetTriple| vmap.get(&t.to_string()).copied())
+            .and_then(|t: &TripleName| vmap.get(&t.to_string()).copied())
             // or, try using the min-glibc-version for the "*" wildcard.
             .or_else(|| vmap.get("*").copied())
     })

--- a/cargo-dist/src/platform.rs
+++ b/cargo-dist/src/platform.rs
@@ -16,7 +16,7 @@
 //! ("x64 macos binaries can run on arm64 macos under rosetta2" is another good canonical example)
 //!
 //! [`PlatformSupport::platforms`][] is an index
-//! from "target I want to install to" ([`TargetTriple`][])
+//! from "target I want to install to" ([`TripleName`][])
 //! to "list of archives we can potentially use to do that" ([`PlatformEntry`][]).
 //! The list is sorted in decreasing order from best-to-worst options. The basic idea
 //! is that you go down that list and try each option in order until one "works".

--- a/cargo-dist/src/platform/github_runners.rs
+++ b/cargo-dist/src/platform/github_runners.rs
@@ -1,0 +1,102 @@
+//! Statically-known information about various GitHub Actions runner names
+
+use std::collections::HashMap;
+
+use crate::platform::targets as t;
+use cargo_dist_schema::{target_lexicon::Triple, GithubRunnerRef, TripleNameRef};
+use tracing::warn;
+
+lazy_static::lazy_static! {
+    static ref KNOWN_GITHUB_RUNNERS: HashMap<&'static GithubRunnerRef, &'static TripleNameRef> = {
+        let mut m = HashMap::new();
+        // cf. https://github.com/actions/runner-images/blob/main/README.md
+        // last updated 2024-10-25
+
+        //-------- linux
+        m.insert(GithubRunnerRef::from_str("ubuntu-20.04"), t::TARGET_X64_LINUX_GNU);
+        m.insert(GithubRunnerRef::from_str("ubuntu-22.04"), t::TARGET_X64_LINUX_GNU);
+        m.insert(GithubRunnerRef::from_str("ubuntu-24.04"), t::TARGET_X64_LINUX_GNU);
+        m.insert(GithubRunnerRef::from_str("ubuntu-latest"), t::TARGET_X64_LINUX_GNU);
+
+        //-------- windows
+        m.insert(GithubRunnerRef::from_str("windows-2019"), t::TARGET_X64_WINDOWS);
+        m.insert(GithubRunnerRef::from_str("windows-2022"), t::TARGET_X64_WINDOWS);
+        m.insert(GithubRunnerRef::from_str("windows-latest"), t::TARGET_X64_WINDOWS);
+
+        //-------- macos x64
+        m.insert(GithubRunnerRef::from_str("macos-12"), t::TARGET_X64_MAC); // deprecated
+        m.insert(GithubRunnerRef::from_str("macos-12-large"), t::TARGET_X64_MAC);
+        m.insert(GithubRunnerRef::from_str("macos-13"), t::TARGET_X64_MAC);
+        m.insert(GithubRunnerRef::from_str("macos-13-large"), t::TARGET_X64_MAC);
+        m.insert(GithubRunnerRef::from_str("macos-14-large"), t::TARGET_X64_MAC);
+        m.insert(GithubRunnerRef::from_str("macos-15-large"), t::TARGET_X64_MAC);
+        m.insert(GithubRunnerRef::from_str("macos-latest-large"), t::TARGET_X64_MAC);
+
+        //-------- macos arm64
+        m.insert(GithubRunnerRef::from_str("macos-13-xlarge"), t::TARGET_ARM64_MAC);
+        m.insert(GithubRunnerRef::from_str("macos-14"), t::TARGET_ARM64_MAC);
+        m.insert(GithubRunnerRef::from_str("macos-14-xlarge"), t::TARGET_ARM64_MAC);
+        m.insert(GithubRunnerRef::from_str("macos-15"), t::TARGET_ARM64_MAC);
+        m.insert(GithubRunnerRef::from_str("macos-15-xlarge"), t::TARGET_ARM64_MAC);
+        m.insert(GithubRunnerRef::from_str("macos-latest"), t::TARGET_ARM64_MAC);
+        m.insert(GithubRunnerRef::from_str("macos-latest-xlarge"), t::TARGET_ARM64_MAC);
+
+        m
+    };
+}
+
+/// Get the target triple for a given GitHub Actions runner (if we know about it)
+pub fn target_for_github_runner(runner: &GithubRunnerRef) -> Option<&'static TripleNameRef> {
+    if let Some(target) = KNOWN_GITHUB_RUNNERS.get(runner).copied() {
+        return Some(target);
+    }
+
+    let runner_str = runner.as_str();
+    if let Some(rest) = runner_str.strip_prefix("buildjet-") {
+        if rest.contains("ubuntu") {
+            if rest.ends_with("-arm") {
+                return Some(t::TARGET_ARM64_LINUX_GNU);
+            } else {
+                return Some(t::TARGET_X64_LINUX_GNU);
+            }
+        }
+    }
+
+    None
+}
+
+/// Get the target triple for a given GitHub Actions runner (if we know about it), or assume x64-linux-gnu
+pub fn target_for_github_runner_or_default(runner: &GithubRunnerRef) -> &'static TripleNameRef {
+    const DEFAULT_ASSUMED_TARGET: &TripleNameRef = t::TARGET_X64_LINUX_GNU;
+
+    target_for_github_runner(runner).unwrap_or_else(|| {
+        warn!(
+            "don't know the triple for github runner '{runner}', assuming {DEFAULT_ASSUMED_TARGET}"
+        );
+        DEFAULT_ASSUMED_TARGET
+    })
+}
+
+/// Gets the parsed [`Triple`] for a given GitHub runner.
+pub fn triple_for_github_runner_or_default(runner: &GithubRunnerRef) -> Triple {
+    // unwrap safety: all the triples in `KNOWN_GITHUB_RUNNERS` should parse
+    // cleanly.
+    target_for_github_runner_or_default(runner).parse().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_target_for_github_runner() {
+        assert_eq!(
+            target_for_github_runner(GithubRunnerRef::from_str("ubuntu-20.04")),
+            Some(t::TARGET_X64_LINUX_GNU)
+        );
+        assert_eq!(
+            target_for_github_runner(GithubRunnerRef::from_str("buildjet-8vcpu-ubuntu-2204-arm")),
+            Some(t::TARGET_ARM64_LINUX_GNU)
+        );
+    }
+}

--- a/cargo-dist/src/platform/targets.rs
+++ b/cargo-dist/src/platform/targets.rs
@@ -2,13 +2,13 @@
 
 // Various target triples
 
-use cargo_dist_schema::TargetTripleRef;
+use cargo_dist_schema::TripleNameRef;
 
 macro_rules! define_target_triples {
     ($($(#[$meta:meta])* const $name:ident = $triple:expr;)*) => {
         $(
             $(#[$meta])*
-            pub const $name: &TargetTripleRef = TargetTripleRef::from_str($triple);
+            pub const $name: &TripleNameRef = TripleNameRef::from_str($triple);
         )*
     };
 }
@@ -29,7 +29,7 @@ define_target_triples!(
 );
 
 /// List of all recognized Windows targets
-pub const KNOWN_WINDOWS_TARGETS: &[&TargetTripleRef] = &[
+pub const KNOWN_WINDOWS_TARGETS: &[&TripleNameRef] = &[
     TARGET_X86_WINDOWS,
     TARGET_X64_WINDOWS,
     TARGET_ARM64_WINDOWS,
@@ -48,7 +48,7 @@ define_target_triples!(
 );
 
 /// List of all recognized Mac targets
-pub const KNOWN_MAC_TARGETS: &[&TargetTripleRef] =
+pub const KNOWN_MAC_TARGETS: &[&TripleNameRef] =
     &[TARGET_X86_MAC, TARGET_X64_MAC, TARGET_ARM64_MAC];
 
 define_target_triples!(
@@ -81,7 +81,7 @@ define_target_triples!(
 );
 
 /// List of all recognized Linux glibc targets
-pub const KNOWN_LINUX_GNU_TARGETS: &[&TargetTripleRef] = &[
+pub const KNOWN_LINUX_GNU_TARGETS: &[&TripleNameRef] = &[
     TARGET_X86_LINUX_GNU,
     TARGET_X64_LINUX_GNU,
     TARGET_ARM64_LINUX_GNU,
@@ -126,7 +126,7 @@ define_target_triples!(
 );
 
 /// List of all recognized Linux MUSL targets
-pub const KNOWN_LINUX_MUSL_TARGETS: &[&TargetTripleRef] = &[
+pub const KNOWN_LINUX_MUSL_TARGETS: &[&TripleNameRef] = &[
     TARGET_X86_LINUX_MUSL,
     TARGET_X64_LINUX_MUSL,
     TARGET_ARM64_LINUX_MUSL,
@@ -142,7 +142,7 @@ pub const KNOWN_LINUX_MUSL_TARGETS: &[&TargetTripleRef] = &[
 ];
 
 /// List of all recognized Linux targets
-pub const KNOWN_LINUX_TARGETS: &[&[&TargetTripleRef]] =
+pub const KNOWN_LINUX_TARGETS: &[&[&TripleNameRef]] =
     &[KNOWN_LINUX_GNU_TARGETS, KNOWN_LINUX_MUSL_TARGETS];
 
 define_target_triples!(
@@ -177,7 +177,7 @@ define_target_triples!(
 );
 
 /// List of all recognized Other targets
-pub const KNOWN_OTHER_TARGETS: &[&TargetTripleRef] = &[
+pub const KNOWN_OTHER_TARGETS: &[&TripleNameRef] = &[
     TARGET_X64_FREEBSD,
     TARGET_X64_ILLUMOS,
     TARGET_X64_NETBSD,
@@ -195,14 +195,10 @@ pub const KNOWN_OTHER_TARGETS: &[&TargetTripleRef] = &[
 ];
 
 /// List of all recognized targets
-pub const KNOWN_TARGET_TRIPLES: &[&[&TargetTripleRef]] = &[
+pub const KNOWN_TARGET_TRIPLES: &[&[&TripleNameRef]] = &[
     KNOWN_WINDOWS_TARGETS,
     KNOWN_MAC_TARGETS,
     KNOWN_LINUX_GNU_TARGETS,
     KNOWN_LINUX_MUSL_TARGETS,
     KNOWN_OTHER_TARGETS,
 ];
-
-/// The current host target (the target of the machine this code is running on).
-/// This is determined through `std::env::consts::OS` rather than running `cargo`
-pub const TARGET_HOST: &TargetTripleRef = TargetTripleRef::from_str(std::env::consts::OS);

--- a/cargo-dist/src/sign/macos.rs
+++ b/cargo-dist/src/sign/macos.rs
@@ -22,7 +22,7 @@ use axoasset::LocalAsset;
 use axoprocess::Cmd;
 use base64::Engine;
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_dist_schema::TargetTripleRef;
+use cargo_dist_schema::TripleNameRef;
 use temp_dir::TempDir;
 use tracing::warn;
 
@@ -157,7 +157,7 @@ impl std::fmt::Debug for CodesignEnv {
 }
 
 impl Codesign {
-    pub fn new(host_target: &TargetTripleRef) -> DistResult<Option<Self>> {
+    pub fn new(host_target: &TripleNameRef) -> DistResult<Option<Self>> {
         if !host_target.is_darwin() {
             return Ok(None);
         }

--- a/cargo-dist/src/sign/mod.rs
+++ b/cargo-dist/src/sign/mod.rs
@@ -5,7 +5,7 @@ use std::os::unix::fs::PermissionsExt;
 
 use axoasset::AxoClient;
 use camino::Utf8Path;
-use cargo_dist_schema::TargetTripleRef;
+use cargo_dist_schema::TripleNameRef;
 
 use crate::{config::ProductionMode, DistResult};
 
@@ -23,7 +23,7 @@ impl Signing {
     /// Setup signing
     pub fn new(
         client: &AxoClient,
-        host_target: &TargetTripleRef,
+        host_target: &TripleNameRef,
         dist_dir: &Utf8Path,
         ssldotcom_windows_sign: Option<ProductionMode>,
         macos_sign: bool,

--- a/cargo-dist/src/sign/ssldotcom.rs
+++ b/cargo-dist/src/sign/ssldotcom.rs
@@ -4,7 +4,7 @@ use axoasset::LocalAsset;
 use axoprocess::Cmd;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use cargo_dist_schema::TargetTripleRef;
+use cargo_dist_schema::TripleNameRef;
 use tracing::info;
 use tracing::warn;
 
@@ -71,7 +71,7 @@ impl CodeSignToolEnv {
 impl CodeSignTool {
     pub fn new(
         client: &AxoClient,
-        host_target: &TargetTripleRef,
+        host_target: &TripleNameRef,
         dist_dir: &Utf8Path,
         ssldotcom_windows_sign: Option<ProductionMode>,
     ) -> DistResult<Option<Self>> {

--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -201,6 +201,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -222,6 +223,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       {{%- if rust_version %}}
       - name: Use rustup to set correct Rust version
         run: rustup update {{{ rust_version }}} --no-self-update && rustup default {{{ rust_version }}}
@@ -319,7 +327,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -1974,7 +1974,10 @@ container = {{ image = "quay.io/pypa/manylinux_2_28_x86_64", host = "aarch64-unk
         let ci_snap = ci_result.check_all()?;
         // Do usual build+plan checks
         let main_result = ctx.cargo_dist_build_and_plan(test_name)?;
-        let main_snap = main_result.check_all(&ctx, ".cargo/bin/")?;
+        // Since this is a cross-compile for a non-local target, we'll
+        // skip trying to actually install the artifact - it won't be
+        // available for our platform in CI.
+        let main_snap = main_result.check_all_no_ruin(&ctx, ".cargo/bin/")?;
         // snapshot all
         main_snap.join(ci_snap).snap();
         Ok(())

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -2210,67 +2210,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -2394,6 +2398,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -2404,6 +2409,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Use rustup to set correct Rust version
         run: rustup update "1.67.1" --no-self-update && rustup default "1.67.1"
       - name: Install dist
@@ -2432,7 +2444,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1595,68 +1595,72 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "targets": [
               "x86_64-unknown-linux-gnu"
             ],
-            "runner": "ubuntu-20.04",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-musl"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
+            "targets": [
+              "x86_64-unknown-linux-musl"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
             "cache_provider": "github"
           }
         ]
@@ -1780,6 +1784,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -1790,6 +1795,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Use rustup to set correct Rust version
         run: rustup update "1.67.1" --no-self-update && rustup default "1.67.1"
       - name: Install dist
@@ -1818,7 +1830,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -2240,67 +2240,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -2424,6 +2428,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -2434,6 +2439,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Use rustup to set correct Rust version
         run: rustup update "1.67.1" --no-self-update && rustup default "1.67.1"
       - name: Install dist
@@ -2462,7 +2474,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -2266,67 +2266,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -2450,6 +2454,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -2460,6 +2465,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Use rustup to set correct Rust version
         run: rustup update "1.67.1" --no-self-update && rustup default "1.67.1"
       - name: Install dist
@@ -2488,7 +2500,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -2250,67 +2250,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -2434,6 +2438,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -2444,6 +2449,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Use rustup to set correct Rust version
         run: rustup update "1.67.1" --no-self-update && rustup default "1.67.1"
       - name: Install dist
@@ -2472,7 +2484,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -3782,67 +3782,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3969,6 +3973,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3979,6 +3984,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -4009,7 +4021,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -3775,67 +3775,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3955,6 +3959,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3965,6 +3970,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -3991,7 +4003,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -3823,67 +3823,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -4005,6 +4009,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -4015,6 +4020,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -4041,7 +4053,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -3825,67 +3825,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -4007,6 +4011,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -4017,6 +4022,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -4043,7 +4055,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3902,6 +3902,24 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "cache_provider": "github"
           },
           {
+            "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=i686-unknown-linux-gnu",
+            "targets": [
+              "i686-unknown-linux-gnu"
+            ],
+            "install_cargo_auditable": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
+            },
+            "packages_install": "if ! command -v cargo-zigbuild > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-zigbuild\nfi",
+            "cache_provider": "github"
+          },
+          {
             "runner": "macos-13",
             "host": "x86_64-apple-darwin",
             "install_dist": {
@@ -3909,22 +3927,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
             "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "targets": [
-              "i686-unknown-linux-gnu"
-            ],
-            "runner": "ubuntu-20.04",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
-            "install_cargo_auditable": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
-            },
-            "dist_args": "--artifacts=local --target=i686-unknown-linux-gnu",
-            "cache_provider": "github"
-          },
-          {
             "targets": [
               "x86_64-apple-darwin"
             ],

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -3885,22 +3885,30 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
-            "targets": [
-              "aarch64-apple-darwin"
-            ],
             "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "i686-unknown-linux-gnu"
             ],
@@ -3920,48 +3928,44 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -4083,6 +4087,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -4093,6 +4098,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -4121,7 +4133,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -3894,67 +3894,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -4076,6 +4080,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -4086,6 +4091,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -4112,7 +4124,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -3791,67 +3791,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3973,6 +3977,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3983,6 +3988,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: "Some build step"
         uses: "some-action-user/some-action"
         with:
@@ -4026,7 +4038,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1575,67 +1575,71 @@ download_binary_and_run_installer "$@" || exit 1
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -1757,6 +1761,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -1767,6 +1772,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -1793,7 +1805,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1575,67 +1575,71 @@ download_binary_and_run_installer "$@" || exit 1
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -1757,6 +1761,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -1767,6 +1772,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -1793,7 +1805,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1575,67 +1575,71 @@ download_binary_and_run_installer "$@" || exit 1
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -1757,6 +1761,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -1767,6 +1772,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -1793,7 +1805,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1575,67 +1575,71 @@ download_binary_and_run_installer "$@" || exit 1
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -1757,6 +1761,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -1767,6 +1772,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -1793,7 +1805,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -2305,7 +2305,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "host": "x86_64-unknown-linux-gnu",
             "container": {
               "image": "messense/cargo-xwin",
-              "host": "x86_64-unknown-linux-musl"
+              "host": "x86_64-unknown-linux-musl",
+              "package_manager": null
             },
             "install_dist": {
               "shell": "sh",
@@ -2362,7 +2363,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "host": "x86_64-unknown-linux-gnu",
             "container": {
               "image": "messense/cargo-xwin",
-              "host": "x86_64-unknown-linux-musl"
+              "host": "x86_64-unknown-linux-musl",
+              "package_manager": null
             },
             "install_dist": {
               "shell": "sh",

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -1662,7 +1663,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "" }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -66,10 +66,9 @@ The installer for axolotlsay 0.2.2
 
 This script detects what platform you're on and fetches an appropriate archive from
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2
-then unpacks the binaries and installs them to the first of the following locations
+then unpacks the binaries and installs them to
 
-    \$NO_SUCH_ENV_VAR/My Nonexistent Documents
-    \$MY_ENV_VAR/My Axolotlsay Documents
+    \$CARGO_HOME/bin (or \$HOME/.cargo/bin)
 
 It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
@@ -167,6 +166,30 @@ download_binary_and_run_installer() {
     case "$_artifact_name" in 
         "axolotlsay-aarch64-apple-darwin.tar.gz")
             _arch="aarch64-apple-darwin"
+            _zip_ext=".tar.gz"
+            _bins="axolotlsay"
+            _bins_js_array='"axolotlsay"'
+            _libs=""
+            _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
+            _updater_name=""
+            _updater_bin=""
+            ;;
+        "axolotlsay-aarch64-pc-windows-msvc.tar.gz")
+            _arch="aarch64-pc-windows-msvc"
+            _zip_ext=".tar.gz"
+            _bins="axolotlsay.exe"
+            _bins_js_array='"axolotlsay.exe"'
+            _libs=""
+            _libs_js_array=""
+            _staticlibs=""
+            _staticlibs_js_array=""
+            _updater_name=""
+            _updater_bin=""
+            ;;
+        "axolotlsay-aarch64-unknown-linux-gnu.tar.gz")
+            _arch="aarch64-unknown-linux-gnu"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
@@ -326,6 +349,12 @@ json_binary_aliases() {
     "aarch64-apple-darwin")
         echo '{}'
         ;;
+    "aarch64-pc-windows-gnu")
+        echo '{}'
+        ;;
+    "aarch64-unknown-linux-gnu")
+        echo '{}'
+        ;;
     "x86_64-apple-darwin")
         echo '{}'
         ;;
@@ -347,6 +376,20 @@ aliases_for_binary() {
 
     case "$_arch" in 
     "aarch64-apple-darwin")
+        case "$_bin" in
+        *)
+            echo ""
+            ;;
+        esac
+        ;;
+    "aarch64-pc-windows-gnu")
+        case "$_bin" in
+        *)
+            echo ""
+            ;;
+        esac
+        ;;
+    "aarch64-unknown-linux-gnu")
         case "$_bin" in
         *)
             echo ""
@@ -399,8 +442,30 @@ select_archive_for_arch() {
                 return 0
             fi
             ;;
+        "aarch64-pc-windows-gnu")
+            _archive="axolotlsay-aarch64-pc-windows-msvc.tar.gz"
+            if [ -n "$_archive" ]; then
+                echo "$_archive"
+                return 0
+            fi
+            ;;
         "aarch64-pc-windows-msvc")
+            _archive="axolotlsay-aarch64-pc-windows-msvc.tar.gz"
+            if [ -n "$_archive" ]; then
+                echo "$_archive"
+                return 0
+            fi
             _archive="axolotlsay-x86_64-pc-windows-msvc.tar.gz"
+            if [ -n "$_archive" ]; then
+                echo "$_archive"
+                return 0
+            fi
+            ;;
+        "aarch64-unknown-linux-gnu")
+            _archive="axolotlsay-aarch64-unknown-linux-gnu.tar.gz"
+            if ! check_glibc "2" "31"; then
+                _archive=""
+            fi
             if [ -n "$_archive" ]; then
                 echo "$_archive"
                 return 0
@@ -524,10 +589,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="flat"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="flat"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -579,27 +644,32 @@ install() {
         esac
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="flat"
-        # Install to $NO_SUCH_ENV_VAR/My Nonexistent Documents
-        if [ -n "${NO_SUCH_ENV_VAR:-}" ]; then
-            _install_dir="$NO_SUCH_ENV_VAR/My Nonexistent Documents"
-            _lib_install_dir="$_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$NO_SUCH_ENV_VAR/My Nonexistent Documents/env"
-            _install_dir_expr="$(replace_home "$_install_dir")"
-            _env_script_path_expr="$(replace_home "$_env_script_path")"
-        fi
-    fi
-    if [ -z "${_install_dir:-}" ]; then
-        _install_layout="flat"
-        # Install to $MY_ENV_VAR/My Axolotlsay Documents
-        if [ -n "${MY_ENV_VAR:-}" ]; then
-            _install_dir="$MY_ENV_VAR/My Axolotlsay Documents"
-            _lib_install_dir="$_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$MY_ENV_VAR/My Axolotlsay Documents/env"
-            _install_dir_expr="$(replace_home "$_install_dir")"
-            _env_script_path_expr="$(replace_home "$_env_script_path")"
+        _install_layout="cargo-home"
+        # first try $CARGO_HOME, then fallback to $HOME/.cargo
+        if [ -n "${CARGO_HOME:-}" ]; then
+            _receipt_install_dir="$CARGO_HOME"
+            _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
+            _env_script_path="$CARGO_HOME/env"
+            # Initially make this early-bound to erase the potentially-temporary env-var
+            _install_dir_expr="$_install_dir"
+            _env_script_path_expr="$_env_script_path"
+            # If CARGO_HOME was set but it ended up being the default $HOME-based path,
+            # then keep things late-bound. Otherwise bake the value for safety.
+            # This is what rustup does, and accurately reproducing it is useful.
+            if [ -n "${HOME:-}" ]; then
+                if [ "$HOME/.cargo/bin" = "$_install_dir" ]; then
+                    _install_dir_expr='$HOME/.cargo/bin'
+                    _env_script_path_expr='$HOME/.cargo/env'
+                fi
+            fi
+        elif [ -n "${HOME:-}" ]; then
+            _receipt_install_dir="$HOME/.cargo"
+            _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
+            _env_script_path="$HOME/.cargo/env"
+            _install_dir_expr='$HOME/.cargo/bin'
+            _env_script_path_expr='$HOME/.cargo/env'
         fi
     fi
 
@@ -1311,71 +1381,6 @@ verify_checksum() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ axolotlsay.rb ================
-class Axolotlsay < Formula
-  desc "💬 a CLI for learning to distribute CLIs in rust"
-  homepage "https://github.com/axodotdev/axolotlsay"
-  version "0.2.2"
-  if OS.mac?
-    if Hardware::CPU.arm?
-      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz"
-    end
-    if Hardware::CPU.intel?
-      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz"
-    end
-  end
-  if OS.linux?
-    if Hardware::CPU.intel?
-      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
-    end
-  end
-  license any_of: ["MIT", "Apache-2.0"]
-
-  BINARY_ALIASES = {
-    "aarch64-apple-darwin": {},
-    "x86_64-apple-darwin": {},
-    "x86_64-pc-windows-gnu": {},
-    "x86_64-unknown-linux-gnu": {}
-  }
-
-  def target_triple
-    cpu = Hardware::CPU.arm? ? "aarch64" : "x86_64"
-    os = OS.mac? ? "apple-darwin" : "unknown-linux-gnu"
-
-    "#{cpu}-#{os}"
-  end
-
-  def install_binary_aliases!
-    BINARY_ALIASES[target_triple.to_sym].each do |source, dests|
-      dests.each do |dest|
-        bin.install_symlink bin/source.to_s => dest
-      end
-    end
-  end
-
-  def install
-    if OS.mac? && Hardware::CPU.arm?
-      bin.install "axolotlsay"
-    end
-    if OS.mac? && Hardware::CPU.intel?
-      bin.install "axolotlsay"
-    end
-    if OS.linux? && Hardware::CPU.intel?
-      bin.install "axolotlsay"
-    end
-
-    install_binary_aliases!
-
-    # Homebrew will automatically install these, so we don't need to do that
-    doc_files = Dir["README.*", "readme.*", "LICENSE", "LICENSE.*", "CHANGELOG.*"]
-    leftover_contents = Dir["*"] - doc_files
-
-    # Install any leftover files in pkgshare; these are probably config or
-    # sample files.
-    pkgshare.install(*leftover_contents) unless leftover_contents.empty?
-  end
-end
-
 ================ axolotlsay-installer.ps1 ================
 # Licensed under the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -1391,10 +1396,9 @@ The installer for axolotlsay 0.2.2
 
 This script detects what platform you're on and fetches an appropriate archive from
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2
-then unpacks the binaries and installs them to the first of the following locations
+then unpacks the binaries and installs them to
 
-    $env:NO_SUCH_ENV_VAR/My Nonexistent Documents
-    $env:MY_ENV_VAR/My Axolotlsay Documents
+    $env:CARGO_HOME/bin (or $HOME/.cargo/bin)
 
 It will then add that dir to PATH by editing your Environment.Path registry key
 
@@ -1470,7 +1474,7 @@ function Install-Binary($install_args) {
   # Platform info injected by dist
   $platforms = @{
     "aarch64-pc-windows-msvc" = @{
-      "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
+      "artifact_name" = "axolotlsay-aarch64-pc-windows-msvc.tar.gz"
       "bins" = @("axolotlsay.exe")
       "libs" = @()
       "staticlibs" = @()
@@ -1640,10 +1644,10 @@ function Invoke-Installer($artifacts, $platforms) {
   # to the older generic one
   if (($env:AXOLOTLSAY_INSTALL_DIR)) {
     $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "flat"
+    $install_layout = "cargo-home"
   } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
     $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "flat"
+    $install_layout = "cargo-home"
   } elseif ($unmanaged_install) {
     $force_install_dir = $unmanaged_install
     $install_layout = "flat"
@@ -1658,7 +1662,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
+        Join-Path $(if ($env:HOME) { $env:HOME } else { "" }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"
@@ -1696,22 +1700,20 @@ function Invoke-Installer($artifacts, $platforms) {
     $receipt_dest_dir = $force_install_dir
   }
   if (-Not $dest_dir) {
-    # Install to $env:NO_SUCH_ENV_VAR/My Nonexistent Documents
-    $dest_dir = if (($base_dir = $env:NO_SUCH_ENV_VAR)) {
-      Join-Path $base_dir "My Nonexistent Documents"
+    # first try $env:CARGO_HOME, then fallback to $HOME
+    # (for whatever reason $HOME is not a normal env var and doesn't need the $env: prefix)
+    $root = if (($base_dir = $env:CARGO_HOME)) {
+      $base_dir
+    } elseif (($base_dir = $HOME)) {
+      Join-Path $base_dir ".cargo"
+    } else {
+      throw "ERROR: could not find your HOME dir or CARGO_HOME to install binaries to"
     }
+
+    $dest_dir = Join-Path $root "bin"
     $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $dest_dir
-    $install_layout = "flat"
-  }
-  if (-Not $dest_dir) {
-    # Install to $env:MY_ENV_VAR/My Axolotlsay Documents
-    $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
-      Join-Path $base_dir "My Axolotlsay Documents"
-    }
-    $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $dest_dir
-    $install_layout = "flat"
+    $receipt_dest_dir = $root
+    $install_layout = "cargo-home"
   }
 
   # Looks like all of the above assignments failed
@@ -1926,7 +1928,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
   "announcement_is_prerelease": false,
   "announcement_title": "Version 0.2.2",
   "announcement_changelog": "```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```",
-  "announcement_github_body": "## Release Notes\n\n```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Install axolotlsay 0.2.2\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\npowershell -ExecutionPolicy ByPass -c \"irm https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.ps1 | iex\"\n```\n\n### Install prebuilt binaries via Homebrew\n\n```sh\nbrew install axolotlsay\n```\n\n## Download axolotlsay 0.2.2\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256) |\n\n",
+  "announcement_github_body": "## Release Notes\n\n```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Install axolotlsay 0.2.2\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\npowershell -ExecutionPolicy ByPass -c \"irm https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.ps1 | iex\"\n```\n\n## Download axolotlsay 0.2.2\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-aarch64-pc-windows-msvc.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-pc-windows-msvc.tar.gz) | ARM64 Windows | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-pc-windows-msvc.tar.gz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256) |\n| [axolotlsay-aarch64-unknown-linux-gnu.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-unknown-linux-gnu.tar.gz) | ARM64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-unknown-linux-gnu.tar.gz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256) |\n\n",
   "releases": [
     {
       "app_name": "axolotlsay",
@@ -1946,10 +1948,13 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
         "axolotlsay-installer.ps1",
-        "axolotlsay.rb",
         "sha256.sum",
         "axolotlsay-aarch64-apple-darwin.tar.gz",
         "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
+        "axolotlsay-aarch64-pc-windows-msvc.tar.gz",
+        "axolotlsay-aarch64-pc-windows-msvc.tar.gz.sha256",
+        "axolotlsay-aarch64-unknown-linux-gnu.tar.gz",
+        "axolotlsay-aarch64-unknown-linux-gnu.tar.gz.sha256",
         "axolotlsay-x86_64-apple-darwin.tar.gz",
         "axolotlsay-x86_64-apple-darwin.tar.gz.sha256",
         "axolotlsay-x86_64-pc-windows-msvc.tar.gz",
@@ -2011,6 +2016,92 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "aarch64-apple-darwin"
       ]
     },
+    "axolotlsay-aarch64-pc-windows-msvc.tar.gz": {
+      "name": "axolotlsay-aarch64-pc-windows-msvc.tar.gz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "aarch64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "axolotlsay-aarch64-pc-windows-msvc-exe-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay.exe",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-aarch64-pc-windows-msvc.tar.gz.sha256"
+    },
+    "axolotlsay-aarch64-pc-windows-msvc.tar.gz.sha256": {
+      "name": "axolotlsay-aarch64-pc-windows-msvc.tar.gz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "aarch64-pc-windows-msvc"
+      ]
+    },
+    "axolotlsay-aarch64-unknown-linux-gnu.tar.gz": {
+      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.gz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "aarch64-unknown-linux-gnu"
+      ],
+      "assets": [
+        {
+          "name": "CHANGELOG.md",
+          "path": "CHANGELOG.md",
+          "kind": "changelog"
+        },
+        {
+          "name": "LICENSE-APACHE",
+          "path": "LICENSE-APACHE",
+          "kind": "license"
+        },
+        {
+          "name": "LICENSE-MIT",
+          "path": "LICENSE-MIT",
+          "kind": "license"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "axolotlsay-aarch64-unknown-linux-gnu-exe-axolotlsay",
+          "name": "axolotlsay",
+          "path": "axolotlsay",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "axolotlsay-aarch64-unknown-linux-gnu.tar.gz.sha256"
+    },
+    "axolotlsay-aarch64-unknown-linux-gnu.tar.gz.sha256": {
+      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.gz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "aarch64-unknown-linux-gnu"
+      ]
+    },
     "axolotlsay-installer.ps1": {
       "name": "axolotlsay-installer.ps1",
       "kind": "installer",
@@ -2026,6 +2117,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "kind": "installer",
       "target_triples": [
         "aarch64-apple-darwin",
+        "aarch64-pc-windows-gnu",
+        "aarch64-unknown-linux-gnu",
         "x86_64-apple-darwin",
         "x86_64-pc-windows-gnu",
         "x86_64-unknown-linux-gnu"
@@ -2162,18 +2255,6 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "x86_64-unknown-linux-gnu"
       ]
     },
-    "axolotlsay.rb": {
-      "name": "axolotlsay.rb",
-      "kind": "installer",
-      "target_triples": [
-        "aarch64-apple-darwin",
-        "x86_64-apple-darwin",
-        "x86_64-pc-windows-gnu",
-        "x86_64-unknown-linux-gnu"
-      ],
-      "install_hint": "brew install axolotlsay",
-      "description": "Install prebuilt binaries via Homebrew"
-    },
     "sha256.sum": {
       "name": "sha256.sum",
       "kind": "unified-checksum"
@@ -2219,6 +2300,46 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "cache_provider": "github"
           },
           {
+            "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "container": {
+              "image": "messense/cargo-xwin",
+              "host": "x86_64-unknown-linux-musl"
+            },
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-pc-windows-msvc",
+            "targets": [
+              "aarch64-pc-windows-msvc"
+            ],
+            "install_cargo_auditable": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
+            },
+            "packages_install": "if ! command -v cargo-xwin > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-xwin\nfi",
+            "cache_provider": "github"
+          },
+          {
+            "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
+            "targets": [
+              "aarch64-unknown-linux-gnu"
+            ],
+            "install_cargo_auditable": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
+            },
+            "packages_install": "if ! command -v cargo-zigbuild > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-zigbuild\nfi",
+            "cache_provider": "github"
+          },
+          {
             "runner": "macos-13",
             "host": "x86_64-apple-darwin",
             "install_dist": {
@@ -2236,20 +2357,25 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "cache_provider": "github"
           },
           {
-            "runner": "windows-2019",
-            "host": "x86_64-pc-windows-msvc",
+            "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "container": {
+              "image": "messense/cargo-xwin",
+              "host": "x86_64-unknown-linux-musl"
+            },
             "install_dist": {
-              "shell": "pwsh",
-              "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
             "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "targets": [
               "x86_64-pc-windows-msvc"
             ],
             "install_cargo_auditable": {
-              "shell": "pwsh",
-              "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
+            "packages_install": "if ! command -v cargo-xwin > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-xwin\nfi",
             "cache_provider": "github"
           },
           {
@@ -2277,3 +2403,296 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
   "linkage": [],
   "upload_files": []
 }
+
+================ release.yml ================
+# This file was autogenerated by dist: https://opensource.axo.dev/cargo-dist/
+#
+# Copyright 2022-2024, axodotdev
+# SPDX-License-Identifier: MIT or Apache-2.0
+#
+# CI that:
+#
+# * checks for a Git Tag that looks like a release
+# * builds artifacts with dist (archives, installers, hashes)
+# * uploads those artifacts to temporary workflow zip
+# * on success, uploads the artifacts to a GitHub Release
+#
+# Note that the GitHub Release will be created with a generated
+# title/body based on your changelogs.
+
+name: Release
+permissions:
+  "contents": "write"
+
+# This task will run whenever you push a git tag that looks like a version
+# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
+# PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
+# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
+#
+# If PACKAGE_NAME is specified, then the announcement will be for that
+# package (erroring out if it doesn't have the given version or isn't dist-able).
+#
+# If PACKAGE_NAME isn't specified, then the announcement will be for all
+# (dist-able) packages in the workspace with that version (this mode is
+# intended for workspaces with only one dist-able package, or with all dist-able
+# packages versioned/released in lockstep).
+#
+# If you push multiple tags at once, separate instances of this workflow will
+# spin up, creating an independent announcement for each one. However, GitHub
+# will hard limit this to 3 tags per commit, as it will assume more tags is a
+# mistake.
+#
+# If there's a prerelease-style suffix to the version, then the release(s)
+# will be marked as a prerelease.
+on:
+  pull_request:
+  push:
+    tags:
+      - '**[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  # Run 'dist plan' (or host) to determine what tasks we need to do
+  plan:
+    runs-on: "ubuntu-20.04"
+    outputs:
+      val: ${{ steps.plan.outputs.manifest }}
+      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
+      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
+      publishing: ${{ !github.event.pull_request }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dist
+        # we specify bash to get pipefail; it guards against the `curl` command
+        # failing. otherwise `sh` won't catch that `curl` returned non-0
+        shell: bash
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+      - name: Cache dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/dist
+      # sure would be cool if github gave us proper conditionals...
+      # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
+      # functionality based on whether this is a pull_request, and whether it's from a fork.
+      # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
+      # but also really annoying to build CI around when it needs secrets to work right.)
+      - id: plan
+        run: |
+          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          echo "dist ran successfully"
+          cat plan-dist-manifest.json
+          echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+      - name: "Upload dist-manifest.json"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-plan-dist-manifest
+          path: plan-dist-manifest.json
+
+  # Build and packages all the platform-specific things
+  build-local-artifacts:
+    name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
+    # Let the initial task tell us to not run (currently very blunt)
+    needs:
+      - plan
+    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
+    strategy:
+      fail-fast: false
+      # Target platforms/runners are computed by dist in create-release.
+      # Each member of the matrix has the following arguments:
+      #
+      # - runner: the github runner
+      # - dist-args: cli flags to pass to dist
+      # - install-dist: expression to run to install dist on the runner
+      #
+      # Typically there will be:
+      # - 1 "global" task that builds universal installers
+      # - N "local" tasks that build each platform's binaries and platform-specific installers
+      matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+    steps:
+      - name: enable windows longpaths
+        run: |
+          git config --global core.longpaths true
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
+      - name: Install dist
+        run: ${{ matrix.install_dist.run }}
+      # Get the dist-manifest
+      - name: Fetch local artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - name: Install dependencies
+        run: |
+          ${{ matrix.packages_install }}
+      - name: Build artifacts
+        run: |
+          # Actually do builds and make zips and whatnot
+          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          echo "dist ran successfully"
+      - id: cargo-dist
+        name: Post-build
+        # We force bash here just because github makes it really hard to get values up
+        # to "real" actions without writing to env-vars, and writing to env-vars has
+        # inconsistent syntax between shell and powershell.
+        shell: bash
+        run: |
+          # Parse out what we just built and upload it to scratch storage
+          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-build-local-${{ join(matrix.targets, '_') }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+
+  # Build and package all the platform-agnostic(ish) things
+  build-global-artifacts:
+    needs:
+      - plan
+      - build-local-artifacts
+    runs-on: "ubuntu-20.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install cached dist
+        uses: actions/download-artifact@v4
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/
+      - run: chmod +x ~/.cargo/bin/dist
+      # Get all the local artifacts for the global tasks to use (for e.g. checksums)
+      - name: Fetch local artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - id: cargo-dist
+        shell: bash
+        run: |
+          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
+          echo "dist ran successfully"
+
+          # Parse out what we just built and upload it to scratch storage
+          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
+          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-build-global
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+  # Determines if we should publish/announce
+  host:
+    needs:
+      - plan
+      - build-local-artifacts
+      - build-global-artifacts
+    # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
+    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: "ubuntu-20.04"
+    outputs:
+      val: ${{ steps.host.outputs.manifest }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install cached dist
+        uses: actions/download-artifact@v4
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/
+      - run: chmod +x ~/.cargo/bin/dist
+      # Fetch artifacts from scratch-storage
+      - name: Fetch artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - id: host
+        shell: bash
+        run: |
+          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
+          echo "artifacts uploaded and released successfully"
+          cat dist-manifest.json
+          echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
+      - name: "Upload dist-manifest.json"
+        uses: actions/upload-artifact@v4
+        with:
+          # Overwrite the previous copy
+          name: artifacts-dist-manifest
+          path: dist-manifest.json
+      # Create a GitHub Release while uploading all files to it
+      - name: "Download GitHub Artifacts"
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: artifacts
+          merge-multiple: true
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm -f artifacts/*-dist-manifest.json
+      - name: Create GitHub Release
+        env:
+          PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
+          ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
+          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
+          RELEASE_COMMIT: "${{ github.sha }}"
+        run: |
+          # Write and read notes from a file to avoid quoting breaking things
+          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+
+          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+
+  announce:
+    needs:
+      - plan
+      - host
+    # use "always() && ..." to allow us to wait for all publish jobs while
+    # still allowing individual publish jobs to skip themselves (for prereleases).
+    # "host" however must run to completion, no skipping allowed!
+    if: ${{ always() && needs.host.result == 'success' }}
+    runs-on: "ubuntu-20.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -66,10 +66,9 @@ The installer for axolotlsay 0.2.2
 
 This script detects what platform you're on and fetches an appropriate archive from
 https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2
-then unpacks the binaries and installs them to the first of the following locations
+then unpacks the binaries and installs them to
 
-    \$NO_SUCH_ENV_VAR/My Nonexistent Documents
-    \$MY_ENV_VAR/My Axolotlsay Documents
+    \$CARGO_HOME/bin (or \$HOME/.cargo/bin)
 
 It will then add that dir to PATH by adding the appropriate line to your shell profiles.
 
@@ -165,44 +164,8 @@ download_binary_and_run_installer() {
 
     # destructure selected archive info into locals
     case "$_artifact_name" in 
-        "axolotlsay-aarch64-apple-darwin.tar.gz")
-            _arch="aarch64-apple-darwin"
-            _zip_ext=".tar.gz"
-            _bins="axolotlsay"
-            _bins_js_array='"axolotlsay"'
-            _libs=""
-            _libs_js_array=""
-            _staticlibs=""
-            _staticlibs_js_array=""
-            _updater_name=""
-            _updater_bin=""
-            ;;
-        "axolotlsay-x86_64-apple-darwin.tar.gz")
-            _arch="x86_64-apple-darwin"
-            _zip_ext=".tar.gz"
-            _bins="axolotlsay"
-            _bins_js_array='"axolotlsay"'
-            _libs=""
-            _libs_js_array=""
-            _staticlibs=""
-            _staticlibs_js_array=""
-            _updater_name=""
-            _updater_bin=""
-            ;;
-        "axolotlsay-x86_64-pc-windows-msvc.tar.gz")
-            _arch="x86_64-pc-windows-msvc"
-            _zip_ext=".tar.gz"
-            _bins="axolotlsay.exe"
-            _bins_js_array='"axolotlsay.exe"'
-            _libs=""
-            _libs_js_array=""
-            _staticlibs=""
-            _staticlibs_js_array=""
-            _updater_name=""
-            _updater_bin=""
-            ;;
-        "axolotlsay-x86_64-unknown-linux-gnu.tar.gz")
-            _arch="x86_64-unknown-linux-gnu"
+        "axolotlsay-aarch64-unknown-linux-gnu.tar.gz")
+            _arch="aarch64-unknown-linux-gnu"
             _zip_ext=".tar.gz"
             _bins="axolotlsay"
             _bins_js_array='"axolotlsay"'
@@ -323,16 +286,7 @@ json_binary_aliases() {
     local _arch="$1"
 
     case "$_arch" in 
-    "aarch64-apple-darwin")
-        echo '{}'
-        ;;
-    "x86_64-apple-darwin")
-        echo '{}'
-        ;;
-    "x86_64-pc-windows-gnu")
-        echo '{}'
-        ;;
-    "x86_64-unknown-linux-gnu")
+    "aarch64-unknown-linux-gnu")
         echo '{}'
         ;;
     *)
@@ -346,28 +300,7 @@ aliases_for_binary() {
     local _arch="$2"
 
     case "$_arch" in 
-    "aarch64-apple-darwin")
-        case "$_bin" in
-        *)
-            echo ""
-            ;;
-        esac
-        ;;
-    "x86_64-apple-darwin")
-        case "$_bin" in
-        *)
-            echo ""
-            ;;
-        esac
-        ;;
-    "x86_64-pc-windows-gnu")
-        case "$_bin" in
-        *)
-            echo ""
-            ;;
-        esac
-        ;;
-    "x86_64-unknown-linux-gnu")
+    "aarch64-unknown-linux-gnu")
         case "$_bin" in
         *)
             echo ""
@@ -387,48 +320,8 @@ select_archive_for_arch() {
     # try each archive, checking runtime conditions like libc versions
     # accepting the first one that matches, as it's the best match
     case "$_true_arch" in 
-        "aarch64-apple-darwin")
-            _archive="axolotlsay-aarch64-apple-darwin.tar.gz"
-            if [ -n "$_archive" ]; then
-                echo "$_archive"
-                return 0
-            fi
-            _archive="axolotlsay-x86_64-apple-darwin.tar.gz"
-            if [ -n "$_archive" ]; then
-                echo "$_archive"
-                return 0
-            fi
-            ;;
-        "aarch64-pc-windows-msvc")
-            _archive="axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-            if [ -n "$_archive" ]; then
-                echo "$_archive"
-                return 0
-            fi
-            ;;
-        "x86_64-apple-darwin")
-            _archive="axolotlsay-x86_64-apple-darwin.tar.gz"
-            if [ -n "$_archive" ]; then
-                echo "$_archive"
-                return 0
-            fi
-            ;;
-        "x86_64-pc-windows-gnu")
-            _archive="axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-            if [ -n "$_archive" ]; then
-                echo "$_archive"
-                return 0
-            fi
-            ;;
-        "x86_64-pc-windows-msvc")
-            _archive="axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-            if [ -n "$_archive" ]; then
-                echo "$_archive"
-                return 0
-            fi
-            ;;
-        "x86_64-unknown-linux-gnu")
-            _archive="axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
+        "aarch64-unknown-linux-gnu")
+            _archive="axolotlsay-aarch64-unknown-linux-gnu.tar.gz"
             if ! check_glibc "2" "31"; then
                 _archive=""
             fi
@@ -524,10 +417,10 @@ install() {
     # to the older generic one
     if [ -n "${AXOLOTLSAY_INSTALL_DIR:-}" ]; then
         _force_install_dir="$AXOLOTLSAY_INSTALL_DIR"
-        _install_layout="flat"
+        _install_layout="cargo-home"
     elif [ -n "${CARGO_DIST_FORCE_INSTALL_DIR:-}" ]; then
         _force_install_dir="$CARGO_DIST_FORCE_INSTALL_DIR"
-        _install_layout="flat"
+        _install_layout="cargo-home"
     elif [ -n "$UNMANAGED_INSTALL" ]; then
         _force_install_dir="$UNMANAGED_INSTALL"
         _install_layout="flat"
@@ -579,27 +472,32 @@ install() {
         esac
     fi
     if [ -z "${_install_dir:-}" ]; then
-        _install_layout="flat"
-        # Install to $NO_SUCH_ENV_VAR/My Nonexistent Documents
-        if [ -n "${NO_SUCH_ENV_VAR:-}" ]; then
-            _install_dir="$NO_SUCH_ENV_VAR/My Nonexistent Documents"
-            _lib_install_dir="$_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$NO_SUCH_ENV_VAR/My Nonexistent Documents/env"
-            _install_dir_expr="$(replace_home "$_install_dir")"
-            _env_script_path_expr="$(replace_home "$_env_script_path")"
-        fi
-    fi
-    if [ -z "${_install_dir:-}" ]; then
-        _install_layout="flat"
-        # Install to $MY_ENV_VAR/My Axolotlsay Documents
-        if [ -n "${MY_ENV_VAR:-}" ]; then
-            _install_dir="$MY_ENV_VAR/My Axolotlsay Documents"
-            _lib_install_dir="$_install_dir"
-            _receipt_install_dir="$_install_dir"
-            _env_script_path="$MY_ENV_VAR/My Axolotlsay Documents/env"
-            _install_dir_expr="$(replace_home "$_install_dir")"
-            _env_script_path_expr="$(replace_home "$_env_script_path")"
+        _install_layout="cargo-home"
+        # first try $CARGO_HOME, then fallback to $HOME/.cargo
+        if [ -n "${CARGO_HOME:-}" ]; then
+            _receipt_install_dir="$CARGO_HOME"
+            _install_dir="$CARGO_HOME/bin"
+            _lib_install_dir="$CARGO_HOME/bin"
+            _env_script_path="$CARGO_HOME/env"
+            # Initially make this early-bound to erase the potentially-temporary env-var
+            _install_dir_expr="$_install_dir"
+            _env_script_path_expr="$_env_script_path"
+            # If CARGO_HOME was set but it ended up being the default $HOME-based path,
+            # then keep things late-bound. Otherwise bake the value for safety.
+            # This is what rustup does, and accurately reproducing it is useful.
+            if [ -n "${HOME:-}" ]; then
+                if [ "$HOME/.cargo/bin" = "$_install_dir" ]; then
+                    _install_dir_expr='$HOME/.cargo/bin'
+                    _env_script_path_expr='$HOME/.cargo/env'
+                fi
+            fi
+        elif [ -n "${HOME:-}" ]; then
+            _receipt_install_dir="$HOME/.cargo"
+            _install_dir="$HOME/.cargo/bin"
+            _lib_install_dir="$HOME/.cargo/bin"
+            _env_script_path="$HOME/.cargo/env"
+            _install_dir_expr='$HOME/.cargo/bin'
+            _env_script_path_expr='$HOME/.cargo/env'
         fi
     fi
 
@@ -1311,609 +1209,6 @@ verify_checksum() {
 
 download_binary_and_run_installer "$@" || exit 1
 
-================ axolotlsay.rb ================
-class Axolotlsay < Formula
-  desc "💬 a CLI for learning to distribute CLIs in rust"
-  homepage "https://github.com/axodotdev/axolotlsay"
-  version "0.2.2"
-  if OS.mac?
-    if Hardware::CPU.arm?
-      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz"
-    end
-    if Hardware::CPU.intel?
-      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz"
-    end
-  end
-  if OS.linux?
-    if Hardware::CPU.intel?
-      url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
-    end
-  end
-  license any_of: ["MIT", "Apache-2.0"]
-
-  BINARY_ALIASES = {
-    "aarch64-apple-darwin": {},
-    "x86_64-apple-darwin": {},
-    "x86_64-pc-windows-gnu": {},
-    "x86_64-unknown-linux-gnu": {}
-  }
-
-  def target_triple
-    cpu = Hardware::CPU.arm? ? "aarch64" : "x86_64"
-    os = OS.mac? ? "apple-darwin" : "unknown-linux-gnu"
-
-    "#{cpu}-#{os}"
-  end
-
-  def install_binary_aliases!
-    BINARY_ALIASES[target_triple.to_sym].each do |source, dests|
-      dests.each do |dest|
-        bin.install_symlink bin/source.to_s => dest
-      end
-    end
-  end
-
-  def install
-    if OS.mac? && Hardware::CPU.arm?
-      bin.install "axolotlsay"
-    end
-    if OS.mac? && Hardware::CPU.intel?
-      bin.install "axolotlsay"
-    end
-    if OS.linux? && Hardware::CPU.intel?
-      bin.install "axolotlsay"
-    end
-
-    install_binary_aliases!
-
-    # Homebrew will automatically install these, so we don't need to do that
-    doc_files = Dir["README.*", "readme.*", "LICENSE", "LICENSE.*", "CHANGELOG.*"]
-    leftover_contents = Dir["*"] - doc_files
-
-    # Install any leftover files in pkgshare; these are probably config or
-    # sample files.
-    pkgshare.install(*leftover_contents) unless leftover_contents.empty?
-  end
-end
-
-================ axolotlsay-installer.ps1 ================
-# Licensed under the MIT license
-# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-# option. This file may not be copied, modified, or distributed
-# except according to those terms.
-
-<#
-.SYNOPSIS
-
-The installer for axolotlsay 0.2.2
-
-.DESCRIPTION
-
-This script detects what platform you're on and fetches an appropriate archive from
-https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2
-then unpacks the binaries and installs them to the first of the following locations
-
-    $env:NO_SUCH_ENV_VAR/My Nonexistent Documents
-    $env:MY_ENV_VAR/My Axolotlsay Documents
-
-It will then add that dir to PATH by editing your Environment.Path registry key
-
-.PARAMETER ArtifactDownloadUrl
-The URL of the directory where artifacts can be fetched from
-
-.PARAMETER NoModifyPath
-Don't add the install directory to PATH
-
-.PARAMETER Help
-Print help
-
-#>
-
-param (
-    [Parameter(HelpMessage = "The URL of the directory where artifacts can be fetched from")]
-    [string]$ArtifactDownloadUrl = 'https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2',
-    [Parameter(HelpMessage = "Don't add the install directory to PATH")]
-    [switch]$NoModifyPath,
-    [Parameter(HelpMessage = "Print Help")]
-    [switch]$Help
-)
-
-$app_name = 'axolotlsay'
-$app_version = '0.2.2'
-if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
-} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
-  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
-} else {
-  $installer_base_url = "https://github.com"
-}
-if ($env:INSTALLER_DOWNLOAD_URL) {
-  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
-} else {
-  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
-}
-
-$receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
-"@
-$receipt_home = "${env:LOCALAPPDATA}\axolotlsay"
-
-if ($env:AXOLOTLSAY_DISABLE_UPDATE) {
-  $install_updater = $false
-} else {
-  $install_updater = $true
-}
-
-if ($NoModifyPath) {
-    Write-Information "-NoModifyPath has been deprecated; please set AXOLOTLSAY_NO_MODIFY_PATH=1 in the environment"
-}
-
-if ($env:AXOLOTLSAY_NO_MODIFY_PATH) {
-    $NoModifyPath = $true
-}
-
-$unmanaged_install = $env:AXOLOTLSAY_UNMANAGED_INSTALL
-
-if ($unmanaged_install) {
-  $NoModifyPath = $true
-  $install_updater = $false
-}
-
-function Install-Binary($install_args) {
-  if ($Help) {
-    Get-Help $PSCommandPath -Detailed
-    Exit
-  }
-
-  Initialize-Environment
-
-  # Platform info injected by dist
-  $platforms = @{
-    "aarch64-pc-windows-msvc" = @{
-      "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = @("axolotlsay.exe")
-      "libs" = @()
-      "staticlibs" = @()
-      "zip_ext" = ".tar.gz"
-      "aliases" = @{
-      }
-      "aliases_json" = '{}'
-    }
-    "x86_64-pc-windows-msvc" = @{
-      "artifact_name" = "axolotlsay-x86_64-pc-windows-msvc.tar.gz"
-      "bins" = @("axolotlsay.exe")
-      "libs" = @()
-      "staticlibs" = @()
-      "zip_ext" = ".tar.gz"
-      "aliases" = @{
-      }
-      "aliases_json" = '{}'
-    }
-  }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
-  # FIXME: add a flag that lets the user not do this step
-  try {
-    Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
-  } catch {
-    throw @"
-We encountered an error trying to perform the installation;
-please review the error messages below.
-
-$_
-"@
-  }
-}
-
-function Get-TargetTriple() {
-  try {
-    # NOTE: this might return X64 on ARM64 Windows, which is OK since emulation is available.
-    # It works correctly starting in PowerShell Core 7.3 and Windows PowerShell in Win 11 22H2.
-    # Ideally this would just be
-    #   [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-    # but that gets a type from the wrong assembly on Windows PowerShell (i.e. not Core)
-    $a = [System.Reflection.Assembly]::LoadWithPartialName("System.Runtime.InteropServices.RuntimeInformation")
-    $t = $a.GetType("System.Runtime.InteropServices.RuntimeInformation")
-    $p = $t.GetProperty("OSArchitecture")
-    # Possible OSArchitecture Values: https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.architecture
-    # Rust supported platforms: https://doc.rust-lang.org/stable/rustc/platform-support.html
-    switch ($p.GetValue($null).ToString())
-    {
-      "X86" { return "i686-pc-windows-msvc" }
-      "X64" { return "x86_64-pc-windows-msvc" }
-      "Arm" { return "thumbv7a-pc-windows-msvc" }
-      "Arm64" { return "aarch64-pc-windows-msvc" }
-    }
-  } catch {
-    # The above was added in .NET 4.7.1, so Windows PowerShell in versions of Windows
-    # prior to Windows 10 v1709 may not have this API.
-    Write-Verbose "Get-TargetTriple: Exception when trying to determine OS architecture."
-    Write-Verbose $_
-  }
-
-  # This is available in .NET 4.0. We already checked for PS 5, which requires .NET 4.5.
-  Write-Verbose("Get-TargetTriple: falling back to Is64BitOperatingSystem.")
-  if ([System.Environment]::Is64BitOperatingSystem) {
-    return "x86_64-pc-windows-msvc"
-  } else {
-    return "i686-pc-windows-msvc"
-  }
-}
-
-function Download($download_url, $platforms) {
-  $arch = Get-TargetTriple
-
-  if (-not $platforms.ContainsKey($arch)) {
-    $platforms_json = ConvertTo-Json $platforms
-    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
-  }
-
-  # Lookup what we expect this platform to look like
-  $info = $platforms[$arch]
-  $zip_ext = $info["zip_ext"]
-  $bin_names = $info["bins"]
-  $lib_names = $info["libs"]
-  $staticlib_names = $info["staticlibs"]
-  $artifact_name = $info["artifact_name"]
-
-  # Make a new temp dir to unpack things to
-  $tmp = New-Temp-Dir
-  $dir_path = "$tmp\$app_name$zip_ext"
-
-  # Download and unpack!
-  $url = "$download_url/$artifact_name"
-  Write-Information "Downloading $app_name $app_version ($arch)"
-  Write-Verbose "  from $url"
-  Write-Verbose "  to $dir_path"
-  $wc = New-Object Net.Webclient
-  $wc.downloadFile($url, $dir_path)
-
-  Write-Verbose "Unpacking to $tmp"
-
-  # Select the tool to unpack the files with.
-  #
-  # As of windows 10(?), powershell comes with tar preinstalled, but in practice
-  # it only seems to support .tar.gz, and not xz/zstd. Still, we should try to
-  # forward all tars to it in case the user has a machine that can handle it!
-  switch -Wildcard ($zip_ext) {
-    ".zip" {
-      Expand-Archive -Path $dir_path -DestinationPath "$tmp";
-      Break
-    }
-    ".tar.*" {
-      tar xf $dir_path --strip-components 1 -C "$tmp";
-      Break
-    }
-    Default {
-      throw "ERROR: unknown archive format $zip_ext"
-    }
-  }
-
-  # Let the next step know what to copy
-  $bin_paths = @()
-  foreach ($bin_name in $bin_names) {
-    Write-Verbose "  Unpacked $bin_name"
-    $bin_paths += "$tmp\$bin_name"
-  }
-  $lib_paths = @()
-  foreach ($lib_name in $lib_names) {
-    Write-Verbose "  Unpacked $lib_name"
-    $lib_paths += "$tmp\$lib_name"
-  }
-  $staticlib_paths = @()
-  foreach ($lib_name in $staticlib_names) {
-    Write-Verbose "  Unpacked $lib_name"
-    $staticlib_paths += "$tmp\$lib_name"
-  }
-
-  if (($null -ne $info["updater"]) -and $install_updater) {
-    $updater_id = $info["updater"]["artifact_name"]
-    $updater_url = "$download_url/$updater_id"
-    $out_name = "$tmp\axolotlsay-update.exe"
-
-    $wc.downloadFile($updater_url, $out_name)
-    $bin_paths += $out_name
-  }
-
-  return @{
-    "bin_paths" = $bin_paths
-    "lib_paths" = $lib_paths
-    "staticlib_paths" = $staticlib_paths
-  }
-}
-
-function Invoke-Installer($artifacts, $platforms) {
-  # Replaces the placeholder binary entry with the actual list of binaries
-  $arch = Get-TargetTriple
-
-  if (-not $platforms.ContainsKey($arch)) {
-    $platforms_json = ConvertTo-Json $platforms
-    throw "ERROR: could not find binaries for this platform. Last platform tried: $arch platform info: $platforms_json"
-  }
-
-  $info = $platforms[$arch]
-
-  # Forces the install to occur at this path, not the default
-  $force_install_dir = $null
-  $install_layout = "unspecified"
-  # Check the newer app-specific variable before falling back
-  # to the older generic one
-  if (($env:AXOLOTLSAY_INSTALL_DIR)) {
-    $force_install_dir = $env:AXOLOTLSAY_INSTALL_DIR
-    $install_layout = "flat"
-  } elseif (($env:CARGO_DIST_FORCE_INSTALL_DIR)) {
-    $force_install_dir = $env:CARGO_DIST_FORCE_INSTALL_DIR
-    $install_layout = "flat"
-  } elseif ($unmanaged_install) {
-    $force_install_dir = $unmanaged_install
-    $install_layout = "flat"
-  }
-
-  # Check if the install layout should be changed from `flat` to `cargo-home`
-  # for backwards compatible updates of applications that switched layouts.
-  if (($force_install_dir) -and ($install_layout -eq "flat")) {
-    # If the install directory is targeting the Cargo home directory, then
-    # we assume this application was previously installed that layout
-    # Note the installer passes the path with `\\` separators, but here they are
-    # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
-    # may not exist.
-    $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
-    }
-    if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
-      $install_layout = "cargo-home"
-    }
-  }
-
-  # The actual path we're going to install to
-  $dest_dir = $null
-  $dest_dir_lib = $null
-  # The install prefix we write to the receipt.
-  # For organized install methods like CargoHome, which have
-  # subdirectories, this is the root without `/bin`. For other
-  # methods, this is the same as `_install_dir`.
-  $receipt_dest_dir = $null
-  # Before actually consulting the configured install strategy, see
-  # if we're overriding it.
-  if (($force_install_dir)) {
-    switch ($install_layout) {
-      "hierarchical" {
-        $dest_dir = Join-Path $force_install_dir "bin"
-        $dest_dir_lib = Join-Path $force_install_dir "lib"
-      }
-      "cargo-home" {
-        $dest_dir = Join-Path $force_install_dir "bin"
-        $dest_dir_lib = $dest_dir
-      }
-      "flat" {
-        $dest_dir = $force_install_dir
-        $dest_dir_lib = $dest_dir
-      }
-      Default {
-        throw "Error: unrecognized installation layout: $install_layout"
-      }
-    }
-    $receipt_dest_dir = $force_install_dir
-  }
-  if (-Not $dest_dir) {
-    # Install to $env:NO_SUCH_ENV_VAR/My Nonexistent Documents
-    $dest_dir = if (($base_dir = $env:NO_SUCH_ENV_VAR)) {
-      Join-Path $base_dir "My Nonexistent Documents"
-    }
-    $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $dest_dir
-    $install_layout = "flat"
-  }
-  if (-Not $dest_dir) {
-    # Install to $env:MY_ENV_VAR/My Axolotlsay Documents
-    $dest_dir = if (($base_dir = $env:MY_ENV_VAR)) {
-      Join-Path $base_dir "My Axolotlsay Documents"
-    }
-    $dest_dir_lib = $dest_dir
-    $receipt_dest_dir = $dest_dir
-    $install_layout = "flat"
-  }
-
-  # Looks like all of the above assignments failed
-  if (-Not $dest_dir) {
-    throw "ERROR: could not find a valid path to install to; please check the installation instructions"
-  }
-
-  # The replace call here ensures proper escaping is inlined into the receipt
-  $receipt = $receipt.Replace('AXO_INSTALL_PREFIX', $receipt_dest_dir.replace("\", "\\"))
-  $receipt = $receipt.Replace('"install_layout":"unspecified"', -join('"install_layout":"', $install_layout, '"'))
-
-  $dest_dir = New-Item -Force -ItemType Directory -Path $dest_dir
-  $dest_dir_lib = New-Item -Force -ItemType Directory -Path $dest_dir_lib
-  Write-Information "Installing to $dest_dir"
-  # Just copy the binaries from the temp location to the install dir
-  foreach ($bin_path in $artifacts["bin_paths"]) {
-    $installed_file = Split-Path -Path "$bin_path" -Leaf
-    Copy-Item "$bin_path" -Destination "$dest_dir" -ErrorAction Stop
-    Remove-Item "$bin_path" -Recurse -Force -ErrorAction Stop
-    Write-Information "  $installed_file"
-
-    if (($dests = $info["aliases"][$installed_file])) {
-      $source = Join-Path "$dest_dir" "$installed_file"
-      foreach ($dest_name in $dests) {
-          $dest = Join-Path $dest_dir $dest_name
-          $null = New-Item -ItemType HardLink -Target "$source" -Path "$dest" -Force -ErrorAction Stop
-      }
-    }
-  }
-  foreach ($lib_path in $artifacts["lib_paths"]) {
-    $installed_file = Split-Path -Path "$lib_path" -Leaf
-    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
-    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
-    Write-Information "  $installed_file"
-  }
-  foreach ($lib_path in $artifacts["staticlib_paths"]) {
-    $installed_file = Split-Path -Path "$lib_path" -Leaf
-    Copy-Item "$lib_path" -Destination "$dest_dir_lib" -ErrorAction Stop
-    Remove-Item "$lib_path" -Recurse -Force -ErrorAction Stop
-    Write-Information "  $installed_file"
-  }
-
-  $formatted_bins = ($info["bins"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_BINS"', $formatted_bins)
-  $formatted_libs = ($info["libs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_DYLIBS"', $formatted_libs)
-  $formatted_staticlibs = ($info["staticlibs"] | ForEach-Object { '"' + $_ + '"' }) -join ","
-  $receipt = $receipt.Replace('"CARGO_DIST_STATICLIBS"', $formatted_staticlibs)
-  # Also replace the aliases with the arch-specific one
-  $receipt = $receipt.Replace('"binary_aliases":{}', -join('"binary_aliases":',  $info['aliases_json']))
-  if ($NoModifyPath) {
-    $receipt = $receipt.Replace('"modify_path":true', '"modify_path":false')
-  }
-
-  # Write the install receipt
-  if ($install_updater) {
-    $null = New-Item -Path $receipt_home -ItemType "directory" -ErrorAction SilentlyContinue
-    # Trying to get Powershell 5.1 (not 6+, which is fake and lies) to write utf8 is a crime
-    # because "Out-File -Encoding utf8" actually still means utf8BOM, so we need to pull out
-    # .NET's APIs which actually do what you tell them (also apparently utf8NoBOM is the
-    # default in newer .NETs but I'd rather not rely on that at this point).
-    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-    [IO.File]::WriteAllLines("$receipt_home/axolotlsay-receipt.json", "$receipt", $Utf8NoBomEncoding)
-  }
-
-  # Respect the environment, but CLI takes precedence
-  if ($null -eq $NoModifyPath) {
-    $NoModifyPath = $env:INSTALLER_NO_MODIFY_PATH
-  }
-
-  Write-Information "everything's installed!"
-  if (-not $NoModifyPath) {
-    Add-Ci-Path $dest_dir
-    if (Add-Path $dest_dir) {
-        Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
-        Write-Information ""
-        Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
-        Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
-    }
-  }
-}
-
-# Attempt to do CI-specific rituals to get the install-dir on PATH faster
-function Add-Ci-Path($OrigPathToAdd) {
-  # If GITHUB_PATH is present, then write install_dir to the file it refs.
-  # After each GitHub Action, the contents will be added to PATH.
-  # So if you put a curl | sh for this script in its own "run" step,
-  # the next step will have this dir on PATH.
-  #
-  # Note that GITHUB_PATH will not resolve any variables, so we in fact
-  # want to write the install dir and not an expression that evals to it
-  if (($gh_path = $env:GITHUB_PATH)) {
-    Write-Output "$OrigPathToAdd" | Out-File -FilePath "$gh_path" -Encoding utf8 -Append
-  }
-}
-
-# Try to add the given path to PATH via the registry
-#
-# Returns true if the registry was modified, otherwise returns false
-# (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
-
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
-
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
-
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
-    return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
-  }
-}
-
-function Initialize-Environment() {
-  If (($PSVersionTable.PSVersion.Major) -lt 5) {
-    throw @"
-Error: PowerShell 5 or later is required to install $app_name.
-Upgrade PowerShell:
-
-    https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell
-
-"@
-  }
-
-  # show notification to change execution policy:
-  $allowedExecutionPolicy = @('Unrestricted', 'RemoteSigned', 'ByPass')
-  If ((Get-ExecutionPolicy).ToString() -notin $allowedExecutionPolicy) {
-    throw @"
-Error: PowerShell requires an execution policy in [$($allowedExecutionPolicy -join ", ")] to run $app_name. For example, to set the execution policy to 'RemoteSigned' please run:
-
-    Set-ExecutionPolicy RemoteSigned -scope CurrentUser
-
-"@
-  }
-
-  # GitHub requires TLS 1.2
-  If ([System.Enum]::GetNames([System.Net.SecurityProtocolType]) -notcontains 'Tls12') {
-    throw @"
-Error: Installing $app_name requires at least .NET Framework 4.5
-Please download and install it first:
-
-    https://www.microsoft.com/net/download
-
-"@
-  }
-}
-
-function New-Temp-Dir() {
-  [CmdletBinding(SupportsShouldProcess)]
-  param()
-  $parent = [System.IO.Path]::GetTempPath()
-  [string] $name = [System.Guid]::NewGuid()
-  New-Item -ItemType Directory -Path (Join-Path $parent $name)
-}
-
-# PSScriptAnalyzer doesn't like how we use our params as globals, this calms it
-$Null = $ArtifactDownloadUrl, $NoModifyPath, $Help
-# Make Write-Information statements be visible
-$InformationPreference = "Continue"
-
-# The default interactive handler
-try {
-  Install-Binary "$Args"
-} catch {
-  Write-Information $_
-  exit 1
-}
-
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
 
@@ -1926,7 +1221,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
   "announcement_is_prerelease": false,
   "announcement_title": "Version 0.2.2",
   "announcement_changelog": "```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```",
-  "announcement_github_body": "## Release Notes\n\n```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Install axolotlsay 0.2.2\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\npowershell -ExecutionPolicy ByPass -c \"irm https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.ps1 | iex\"\n```\n\n### Install prebuilt binaries via Homebrew\n\n```sh\nbrew install axolotlsay\n```\n\n## Download axolotlsay 0.2.2\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz) | Apple Silicon macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-apple-darwin.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz) | Intel macOS | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz.sha256) |\n| [axolotlsay-x86_64-pc-windows-msvc.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz) | x64 Windows | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256) |\n| [axolotlsay-x86_64-unknown-linux-gnu.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz) | x64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256) |\n\n",
+  "announcement_github_body": "## Release Notes\n\n```text\n         +----------------------------------+\n         | now with arm64 linux binaries!!! |\n         +----------------------------------+\n        /\n≽(◕ ᴗ ◕)≼\n```\n\n## Install axolotlsay 0.2.2\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.sh | sh\n```\n\n## Download axolotlsay 0.2.2\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [axolotlsay-aarch64-unknown-linux-gnu.tar.gz](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-unknown-linux-gnu.tar.gz) | ARM64 Linux | [checksum](https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-unknown-linux-gnu.tar.gz.sha256) |\n\n",
   "releases": [
     {
       "app_name": "axolotlsay",
@@ -1945,17 +1240,9 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "source.tar.gz",
         "source.tar.gz.sha256",
         "axolotlsay-installer.sh",
-        "axolotlsay-installer.ps1",
-        "axolotlsay.rb",
         "sha256.sum",
-        "axolotlsay-aarch64-apple-darwin.tar.gz",
-        "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
-        "axolotlsay-x86_64-apple-darwin.tar.gz",
-        "axolotlsay-x86_64-apple-darwin.tar.gz.sha256",
-        "axolotlsay-x86_64-pc-windows-msvc.tar.gz",
-        "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256",
-        "axolotlsay-x86_64-unknown-linux-gnu.tar.gz",
-        "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256"
+        "axolotlsay-aarch64-unknown-linux-gnu.tar.gz",
+        "axolotlsay-aarch64-unknown-linux-gnu.tar.gz.sha256"
       ],
       "hosting": {
         "github": {
@@ -1968,11 +1255,11 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
     }
   ],
   "artifacts": {
-    "axolotlsay-aarch64-apple-darwin.tar.gz": {
-      "name": "axolotlsay-aarch64-apple-darwin.tar.gz",
+    "axolotlsay-aarch64-unknown-linux-gnu.tar.gz": {
+      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.gz",
       "kind": "executable-zip",
       "target_triples": [
-        "aarch64-apple-darwin"
+        "aarch64-unknown-linux-gnu"
       ],
       "assets": [
         {
@@ -1996,183 +1283,29 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
           "kind": "readme"
         },
         {
-          "id": "axolotlsay-aarch64-apple-darwin-exe-axolotlsay",
+          "id": "axolotlsay-aarch64-unknown-linux-gnu-exe-axolotlsay",
           "name": "axolotlsay",
           "path": "axolotlsay",
           "kind": "executable"
         }
       ],
-      "checksum": "axolotlsay-aarch64-apple-darwin.tar.gz.sha256"
+      "checksum": "axolotlsay-aarch64-unknown-linux-gnu.tar.gz.sha256"
     },
-    "axolotlsay-aarch64-apple-darwin.tar.gz.sha256": {
-      "name": "axolotlsay-aarch64-apple-darwin.tar.gz.sha256",
+    "axolotlsay-aarch64-unknown-linux-gnu.tar.gz.sha256": {
+      "name": "axolotlsay-aarch64-unknown-linux-gnu.tar.gz.sha256",
       "kind": "checksum",
       "target_triples": [
-        "aarch64-apple-darwin"
+        "aarch64-unknown-linux-gnu"
       ]
-    },
-    "axolotlsay-installer.ps1": {
-      "name": "axolotlsay-installer.ps1",
-      "kind": "installer",
-      "target_triples": [
-        "aarch64-pc-windows-msvc",
-        "x86_64-pc-windows-msvc"
-      ],
-      "install_hint": "powershell -ExecutionPolicy ByPass -c \"irm https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.ps1 | iex\"",
-      "description": "Install prebuilt binaries via powershell script"
     },
     "axolotlsay-installer.sh": {
       "name": "axolotlsay-installer.sh",
       "kind": "installer",
       "target_triples": [
-        "aarch64-apple-darwin",
-        "x86_64-apple-darwin",
-        "x86_64-pc-windows-gnu",
-        "x86_64-unknown-linux-gnu"
+        "aarch64-unknown-linux-gnu"
       ],
       "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-installer.sh | sh",
       "description": "Install prebuilt binaries via shell script"
-    },
-    "axolotlsay-x86_64-apple-darwin.tar.gz": {
-      "name": "axolotlsay-x86_64-apple-darwin.tar.gz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "x86_64-apple-darwin"
-      ],
-      "assets": [
-        {
-          "name": "CHANGELOG.md",
-          "path": "CHANGELOG.md",
-          "kind": "changelog"
-        },
-        {
-          "name": "LICENSE-APACHE",
-          "path": "LICENSE-APACHE",
-          "kind": "license"
-        },
-        {
-          "name": "LICENSE-MIT",
-          "path": "LICENSE-MIT",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "id": "axolotlsay-x86_64-apple-darwin-exe-axolotlsay",
-          "name": "axolotlsay",
-          "path": "axolotlsay",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "axolotlsay-x86_64-apple-darwin.tar.gz.sha256"
-    },
-    "axolotlsay-x86_64-apple-darwin.tar.gz.sha256": {
-      "name": "axolotlsay-x86_64-apple-darwin.tar.gz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "x86_64-apple-darwin"
-      ]
-    },
-    "axolotlsay-x86_64-pc-windows-msvc.tar.gz": {
-      "name": "axolotlsay-x86_64-pc-windows-msvc.tar.gz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "x86_64-pc-windows-msvc"
-      ],
-      "assets": [
-        {
-          "name": "CHANGELOG.md",
-          "path": "CHANGELOG.md",
-          "kind": "changelog"
-        },
-        {
-          "name": "LICENSE-APACHE",
-          "path": "LICENSE-APACHE",
-          "kind": "license"
-        },
-        {
-          "name": "LICENSE-MIT",
-          "path": "LICENSE-MIT",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "id": "axolotlsay-x86_64-pc-windows-msvc-exe-axolotlsay",
-          "name": "axolotlsay",
-          "path": "axolotlsay.exe",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256"
-    },
-    "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256": {
-      "name": "axolotlsay-x86_64-pc-windows-msvc.tar.gz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "x86_64-pc-windows-msvc"
-      ]
-    },
-    "axolotlsay-x86_64-unknown-linux-gnu.tar.gz": {
-      "name": "axolotlsay-x86_64-unknown-linux-gnu.tar.gz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "x86_64-unknown-linux-gnu"
-      ],
-      "assets": [
-        {
-          "name": "CHANGELOG.md",
-          "path": "CHANGELOG.md",
-          "kind": "changelog"
-        },
-        {
-          "name": "LICENSE-APACHE",
-          "path": "LICENSE-APACHE",
-          "kind": "license"
-        },
-        {
-          "name": "LICENSE-MIT",
-          "path": "LICENSE-MIT",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "id": "axolotlsay-x86_64-unknown-linux-gnu-exe-axolotlsay",
-          "name": "axolotlsay",
-          "path": "axolotlsay",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256"
-    },
-    "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256": {
-      "name": "axolotlsay-x86_64-unknown-linux-gnu.tar.gz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "x86_64-unknown-linux-gnu"
-      ]
-    },
-    "axolotlsay.rb": {
-      "name": "axolotlsay.rb",
-      "kind": "installer",
-      "target_triples": [
-        "aarch64-apple-darwin",
-        "x86_64-apple-darwin",
-        "x86_64-pc-windows-gnu",
-        "x86_64-unknown-linux-gnu"
-      ],
-      "install_hint": "brew install axolotlsay",
-      "description": "Install prebuilt binaries via Homebrew"
     },
     "sha256.sum": {
       "name": "sha256.sum",
@@ -2202,66 +1335,19 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
-            "runner": "macos-13",
-            "host": "x86_64-apple-darwin",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
-            "targets": [
-              "aarch64-apple-darwin"
-            ],
-            "install_cargo_auditable": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
-            },
-            "cache_provider": "github"
-          },
-          {
-            "runner": "macos-13",
-            "host": "x86_64-apple-darwin",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
-            "targets": [
-              "x86_64-apple-darwin"
-            ],
-            "install_cargo_auditable": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
-            },
-            "cache_provider": "github"
-          },
-          {
-            "runner": "windows-2019",
-            "host": "x86_64-pc-windows-msvc",
-            "install_dist": {
-              "shell": "pwsh",
-              "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
-            },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
-            "install_cargo_auditable": {
-              "shell": "pwsh",
-              "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
-            },
-            "cache_provider": "github"
-          },
-          {
             "runner": "ubuntu-20.04",
             "host": "x86_64-unknown-linux-gnu",
+            "container": {
+              "image": "quay.io/pypa/manylinux_2_28_x86_64",
+              "host": "aarch64-unknown-linux-gnu"
+            },
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
             "targets": [
-              "x86_64-unknown-linux-gnu"
+              "aarch64-unknown-linux-gnu"
             ],
             "install_cargo_auditable": {
               "shell": "sh",
@@ -2277,3 +1363,296 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
   "linkage": [],
   "upload_files": []
 }
+
+================ release.yml ================
+# This file was autogenerated by dist: https://opensource.axo.dev/cargo-dist/
+#
+# Copyright 2022-2024, axodotdev
+# SPDX-License-Identifier: MIT or Apache-2.0
+#
+# CI that:
+#
+# * checks for a Git Tag that looks like a release
+# * builds artifacts with dist (archives, installers, hashes)
+# * uploads those artifacts to temporary workflow zip
+# * on success, uploads the artifacts to a GitHub Release
+#
+# Note that the GitHub Release will be created with a generated
+# title/body based on your changelogs.
+
+name: Release
+permissions:
+  "contents": "write"
+
+# This task will run whenever you push a git tag that looks like a version
+# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
+# PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
+# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
+#
+# If PACKAGE_NAME is specified, then the announcement will be for that
+# package (erroring out if it doesn't have the given version or isn't dist-able).
+#
+# If PACKAGE_NAME isn't specified, then the announcement will be for all
+# (dist-able) packages in the workspace with that version (this mode is
+# intended for workspaces with only one dist-able package, or with all dist-able
+# packages versioned/released in lockstep).
+#
+# If you push multiple tags at once, separate instances of this workflow will
+# spin up, creating an independent announcement for each one. However, GitHub
+# will hard limit this to 3 tags per commit, as it will assume more tags is a
+# mistake.
+#
+# If there's a prerelease-style suffix to the version, then the release(s)
+# will be marked as a prerelease.
+on:
+  pull_request:
+  push:
+    tags:
+      - '**[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  # Run 'dist plan' (or host) to determine what tasks we need to do
+  plan:
+    runs-on: "ubuntu-20.04"
+    outputs:
+      val: ${{ steps.plan.outputs.manifest }}
+      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
+      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
+      publishing: ${{ !github.event.pull_request }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dist
+        # we specify bash to get pipefail; it guards against the `curl` command
+        # failing. otherwise `sh` won't catch that `curl` returned non-0
+        shell: bash
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+      - name: Cache dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/dist
+      # sure would be cool if github gave us proper conditionals...
+      # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
+      # functionality based on whether this is a pull_request, and whether it's from a fork.
+      # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
+      # but also really annoying to build CI around when it needs secrets to work right.)
+      - id: plan
+        run: |
+          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          echo "dist ran successfully"
+          cat plan-dist-manifest.json
+          echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+      - name: "Upload dist-manifest.json"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-plan-dist-manifest
+          path: plan-dist-manifest.json
+
+  # Build and packages all the platform-specific things
+  build-local-artifacts:
+    name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
+    # Let the initial task tell us to not run (currently very blunt)
+    needs:
+      - plan
+    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
+    strategy:
+      fail-fast: false
+      # Target platforms/runners are computed by dist in create-release.
+      # Each member of the matrix has the following arguments:
+      #
+      # - runner: the github runner
+      # - dist-args: cli flags to pass to dist
+      # - install-dist: expression to run to install dist on the runner
+      #
+      # Typically there will be:
+      # - 1 "global" task that builds universal installers
+      # - N "local" tasks that build each platform's binaries and platform-specific installers
+      matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+    steps:
+      - name: enable windows longpaths
+        run: |
+          git config --global core.longpaths true
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
+      - name: Install dist
+        run: ${{ matrix.install_dist.run }}
+      # Get the dist-manifest
+      - name: Fetch local artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - name: Install dependencies
+        run: |
+          ${{ matrix.packages_install }}
+      - name: Build artifacts
+        run: |
+          # Actually do builds and make zips and whatnot
+          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          echo "dist ran successfully"
+      - id: cargo-dist
+        name: Post-build
+        # We force bash here just because github makes it really hard to get values up
+        # to "real" actions without writing to env-vars, and writing to env-vars has
+        # inconsistent syntax between shell and powershell.
+        shell: bash
+        run: |
+          # Parse out what we just built and upload it to scratch storage
+          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-build-local-${{ join(matrix.targets, '_') }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+
+  # Build and package all the platform-agnostic(ish) things
+  build-global-artifacts:
+    needs:
+      - plan
+      - build-local-artifacts
+    runs-on: "ubuntu-20.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install cached dist
+        uses: actions/download-artifact@v4
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/
+      - run: chmod +x ~/.cargo/bin/dist
+      # Get all the local artifacts for the global tasks to use (for e.g. checksums)
+      - name: Fetch local artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - id: cargo-dist
+        shell: bash
+        run: |
+          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
+          echo "dist ran successfully"
+
+          # Parse out what we just built and upload it to scratch storage
+          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
+          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-build-global
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+  # Determines if we should publish/announce
+  host:
+    needs:
+      - plan
+      - build-local-artifacts
+      - build-global-artifacts
+    # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
+    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: "ubuntu-20.04"
+    outputs:
+      val: ${{ steps.host.outputs.manifest }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install cached dist
+        uses: actions/download-artifact@v4
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/
+      - run: chmod +x ~/.cargo/bin/dist
+      # Fetch artifacts from scratch-storage
+      - name: Fetch artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - id: host
+        shell: bash
+        run: |
+          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
+          echo "artifacts uploaded and released successfully"
+          cat dist-manifest.json
+          echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
+      - name: "Upload dist-manifest.json"
+        uses: actions/upload-artifact@v4
+        with:
+          # Overwrite the previous copy
+          name: artifacts-dist-manifest
+          path: dist-manifest.json
+      # Create a GitHub Release while uploading all files to it
+      - name: "Download GitHub Artifacts"
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: artifacts
+          merge-multiple: true
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm -f artifacts/*-dist-manifest.json
+      - name: Create GitHub Release
+        env:
+          PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
+          ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
+          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
+          RELEASE_COMMIT: "${{ github.sha }}"
+        run: |
+          # Write and read notes from a file to avoid quoting breaking things
+          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+
+          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+
+  announce:
+    needs:
+      - plan
+      - host
+    # use "always() && ..." to allow us to wait for all publish jobs while
+    # still allowing individual publish jobs to skip themselves (for prereleases).
+    # "host" however must run to completion, no skipping allowed!
+    if: ${{ always() && needs.host.result == 'success' }}
+    runs-on: "ubuntu-20.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
+snapshot_kind: text
 ---
 ================ axolotlsay-installer.sh ================
 #!/bin/sh
@@ -1339,7 +1340,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "host": "x86_64-unknown-linux-gnu",
             "container": {
               "image": "quay.io/pypa/manylinux_2_28_x86_64",
-              "host": "aarch64-unknown-linux-gnu"
+              "host": "aarch64-unknown-linux-gnu",
+              "package_manager": null
             },
             "install_dist": {
               "shell": "sh",

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -1,7 +1,6 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
-snapshot_kind: text
 ---
 ================ axolotl-brew.rb ================
 class AxolotlBrew < Formula
@@ -332,67 +331,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -500,6 +503,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -510,6 +514,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ join(matrix.targets, '-') }}
@@ -540,7 +551,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -1,7 +1,6 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
-snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -254,69 +253,73 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "host": "aarch64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
             "targets": [
               "aarch64-unknown-linux-gnu"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
             "cache_provider": "buildjet"
           },
           {
+            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "host": "aarch64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
             "targets": [
               "aarch64-unknown-linux-musl"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
-            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
             "cache_provider": "buildjet"
           },
           {
+            "runner": "buildjet-8vcpu-ubuntu-2204",
+            "host": "x86_64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "targets": [
               "x86_64-unknown-linux-gnu"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "buildjet"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-musl"
-            ],
             "runner": "buildjet-8vcpu-ubuntu-2204",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
+            "targets": [
+              "x86_64-unknown-linux-musl"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
             "cache_provider": "buildjet"
           }
         ]
@@ -438,6 +441,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -448,6 +452,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -474,7 +485,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -3779,67 +3779,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-n
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3961,6 +3965,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3971,6 +3976,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -3997,7 +4009,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -1,7 +1,6 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
-snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -254,67 +253,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -440,6 +443,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -450,6 +454,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -476,7 +487,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -1,7 +1,6 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
-snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -262,67 +261,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -450,6 +453,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -460,6 +464,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -486,7 +497,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -1,7 +1,6 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
-snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -255,67 +254,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -439,6 +442,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -449,6 +453,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -475,7 +486,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -2125,67 +2125,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://dl.bearcove.cloud/dump/dist-cross/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://dl.bearcove.cloud/dump/dist-cross/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://dl.bearcove.cloud/dump/dist-cross/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://dl.bearcove.cloud/dump/dist-cross/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://dl.bearcove.cloud/dump/dist-cross/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://dl.bearcove.cloud/dump/dist-cross/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -2307,6 +2311,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -2317,6 +2322,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -2343,7 +2355,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -3713,67 +3713,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3895,6 +3899,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3905,6 +3910,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -3931,7 +3943,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -4342,67 +4342,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -4524,6 +4528,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -4534,6 +4539,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ join(matrix.targets, '-') }}
@@ -4564,7 +4576,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_linux_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_linux_only.snap
@@ -1,7 +1,6 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
-snapshot_kind: text
 ---
 ================ axolotlsay.rb ================
 class Axolotlsay < Formula
@@ -177,19 +176,20 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -311,6 +311,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -321,6 +322,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -347,7 +355,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_macos_x86_64_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_macos_x86_64_only.snap
@@ -1,7 +1,6 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
-snapshot_kind: text
 ---
 ================ axolotlsay.rb ================
 class Axolotlsay < Formula
@@ -180,19 +179,20 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
-            "targets": [
-              "x86_64-apple-darwin"
-            ],
             "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           }
         ]
@@ -314,6 +314,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -324,6 +325,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -350,7 +358,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -3791,69 +3791,73 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "packages_install": "cat << EOF >Brewfile\ncask \"homebrew/cask/macfuse\"\nbrew \"libcue\"\nEOF\n\nbrew bundle install",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "packages_install": "cat << EOF >Brewfile\ncask \"homebrew/cask/macfuse\"\nbrew \"libcue\"\nEOF\n\nbrew bundle install",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3975,6 +3979,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3985,6 +3990,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -4011,7 +4023,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -3090,68 +3090,72 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "targets": [
               "x86_64-unknown-linux-gnu"
             ],
-            "runner": "ubuntu-20.04",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-musl"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
+            "targets": [
+              "x86_64-unknown-linux-musl"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
             "cache_provider": "github"
           }
         ]
@@ -3273,6 +3277,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3283,6 +3288,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -3309,7 +3321,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -3025,52 +3025,55 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-musl"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
+            "targets": [
+              "x86_64-unknown-linux-musl"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
             "cache_provider": "github"
           }
         ]
@@ -3192,6 +3195,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3202,6 +3206,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -3228,7 +3239,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -3713,67 +3713,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3895,6 +3899,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3905,6 +3910,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ join(matrix.targets, '-') }}
@@ -3935,7 +3947,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -254,67 +254,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -254,67 +254,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -3829,67 +3829,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -4011,6 +4015,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -4021,6 +4026,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -4047,7 +4059,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -2203,67 +2203,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -2385,6 +2389,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -2399,6 +2404,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -2425,7 +2437,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -2203,67 +2203,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -2385,6 +2389,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -2399,6 +2404,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -2425,7 +2437,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -1,7 +1,6 @@
 ---
 source: cargo-dist/tests/gallery/dist/snapshot.rs
 expression: self.payload
-snapshot_kind: text
 ---
 ================ sha256.sum ================
 CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.gz
@@ -254,67 +253,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -436,6 +439,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -446,6 +450,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -472,7 +483,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -3831,67 +3831,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -4013,6 +4017,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -4023,6 +4028,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -4049,7 +4061,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -3713,67 +3713,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3895,6 +3899,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3905,6 +3910,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -3931,7 +3943,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -3713,67 +3713,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3895,6 +3899,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3905,6 +3910,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -3931,7 +3943,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -3713,67 +3713,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3895,6 +3899,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3905,6 +3910,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -3931,7 +3943,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -3713,67 +3713,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3905,6 +3909,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3915,6 +3920,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ join(matrix.targets, '-') }}
@@ -3945,7 +3957,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -3713,67 +3713,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]
@@ -3895,6 +3899,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -3905,6 +3910,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -3931,7 +3943,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -2203,67 +2203,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -2179,67 +2179,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -2179,67 +2179,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -2179,67 +2179,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -2179,67 +2179,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -2179,67 +2179,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -2179,67 +2179,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -2179,67 +2179,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -2179,67 +2179,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -2202,67 +2202,71 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "targets": [
               "x86_64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/vSOME_VERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -522,117 +522,124 @@ stdout:
       "artifacts_matrix": {
         "include": [
           {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "runner": "macos-13",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
             "cache_provider": "github"
           },
           {
+            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "host": "aarch64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
             "targets": [
               "aarch64-unknown-linux-gnu"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
             "cache_provider": "buildjet"
           },
           {
+            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
+            "host": "aarch64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
             "targets": [
               "aarch64-unknown-linux-musl"
             ],
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
-            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
             "cache_provider": "buildjet"
           },
           {
-            "targets": [
-              "x86_64-apple-darwin"
-            ],
             "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ],
             "runner": "windows-2019",
+            "host": "x86_64-pc-windows-msvc",
             "install_dist": {
               "shell": "pwsh",
               "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.ps1 | iex"
             },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
             "install_cargo_auditable": {
               "shell": "pwsh",
               "run": "powershell -c \"irm https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.ps1 | iex\""
             },
-            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
             "cache_provider": "github"
           },
           {
+            "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "targets": [
               "x86_64-unknown-linux-gnu"
             ],
-            "runner": "ubuntu-20.04",
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
-            },
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
             "cache_provider": "github"
           },
           {
-            "targets": [
-              "x86_64-unknown-linux-musl"
-            ],
             "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
             },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
+            "targets": [
+              "x86_64-unknown-linux-musl"
+            ],
             "install_cargo_auditable": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
-            "packages_install": "sudo apt-get update && sudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
             "cache_provider": "github"
           }
         ]


### PR DESCRIPTION
This PRs makes dist aware of the host/target divide, and teaches it to install and use tools like `cargo-zigbuild` and `cargo-xwin`.

Additionally, it teaches dist to run local jobs in containers (like the `manylinux` ones for compat reason, or the cargo-xwin ones, for "fast cross-compile" reasons).