### PR TITLE
Use `$HOME` instead of `$env:HOME` when constructing default Cargo home path

### DIFF
--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -311,7 +311,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1691,7 +1691,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1717,7 +1717,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1669,7 +1669,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1644,7 +1644,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1644,7 +1644,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1691,7 +1691,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1695,7 +1695,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1664,7 +1664,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -1596,7 +1596,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1660,7 +1660,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"
@@ -3577,7 +3577,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1695,7 +1695,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1596,7 +1596,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1596,7 +1596,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1669,7 +1669,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1661,7 +1661,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1644,7 +1644,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1644,7 +1644,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1644,7 +1644,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1644,7 +1644,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1658,7 +1658,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1644,7 +1644,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1644,7 +1644,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1644,7 +1644,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1644,7 +1644,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1658,7 +1658,7 @@ function Invoke-Installer($artifacts, $platforms) {
     # `\` so we normalize for comparison. We don't use `Resolve-Path` because they
     # may not exist.
     $cargo_home = if ($env:CARGO_HOME) { $env:CARGO_HOME } else {
-        Join-Path $(if ($env:HOME) { $env:HOME } else { "." }) ".cargo"
+        Join-Path $(if ($HOME) { $HOME } else { "." }) ".cargo"
     }
     if ($force_install_dir.Replace('\\', '\') -eq $cargo_home) {
       $install_layout = "cargo-home"


### PR DESCRIPTION
Fix for the patch in https://github.com/axodotdev/cargo-dist/pull/1538 

The latter does not work on some machines and `$HOME` is consistent with other usage in the script.
