### PR TITLE
Fix cache misses in CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
     env:
       # runtest the installer scripts
       RUIN_MY_COMPUTER_WITH_INSTALLERS: all
-      CARGO_DIST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       # Test the cross-product of these platforms+toolchains
       matrix:
@@ -119,6 +118,7 @@ jobs:
       - run: cargo test --workspace
         env:
           PWD: ${{ env.GITHUB_WORKSPACE }}
+          CARGO_DIST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Test the examples (default features)
       # - run: cargo test --workspace --examples --bins
       #  env:


### PR DESCRIPTION
The `rust-cache` action uses environment variables as part of the cache key:

```
# A whitespace separated list of env-var *prefixes* who's value contributes
# to the environment cache key.
# The env-vars are matched by *prefix*, so the default `RUST` var will
# match all of `RUSTC`, `RUSTUP_*`, `RUSTFLAGS`, `RUSTDOC_*`, etc.
# default: "CARGO CC CFLAGS CXX CMAKE RUST"
env-vars: ""
```

Since the per-run `GITHUB_TOKEN` was being placed in the `CARGO_DIST_GITHUB_TOKEN` variable (which matches the defaults above), each test run had a unique cache key and every cache lookup in CI was a cache miss. Downloading and compiling on Windows (as an example) takes >8m with no cache so this should provide a dramatic speed-up.

I tested this by pushing an empty commit to the branch and observed that the cache key was unchanged. If you want, I can push another empty commit here to demonstrate the fix and speed-up, but it looks like you don't squash merge so I shall not by default.