### PR TITLE
Update own dist and test cross-compiling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.25.2-prerelease.2/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.26.0-prerelease.1/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -111,6 +111,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -121,6 +122,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -151,7 +159,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "0.26.0-prerelease.1"
+version = "0.26.0-prerelease.2"
 dependencies = [
  "axoasset",
  "axoprocess",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.26.0-prerelease.1"
+version = "0.26.0-prerelease.2"
 dependencies = [
  "axoasset",
  "axocli",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.26.0-prerelease.1"
+version = "0.26.0-prerelease.2"
 dependencies = [
  "camino",
  "gazenot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
 homepage = "https://opensource.axo.dev/cargo-dist/"
-version = "0.26.0-prerelease.1"
+version = "0.26.0-prerelease.2"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!
-cargo-dist-schema = { version = "=0.26.0-prerelease.1", path = "cargo-dist-schema" }
-axoproject = { version = "=0.26.0-prerelease.1", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
+cargo-dist-schema = { version = "=0.26.0-prerelease.2", path = "cargo-dist-schema" }
+axoproject = { version = "=0.26.0-prerelease.2", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
 
 # first-party deps
 axocli = { version = "0.2.0" }

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -539,8 +539,13 @@ stdout:
             "cache_provider": "github"
           },
           {
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
-            "host": "aarch64-unknown-linux-gnu",
+            "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "container": {
+              "image": "quay.io/pypa/manylinux_2_28_x86_64",
+              "host": "x86_64-unknown-linux-musl",
+              "package_manager": null
+            },
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
@@ -553,11 +558,17 @@ stdout:
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "cache_provider": "buildjet"
+            "packages_install": "if ! command -v cargo-zigbuild > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-zigbuild\nfi",
+            "cache_provider": "github"
           },
           {
-            "runner": "buildjet-8vcpu-ubuntu-2204-arm",
-            "host": "aarch64-unknown-linux-gnu",
+            "runner": "ubuntu-20.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "container": {
+              "image": "quay.io/pypa/manylinux_2_28_x86_64",
+              "host": "x86_64-unknown-linux-musl",
+              "package_manager": null
+            },
             "install_dist": {
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
@@ -570,8 +581,8 @@ stdout:
               "shell": "sh",
               "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-secure-code/cargo-auditable/releases/latest/download/cargo-auditable-installer.sh | sh"
             },
-            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
-            "cache_provider": "buildjet"
+            "packages_install": "if ! command -v cargo-zigbuild > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-zigbuild\nfi",
+            "cache_provider": "github"
           },
           {
             "runner": "macos-13",

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.25.2-prerelease.2"
+cargo-dist-version = "0.26.0-prerelease.1"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -32,9 +32,13 @@ install-path = "CARGO_HOME"
 artifacts = ["dist-manifest-schema.json"]
 build = ["cargo", "run", "--release", "--", "dist", "manifest-schema", "--output=dist-manifest-schema.json"]
 
-[dist.github-custom-runners]
-aarch64-unknown-linux-gnu = "buildjet-8vcpu-ubuntu-2204-arm"
-aarch64-unknown-linux-musl = "buildjet-8vcpu-ubuntu-2204-arm"
-
 [dist.bin-aliases]
 "dist" = ["cargo-dist"]
+
+[dist.github-custom-runners.aarch64-unknown-linux-gnu.container]
+image = "quay.io/pypa/manylinux_2_28_x86_64"
+host = "x86_64-unknown-linux-musl"
+
+[dist.github-custom-runners.aarch64-unknown-linux-musl.container]
+image = "quay.io/pypa/manylinux_2_28_x86_64"
+host = "x86_64-unknown-linux-musl"


### PR DESCRIPTION
This updates to the new prerelease and configures us to cross-compile to aarch64-linux instead of using Buildjet runners. It also sets the PR build mode to "upload" so we can see if it works.