### PR TITLE
Explicitly set manifest path when building MSI with WiX

### DIFF
--- a/cargo-dist/src/backend/installer/msi.rs
+++ b/cargo-dist/src/backend/installer/msi.rs
@@ -38,6 +38,7 @@ impl MsiInstallerInfo {
         info!("building an msi: {}", self.file_path);
 
         let mut b = wix::create::Builder::new();
+        b.input(Some(self.manifest_path.as_str()));
         // Build this specific package
         b.package(Some(&self.pkg_spec));
         // dist already did the build for us


### PR DESCRIPTION
Use an explicit manifest path when building MSI with WiX, in case Cargo.toml is in a sub-folder.

Unfortunately I missed this in https://github.com/axodotdev/cargo-dist/pull/1454.