### PR TITLE
Have workflows run `dist plan` on all known tags.

### DIFF
--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -134,6 +134,8 @@ pub enum Commands {
     /// Report on the dynamic libraries used by the built artifacts.
     #[clap(disable_version_flag = true)]
     Linkage(LinkageArgs),
+    /// List all version tags known by dist.
+    ListTags(ListTagsArgs),
     /// Generate the final build manifest without running any builds.
     ///
     /// This command is designed to match the exact behaviour of
@@ -331,6 +333,9 @@ pub struct LinkageArgs {
     #[clap(long)]
     pub from_json: Option<String>,
 }
+
+#[derive(Args, Clone, Debug)]
+pub struct ListTagsArgs {}
 
 #[derive(Args, Clone, Debug)]
 pub struct HelpMarkdownArgs {}

--- a/cargo-dist/tests/snapshots/long-help.snap
+++ b/cargo-dist/tests/snapshots/long-help.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/cli-tests.rs
 expression: format_outputs(&output)
+snapshot_kind: text
 ---
 stdout:
 Professional packaging and distribution for ambitious developers.
@@ -15,6 +16,7 @@ Commands:
   init        Setup or update dist
   generate    Generate one or more pieces of configuration
   linkage     Report on the dynamic libraries used by the built artifacts
+  list-tags   List all version tags known by dist
   manifest    Generate the final build manifest without running any builds
   plan        Get a plan of what to build (and check project status)
   host        Host artifacts

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/cli-tests.rs
 expression: format_outputs(&output)
+snapshot_kind: text
 ---
 stdout:
 # dist CLI manual
@@ -23,6 +24,7 @@ dist <COMMAND>
 * [init](#cargo-dist-init): Setup or update dist
 * [generate](#cargo-dist-generate): Generate one or more pieces of configuration
 * [linkage](#cargo-dist-linkage): Report on the dynamic libraries used by the built artifacts
+* [list-tags](#cargo-dist-list-tags): List all version tags known by dist
 * [manifest](#cargo-dist-manifest): Generate the final build manifest without running any builds
 * [plan](#cargo-dist-plan): Get a plan of what to build (and check project status)
 * [host](#cargo-dist-host): Host artifacts
@@ -235,6 +237,23 @@ Print help (see a summary with '-h')
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
+## dist list-tags
+List all version tags known by dist
+
+### Usage
+
+```text
+dist list-tags [OPTIONS]
+```
+
+### Options
+#### `-h, --help`
+Print help (see a summary with '-h')
+
+### GLOBAL OPTIONS
+This subcommand accepts all the [global options](#global-options)
+
+<br><br><br>
 ## dist manifest
 Generate the final build manifest without running any builds.
 
@@ -395,6 +414,7 @@ dist help [COMMAND]
 * [init](#cargo-dist-init): Setup or update dist
 * [generate](#cargo-dist-generate): Generate one or more pieces of configuration
 * [linkage](#cargo-dist-linkage): Report on the dynamic libraries used by the built artifacts
+* [list-tags](#cargo-dist-list-tags): List all version tags known by dist
 * [manifest](#cargo-dist-manifest): Generate the final build manifest without running any builds
 * [plan](#cargo-dist-plan): Get a plan of what to build (and check project status)
 * [host](#cargo-dist-host): Host artifacts

--- a/cargo-dist/tests/snapshots/short-help.snap
+++ b/cargo-dist/tests/snapshots/short-help.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/cli-tests.rs
 expression: format_outputs(&output)
+snapshot_kind: text
 ---
 stdout:
 Professional packaging and distribution for ambitious developers
@@ -13,6 +14,7 @@ Commands:
   init        Setup or update dist
   generate    Generate one or more pieces of configuration
   linkage     Report on the dynamic libraries used by the built artifacts
+  list-tags   List all version tags known by dist
   manifest    Generate the final build manifest without running any builds
   plan        Get a plan of what to build (and check project status)
   host        Host artifacts


### PR DESCRIPTION
General idea:
- add a command (or flag for dist plan) that prints a JSON representation of all possible tags
- in the generated workflow, use that new command to determine what tags there are, and run `dist plan --output-format=json --tag=${TAG} > plan-dist-manifest-${TAG}.json` for each one

Replaces #1560.