### PR TITLE
chore: set rust-version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
 homepage = "https://opensource.axo.dev/cargo-dist/"
 version = "0.26.0-prerelease.2"
+rust-version = "1.70.0"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!

--- a/axoproject/Cargo.toml
+++ b/axoproject/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+rust-version.workspace = true
 exclude = [
   "book/*",
   "src/snapshots/*",

--- a/cargo-dist-schema/Cargo.toml
+++ b/cargo-dist-schema/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+rust-version.workspace = true
 exclude = [
   "book/*",
   "src/snapshots/*",

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+rust-version.workspace = true
 readme = "../README.md"
 exclude = [
   "book/*",


### PR DESCRIPTION
We've had an informal MSRV, but didn't really enforce it anywhere. 1.70.0 was picked somewhat arbitrarily.

This is mainly for the benefit of `cargo install` users.