### PR TITLE
feat: update axoupdater, fetch known-good version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "axoupdater"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb8d8889305a413a040f281197bb2f8982a1d25c9696707cab350e3cc780ba5"
+checksum = "a70b7d3a9ea86ef8d17dada23f2c42518ed4b75dd6a8ff761f8988b448db8454"
 dependencies = [
  "axoasset",
  "axoprocess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ axoproject = { version = "=0.26.1", path = "axoproject", default-features = fals
 
 # first-party deps
 axocli = { version = "0.2.0" }
-axoupdater = { version = "0.8.1" }
+axoupdater = { version = "0.8.2" }
 axotag = "0.2.0"
 axoasset = { version = "1.2.0", features = ["json-serde", "toml-serde", "toml-edit", "yaml-serde", "compression", "remote"] }
 axoprocess = { version = "0.2.0" }

--- a/cargo-dist/src/config/v0.rs
+++ b/cargo-dist/src/config/v0.rs
@@ -426,6 +426,10 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub install_updater: Option<bool>,
 
+    /// Whether to always use the latest axoupdater instead of a known-good version
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub always_use_latest_updater: Option<bool>,
+
     /// Whether artifacts/installers for this app should be displayed in release bodies
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display: Option<bool>,
@@ -533,6 +537,7 @@ impl DistMetadata {
             bin_aliases: _,
             tag_namespace: _,
             install_updater: _,
+            always_use_latest_updater: _,
             github_releases_repo: _,
             github_releases_submodule_path: _,
             display: _,
@@ -634,6 +639,7 @@ impl DistMetadata {
             bin_aliases,
             tag_namespace,
             install_updater,
+            always_use_latest_updater,
             github_releases_repo,
             github_releases_submodule_path,
             display,
@@ -817,6 +823,9 @@ impl DistMetadata {
         }
         if install_updater.is_none() {
             *install_updater = workspace_config.install_updater;
+        }
+        if always_use_latest_updater.is_none() {
+            *always_use_latest_updater = workspace_config.always_use_latest_updater;
         }
         if display.is_none() {
             *display = workspace_config.display;

--- a/cargo-dist/src/config/v0_to_v1.rs
+++ b/cargo-dist/src/config/v0_to_v1.rs
@@ -78,6 +78,7 @@ impl DistMetadata {
             bin_aliases,
             tag_namespace,
             install_updater,
+            always_use_latest_updater,
             display,
             display_name,
             package_libraries,
@@ -314,7 +315,8 @@ impl DistMetadata {
             || install_success_msg.is_some()
             || install_libraries.is_some()
             || bin_aliases.is_some()
-            || install_updater.is_some();
+            || install_updater.is_some()
+            || always_use_latest_updater.is_some();
         let installer_layer = needs_installer_layer.then_some(InstallerLayer {
             common: CommonInstallerLayer {
                 install_path,
@@ -329,6 +331,7 @@ impl DistMetadata {
             shell: shell_installer_layer,
             pkg: pkg_installer_layer,
             updater: install_updater,
+            always_use_latest_updater,
         });
 
         // publish

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -456,6 +456,7 @@ fn get_new_dist_metadata(
             bin_aliases: None,
             tag_namespace: None,
             install_updater: None,
+            always_use_latest_updater: None,
             display: None,
             display_name: None,
             package_libraries: None,
@@ -951,6 +952,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         hosting,
         tag_namespace,
         install_updater,
+        always_use_latest_updater,
         display,
         display_name,
         github_release,
@@ -1338,6 +1340,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "install-updater",
         "# Whether to install an updater program\n",
         *install_updater,
+    );
+
+    apply_optional_value(
+        table,
+        "always-use-latest-updater",
+        "# Whether to always use the latest updater instead of a specific known-good version\n",
+        *always_use_latest_updater,
     );
 
     apply_optional_value(

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -251,9 +251,12 @@ fn run_build_step(
     Ok(())
 }
 
-const AXOUPDATER_ASSET_ROOT: &str =
-    "https://github.com/axodotdev/axoupdater/releases/latest/download";
+const AXOUPDATER_ASSET_ROOT: &str = "https://github.com/axodotdev/axoupdater/releases";
 const AXOUPDATER_MINIMUM_VERSION: &str = "0.7.0";
+
+fn axoupdater_asset_root() -> String {
+    format!("{AXOUPDATER_ASSET_ROOT}/download/v{}", axoupdater::VERSION)
+}
 
 /// Fetches an installer executable and installs it in the expected target path.
 pub fn fetch_updater(dist_graph: &DistGraph, updater: &UpdaterStep) -> DistResult<()> {
@@ -263,7 +266,8 @@ pub fn fetch_updater(dist_graph: &DistGraph, updater: &UpdaterStep) -> DistResul
         ".tar.xz"
     };
     let expected_url = format!(
-        "{AXOUPDATER_ASSET_ROOT}/axoupdater-cli-{}{ext}",
+        "{}/axoupdater-cli-{}{ext}",
+        axoupdater_asset_root(),
         updater.target_triple
     );
 

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -254,6 +254,10 @@ fn run_build_step(
 const AXOUPDATER_ASSET_ROOT: &str = "https://github.com/axodotdev/axoupdater/releases";
 const AXOUPDATER_MINIMUM_VERSION: &str = "0.7.0";
 
+fn axoupdater_latest_asset_root() -> String {
+    format!("{AXOUPDATER_ASSET_ROOT}/latest/download")
+}
+
 fn axoupdater_asset_root() -> String {
     format!("{AXOUPDATER_ASSET_ROOT}/download/v{}", axoupdater::VERSION)
 }
@@ -265,10 +269,16 @@ pub fn fetch_updater(dist_graph: &DistGraph, updater: &UpdaterStep) -> DistResul
     } else {
         ".tar.xz"
     };
+
+    let asset_root = if updater.use_latest {
+        axoupdater_latest_asset_root()
+    } else {
+        axoupdater_asset_root()
+    };
+
     let expected_url = format!(
         "{}/axoupdater-cli-{}{ext}",
-        axoupdater_asset_root(),
-        updater.target_triple
+        asset_root, updater.target_triple
     );
 
     let handle = tokio::runtime::Handle::current();

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -895,6 +895,7 @@ unix-archive = ".tar.gz"
 windows-archive = ".tar.gz"
 npm-scope ="@axodotdev"
 install-updater = true
+always-use-latest-updater = true
 
 [package.metadata.wix]
 upgrade-guid = "B36177BE-EA4D-44FB-B05C-EDDABDAA95CA"


### PR DESCRIPTION
Instead of always fetching the latest axoupdater, fetch the version that this version of dist itself uses as a library. That way, we're always fetching something predictable.