### PR TITLE
docs: fix typo in glibc config

### DIFF
--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -520,7 +520,7 @@ For instance for packages that are a library and a CLI binary, some developers p
 > ```toml
 > [dist.min-glibc-version]
 > # Override glibc version for specific target triplets
-> aarch64-unknown-linux-gnu "2.19"
+> aarch64-unknown-linux-gnu = "2.19"
 > x86_64-unknown-linux-gnu = "2.18"
 > # Override all remaining glibc versions.
 > "*" = "2.17"


### PR DESCRIPTION
This is the one thing that gets rendered as a syntax error in the normal view... because it *is* a typo, turns out. Just a missing character.