### PR TITLE
Refactor `dist init` and split out `dist migrate`

### DIFF
--- a/cargo-dist/src/cli.rs
+++ b/cargo-dist/src/cli.rs
@@ -124,6 +124,8 @@ pub enum Commands {
     /// also handle updating your project to a new version of dist if you're running one.
     #[clap(disable_version_flag = true)]
     Init(InitArgs),
+    /// Migrate to the latest configuration variant.
+    Migrate(MigrateArgs),
     /// Generate one or more pieces of configuration
     #[clap(disable_version_flag = true)]
     Generate(GenerateArgs),
@@ -274,6 +276,9 @@ pub struct InitArgs {
     #[clap(long, value_delimiter(','))]
     pub hosting: Vec<HostingStyle>,
 }
+
+#[derive(Args, Clone, Debug)]
+pub struct MigrateArgs {}
 
 /// Which style(s) of configuration to generate
 #[derive(ValueEnum, Copy, Clone, Debug)]

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -37,7 +37,7 @@ use temp_dir::TempDir;
 use tracing::info;
 
 use errors::*;
-pub use init::{do_init, InitArgs};
+pub use init::{do_init, do_migrate, InitArgs};
 pub use tasks::*;
 
 pub mod announce;

--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -20,7 +20,7 @@ use console::Term;
 use miette::{miette, IntoDiagnostic};
 use net::ClientSettings;
 
-use crate::cli::{BuildArgs, GenerateArgs, GenerateCiArgs, InitArgs, LinkageArgs};
+use crate::cli::{BuildArgs, GenerateArgs, GenerateCiArgs, InitArgs, LinkageArgs, MigrateArgs};
 
 mod cli;
 
@@ -49,6 +49,7 @@ fn real_main(cli: &axocli::CliApp<Cli>) -> Result<(), miette::Report> {
     let config = &cli.config;
     match &config.command {
         Commands::Init(args) => cmd_init(config, args),
+        Commands::Migrate(args) => cmd_migrate(config, args),
         Commands::Generate(args) => cmd_generate(config, args),
         Commands::GenerateCi(args) => cmd_generate_ci(config, args),
         Commands::Linkage(args) => cmd_linkage(config, args),
@@ -416,6 +417,11 @@ fn generate_manifest(
     }
 
     Ok(report)
+}
+
+fn cmd_migrate(_cli: &Cli, _args: &MigrateArgs) -> Result<(), miette::Report> {
+    do_migrate()?;
+    Ok(())
 }
 
 fn cmd_init(cli: &Cli, args: &InitArgs) -> Result<(), miette::Report> {

--- a/cargo-dist/tests/snapshots/long-help.snap
+++ b/cargo-dist/tests/snapshots/long-help.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/cli-tests.rs
 expression: format_outputs(&output)
+snapshot_kind: text
 ---
 stdout:
 Professional packaging and distribution for ambitious developers.
@@ -13,6 +14,7 @@ Usage: dist [OPTIONS]
 Commands:
   build       Build artifacts
   init        Setup or update dist
+  migrate     Migrate to the latest configuration variant
   generate    Generate one or more pieces of configuration
   linkage     Report on the dynamic libraries used by the built artifacts
   manifest    Generate the final build manifest without running any builds

--- a/cargo-dist/tests/snapshots/markdown-help.snap
+++ b/cargo-dist/tests/snapshots/markdown-help.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/cli-tests.rs
 expression: format_outputs(&output)
+snapshot_kind: text
 ---
 stdout:
 # dist CLI manual
@@ -21,6 +22,7 @@ dist <COMMAND>
 ### Commands
 * [build](#cargo-dist-build): Build artifacts
 * [init](#cargo-dist-init): Setup or update dist
+* [migrate](#cargo-dist-migrate): Migrate to the latest configuration variant
 * [generate](#cargo-dist-generate): Generate one or more pieces of configuration
 * [linkage](#cargo-dist-linkage): Report on the dynamic libraries used by the built artifacts
 * [manifest](#cargo-dist-manifest): Generate the final build manifest without running any builds
@@ -175,6 +177,23 @@ Possible values:
 - github:    Host on Github Releases
 - axodotdev: Host on Axo Releases ("Abyss")
 
+#### `-h, --help`
+Print help (see a summary with '-h')
+
+### GLOBAL OPTIONS
+This subcommand accepts all the [global options](#global-options)
+
+<br><br><br>
+## dist migrate
+Migrate to the latest configuration variant
+
+### Usage
+
+```text
+dist migrate [OPTIONS]
+```
+
+### Options
 #### `-h, --help`
 Print help (see a summary with '-h')
 
@@ -393,6 +412,7 @@ dist help [COMMAND]
 ### Commands
 * [build](#cargo-dist-build): Build artifacts
 * [init](#cargo-dist-init): Setup or update dist
+* [migrate](#cargo-dist-migrate): Migrate to the latest configuration variant
 * [generate](#cargo-dist-generate): Generate one or more pieces of configuration
 * [linkage](#cargo-dist-linkage): Report on the dynamic libraries used by the built artifacts
 * [manifest](#cargo-dist-manifest): Generate the final build manifest without running any builds

--- a/cargo-dist/tests/snapshots/short-help.snap
+++ b/cargo-dist/tests/snapshots/short-help.snap
@@ -1,6 +1,7 @@
 ---
 source: cargo-dist/tests/cli-tests.rs
 expression: format_outputs(&output)
+snapshot_kind: text
 ---
 stdout:
 Professional packaging and distribution for ambitious developers
@@ -11,6 +12,7 @@ Usage: dist [OPTIONS]
 Commands:
   build       Build artifacts
   init        Setup or update dist
+  migrate     Migrate to the latest configuration variant
   generate    Generate one or more pieces of configuration
   linkage     Report on the dynamic libraries used by the built artifacts
   manifest    Generate the final build manifest without running any builds


### PR DESCRIPTION
- `dist init` still works as on main
- `dist migrate` does the migration part of `dist init`
- `dist init`'s migration functionality is now implemented in terms of `dist migrate`

This shows `dist migrate` on its own:

![image](https://github.com/user-attachments/assets/96536825-3884-4066-bc41-211c4cf8ca2e)

And this shows that `dist migrate` is _only_ a migration, and explicitly does not do the re-init part:

![image](https://github.com/user-attachments/assets/15c1dfe4-b054-4e52-963e-14824be61ae9)
