### PR TITLE
Rename save_cargo_toml()->write_toml() and load_cargo_toml()->load_toml().

### DIFF
--- a/cargo-dist/src/backend/installer/msi.rs
+++ b/cargo-dist/src/backend/installer/msi.rs
@@ -133,7 +133,7 @@ impl MsiInstallerInfo {
     /// Check that wix GUIDs are set in the package's Cargo.toml
     fn check_wix_guids(&self) -> DistResult<()> {
         // Ok we have changes to make, let's load the toml
-        let mut package_toml = config::load_cargo_toml(&self.manifest_path)?;
+        let mut package_toml = config::load_toml(&self.manifest_path)?;
         if update_wix_metadata(&mut package_toml) {
             Err(DistError::MissingWixGuids {
                 manifest_path: self.manifest_path.clone(),
@@ -146,9 +146,9 @@ impl MsiInstallerInfo {
 
     /// Write wix GUIDs to the package's Cargo.toml
     fn write_wix_guids_to_disk(&self) -> DistResult<()> {
-        let mut package_toml = config::load_cargo_toml(&self.manifest_path)?;
+        let mut package_toml = config::load_toml(&self.manifest_path)?;
         if update_wix_metadata(&mut package_toml) {
-            config::save_cargo_toml(&self.manifest_path, package_toml)?;
+            config::write_toml(&self.manifest_path, package_toml)?;
         }
         Ok(())
     }

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -990,15 +990,15 @@ pub fn get_project() -> Result<axoproject::WorkspaceGraph, axoproject::errors::P
     Ok(workspaces)
 }
 
-/// Load a Cargo.toml into toml-edit form
-pub fn load_cargo_toml(manifest_path: &Utf8Path) -> DistResult<toml_edit::DocumentMut> {
+/// Load a TOML file to a toml-edit document.
+pub fn load_toml(manifest_path: &Utf8Path) -> DistResult<toml_edit::DocumentMut> {
     let src = axoasset::SourceFile::load_local(manifest_path)?;
     let toml = src.deserialize_toml_edit()?;
     Ok(toml)
 }
 
-/// Save a Cargo.toml from toml-edit form
-pub fn save_cargo_toml(manifest_path: &Utf8Path, toml: toml_edit::DocumentMut) -> DistResult<()> {
+/// Save a toml-edit document to a TOML file.
+pub fn write_toml(manifest_path: &Utf8Path, toml: toml_edit::DocumentMut) -> DistResult<()> {
     let toml_text = toml.to_string();
     axoasset::LocalAsset::write_new(&toml_text, manifest_path)?;
     Ok(())

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -87,9 +87,9 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
     for workspace_idx in workspaces.all_workspace_indices() {
         let workspace = workspaces.workspace(workspace_idx);
         if workspace.kind == WorkspaceKind::Rust {
-            let mut workspace_toml = config::load_cargo_toml(&workspace.manifest_path)?;
+            let mut workspace_toml = config::load_toml(&workspace.manifest_path)?;
             did_add_profile |= init_dist_profile(cfg, &mut workspace_toml)?;
-            config::save_cargo_toml(&workspace.manifest_path, workspace_toml)?;
+            config::write_toml(&workspace.manifest_path, workspace_toml)?;
         }
     }
 
@@ -98,7 +98,7 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
     }
 
     // Load in the root workspace toml to edit and write back
-    let workspace_toml = config::load_cargo_toml(&root_workspace.manifest_path)?;
+    let workspace_toml = config::load_toml(&root_workspace.manifest_path)?;
     let mut original_workspace_toml = workspace_toml.clone();
     let initted = has_metadata_table(root_workspace);
 
@@ -207,7 +207,7 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
     };
 
     // Save the workspace toml (potentially an effective no-op if we made no edits)
-    config::save_cargo_toml(&destination, workspace_toml)?;
+    config::write_toml(&destination, workspace_toml)?;
     let key = if desired_workspace_kind == WorkspaceKind::Rust {
         "[workspace.metadata.dist]"
     } else {
@@ -224,7 +224,7 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
             .and_then(|metadata_item| metadata_item.as_table_mut())
             .and_then(|table| table.remove("dist"));
 
-        config::save_cargo_toml(&root_workspace.manifest_path, original_workspace_toml)?;
+        config::write_toml(&root_workspace.manifest_path, original_workspace_toml)?;
     }
 
     // Now that we've done the stuff that's definitely part of the root Cargo.toml,
@@ -236,7 +236,7 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
 
         if needs_edit {
             // Ok we have changes to make, let's load the toml
-            let mut package_toml = config::load_cargo_toml(&package.manifest_path)?;
+            let mut package_toml = config::load_toml(&package.manifest_path)?;
             let metadata = config::get_toml_metadata(&mut package_toml, false);
 
             // Apply [package.metadata.dist]
@@ -247,7 +247,7 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
             }
 
             // Save the result
-            config::save_cargo_toml(&package.manifest_path, package_toml)?;
+            config::write_toml(&package.manifest_path, package_toml)?;
             if writing_metadata {
                 eprintln!(
                     "{check} added [package.metadata.dist] to {}'s Cargo.toml",


### PR DESCRIPTION
Neither of them are Cargo.toml-specific in any way.