### PR TITLE
feat: enable auditable with xwin

### DIFF
--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -185,18 +185,18 @@ pub fn make_build_cargo_target_command(
     let mut command = Cmd::new(cargo_cmd, "build your app with Cargo");
     if auditable {
         command.arg("auditable");
-        if wrapper.is_some() {
-            return Err(DistError::CannotDoCargoAuditableAndCrossCompile {
-                host: host.to_owned(),
-                target,
-            });
-        }
     }
     match wrapper {
         None => {
             command.arg("build");
         }
         Some(CargoBuildWrapper::ZigBuild) => {
+            if auditable {
+                return Err(DistError::CannotDoCargoAuditableAndCrossCompile {
+                    host: host.to_owned(),
+                    target,
+                });
+            }
             command.arg("zigbuild");
         }
         Some(CargoBuildWrapper::Xwin) => {


### PR DESCRIPTION
In testing, I've been able to confirm that cargo-auditable and cargo-xwin are compatible; zigbuild is the only one with a compatibility issue.

Refs #1608.