### PR TITLE
chore: tweak rust-version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
 homepage = "https://opensource.axo.dev/cargo-dist/"
 version = "0.26.0-prerelease.3"
-rust-version = "1.70.0"
+rust-version = "1.73"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!


### PR DESCRIPTION
The guppy we use says it's for Rust 1.73, so that's our actual MSRV.