### PR TITLE
docs: clean up old cross-compile references

### DIFF
--- a/book/src/artifacts/archives.md
+++ b/book/src/artifacts/archives.md
@@ -55,8 +55,6 @@ By default we build your packages with default features, but this can be configu
 
 When targeting windows-msvc we will unconditionally [append "-Ctarget-feature=+crt-static"][crt-static] to your RUSTFLAGS, which should just be the default for rustc but isn't for legacy reasons.
 
-We don't really [support cross-compilation][issue-cross], but we'll faithfully attempt the compile by telling rustup to install the toolchain and passing `--target` to cargo as instructed -- it will probably just fail. On macOS cross-compiles between Intel and Apple Silicon will work. [linux-musl is slated for a future version][issue-musl].
-
 
 
 ## Code Signing
@@ -79,7 +77,6 @@ Roughly speaking, codesigning can be broken up into "Is this app made by the dev
 [config-targets]:  ../reference/config.md#targets
 
 [issue-musl]: https://github.com/axodotdev/cargo-dist/issues/75
-[issue-cross]: https://github.com/axodotdev/cargo-dist/issues/74
 [issue-sigstore]: https://github.com/axodotdev/cargo-dist/issues/120
 [issue-native-sign]: https://github.com/axodotdev/cargo-dist/issues/21
 

--- a/book/src/reference/concepts.md
+++ b/book/src/reference/concepts.md
@@ -202,8 +202,6 @@ Host mode is the default "do something useful on my machine" mode. It's intended
 
 It's currently roughly equivalent to `--artifacts=all --target=HOST_TARGET`, but HOST_TARGET is allowed to fall outside the set of targets defined in your Cargo.toml, because it's not terribly useful to tell someone trying out dist on ARM64 Linux that their platform isn't defined in the config.
 
-In principle when we have better support for cross-compilation we might also try to build "nice" crosses like "intel apple => arm64 apple". Do not rely on the behaviour of this mode, always use one of the 3 other modes in your infra/scripts!
-
 If you *do* pass `--target` in host mode then we won't do fuzzy target selection and will just build the targets you ask for like normal.
 
 


### PR DESCRIPTION
We have several references to cross-compile not existing; these should just be removed, so users searching for cross-compiles in the docs will find the actual instructions for the new feature.