### PR TITLE
feat(generic): error on using cargo-only options

### DIFF
--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -556,6 +556,14 @@ pub enum DistError {
         target: Triple,
     },
 
+    /// Generic build with Cargo-only build options
+    #[error("You're building a generic package but have a Cargo-only option enabled")]
+    #[diagnostic(help("Please disable the following from your configuration: {}", options.join(", ")))]
+    CargoOnlyBuildOptions {
+        /// The names of the invalid options
+        options: Vec<String>,
+    },
+
     /// missing "build-command" for a package that needs one
     #[error("dist package was missing a build-command\n{manifest}")]
     #[diagnostic(help(

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -2650,8 +2650,10 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         for workspace_idx in self.workspaces.all_workspace_indices() {
             let workspace_kind = self.workspaces.workspace(workspace_idx).kind;
             let builds = match workspace_kind {
-                axoproject::WorkspaceKind::Javascript => self.compute_generic_builds(workspace_idx),
-                axoproject::WorkspaceKind::Generic => self.compute_generic_builds(workspace_idx),
+                axoproject::WorkspaceKind::Javascript => {
+                    self.compute_generic_builds(workspace_idx)?
+                }
+                axoproject::WorkspaceKind::Generic => self.compute_generic_builds(workspace_idx)?,
                 axoproject::WorkspaceKind::Rust => self.compute_cargo_builds(workspace_idx)?,
             };
             local_build_steps.extend(builds);


### PR DESCRIPTION
These options aren't valid when performing generic builds, and we should give the user a warning about that as far ahead of time as we can. Output during `plan`:

```
  × You're building a generic package but have a Cargo-only option enabled
  help: Please disable the following from your configuration: cargo-auditable, cargo-cyclonedx
```

I've confirmed that there are no errors during Rust builds.

Fixes #1526.