### PR TITLE
fix: cyclonedx check is unnecessary (only called in CI)

### DIFF
--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -70,8 +70,6 @@ pub fn do_env_test(cfg: &Config) -> DistResult<()> {
 
     // cargo-auditable is used only in local builds
     let need_cargo_auditable = builds.cargo.cargo_auditable && local_builds;
-    // cyclonedx is used only in global builds
-    let need_cargo_cyclonedx = builds.cargo.cargo_cyclonedx && !local_builds;
     // omnibor is used in both local and global builds
     let need_omnibor = builds.omnibor;
     let mut need_xwin = false;
@@ -111,7 +109,6 @@ pub fn do_env_test(cfg: &Config) -> DistResult<()> {
     // Vec<Option<Result<&Tool, DistResult>>>.
     let all_tools: Vec<Option<DistResult<&Tool>>> = vec![
         need_cargo_auditable.then(|| tools.cargo_auditable()),
-        need_cargo_cyclonedx.then(|| tools.cargo_cyclonedx()),
         need_omnibor.then(|| tools.omnibor()),
         need_xwin.then(|| tools.cargo_xwin()),
         need_zigbuild.then(|| tools.cargo_zigbuild()),

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -61,14 +61,17 @@ mod tests;
 pub fn do_env_test(cfg: &Config) -> DistResult<()> {
     let (dist, _manifest) = tasks::gather_work(cfg)?;
 
-    let global_builds = cfg.artifact_mode == ArtifactMode::Global;
+    let local_builds = matches!(
+        cfg.artifact_mode,
+        ArtifactMode::Local | ArtifactMode::All | ArtifactMode::Host
+    );
 
     let builds = dist.config.builds;
 
     // cargo-auditable is used only in local builds
-    let need_cargo_auditable = builds.cargo.cargo_auditable && !global_builds;
+    let need_cargo_auditable = builds.cargo.cargo_auditable && local_builds;
     // cyclonedx is used only in global builds
-    let need_cargo_cyclonedx = builds.cargo.cargo_cyclonedx && global_builds;
+    let need_cargo_cyclonedx = builds.cargo.cargo_cyclonedx && !local_builds;
     // omnibor is used in both local and global builds
     let need_omnibor = builds.omnibor;
     let mut need_xwin = false;

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -65,8 +65,11 @@ pub fn do_env_test(cfg: &Config) -> DistResult<()> {
 
     let builds = dist.config.builds;
 
+    // cargo-auditable is used only in local builds
     let need_cargo_auditable = builds.cargo.cargo_auditable && !global_builds;
-    let need_cargo_cyclonedx = builds.cargo.cargo_cyclonedx && !global_builds;
+    // cyclonedx is used only in global builds
+    let need_cargo_cyclonedx = builds.cargo.cargo_cyclonedx && global_builds;
+    // omnibor is used in both local and global builds
     let need_omnibor = builds.omnibor;
     let mut need_xwin = false;
     let mut need_zigbuild = false;


### PR DESCRIPTION
I've also adjusted what counts as a "global" build - the "all" and "host" modes build global artifacts too, so we should check those.

We discussed this and realized there was a mismatch between how we check for cyclonedx and how we use it. It's currently executed in CI, rather than from Rust as one of the builds, so we don't actually run it during `cargo build -aglobal`. As a result there's no real reason to check for it right now - it's always installed in the only place we use it. We can add back the check if we move the execution to Rust. #1652 