### PR TITLE
[WIP] Implement config v0 -> v1 migration.

### DIFF
--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -930,8 +930,13 @@ impl std::fmt::Display for ProductionMode {
     }
 }
 
-pub(crate) fn load_config(dist_manifest_path: &Utf8Path) -> DistResult<DistWorkspaceConfig> {
-    let src = SourceFile::load_local(dist_manifest_path)?;
+pub(crate) fn try_load_config(dist_manifest_path: Option<&Utf8PathBuf>) -> DistResult<DistWorkspaceConfig> {
+    let path = dist_manifest_path.ok_or(DistError::NoDistManifest {})?;
+    load_config(path)
+}
+
+pub(crate) fn load_config(dist_manifest_path: &Utf8PathBuf) -> DistResult<DistWorkspaceConfig> {
+    let src = SourceFile::load_local(dist_manifest_path.as_path())?;
     parse_config(src)
 }
 

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -956,12 +956,8 @@ pub(crate) fn parse_metadata_table_or_manifest(
     }
 }
 
-pub(crate) fn has_v0_config(root_workspace: &axoproject::WorkspaceInfo) -> bool {
-    if let Some(dist_manifest_path) = root_workspace.dist_manifest_path.as_deref() {
-        crate::config::load_v0_config(dist_manifest_path).is_ok()
-    } else {
-        false
-    }
+pub(crate) fn is_v0_config(dist_manifest_path: &Utf8Path) -> bool {
+    crate::config::load_v0_config(dist_manifest_path).is_ok()
 }
 
 pub(crate) fn load_v0_config(dist_manifest_path: &Utf8Path) -> DistResult<V0WorkspaceConfig> {
@@ -998,6 +994,10 @@ pub(crate) fn parse_metadata_table(
     manifest_path: &Utf8Path,
     metadata_table: Option<&serde_json::Value>,
 ) -> DistResult<DistMetadata> {
+    if crate::config::is_v0_config(manifest_path) {
+        return Err(DistError::OldConfigFormat {});
+    }
+
     Ok(metadata_table
         .and_then(|t| t.get(METADATA_DIST))
         .map(DistMetadata::deserialize)

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -930,10 +930,6 @@ impl std::fmt::Display for ProductionMode {
     }
 }
 
-pub(crate) fn is_v1_config(dist_manifest_path: &Utf8Path) -> bool {
-    crate::config::load_config(dist_manifest_path).is_ok()
-}
-
 pub(crate) fn load_config(dist_manifest_path: &Utf8Path) -> DistResult<DistWorkspaceConfig> {
     let src = SourceFile::load_local(dist_manifest_path)?;
     parse_config(src)
@@ -961,8 +957,7 @@ pub(crate) fn parse_metadata_table_or_manifest(
 }
 
 pub(crate) fn is_v0_config(dist_manifest_path: &Utf8Path) -> bool {
-    !is_v1_config(dist_manifest_path) &&
-        crate::config::load_v0_config(dist_manifest_path).is_ok()
+    crate::config::load_v0_config(dist_manifest_path).is_ok()
 }
 
 pub(crate) fn load_v0_config(dist_manifest_path: &Utf8Path) -> DistResult<V0WorkspaceConfig> {

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -956,6 +956,14 @@ pub(crate) fn parse_metadata_table_or_manifest(
     }
 }
 
+pub(crate) fn has_v0_config(root_workspace: &axoproject::WorkspaceInfo) -> bool {
+    if let Some(dist_manifest_path) = root_workspace.dist_manifest_path.as_deref() {
+        crate::config::load_v0_config(dist_manifest_path).is_ok()
+    } else {
+        false
+    }
+}
+
 pub(crate) fn load_v0_config(dist_manifest_path: &Utf8Path) -> DistResult<V0WorkspaceConfig> {
     let src = SourceFile::load_local(dist_manifest_path)?;
     parse_v0_config(src)

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -930,6 +930,10 @@ impl std::fmt::Display for ProductionMode {
     }
 }
 
+pub(crate) fn is_v1_config(dist_manifest_path: &Utf8Path) -> bool {
+    crate::config::load_config(dist_manifest_path).is_ok()
+}
+
 pub(crate) fn load_config(dist_manifest_path: &Utf8Path) -> DistResult<DistWorkspaceConfig> {
     let src = SourceFile::load_local(dist_manifest_path)?;
     parse_config(src)
@@ -957,7 +961,8 @@ pub(crate) fn parse_metadata_table_or_manifest(
 }
 
 pub(crate) fn is_v0_config(dist_manifest_path: &Utf8Path) -> bool {
-    crate::config::load_v0_config(dist_manifest_path).is_ok()
+    !is_v1_config(dist_manifest_path) &&
+        crate::config::load_v0_config(dist_manifest_path).is_ok()
 }
 
 pub(crate) fn load_v0_config(dist_manifest_path: &Utf8Path) -> DistResult<V0WorkspaceConfig> {

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -930,6 +930,10 @@ impl std::fmt::Display for ProductionMode {
     }
 }
 
+pub(crate) fn is_v1_config(dist_manifest_path: &Utf8Path) -> bool {
+    load_config(&dist_manifest_path.to_owned()).is_ok()
+}
+
 pub(crate) fn try_load_config(dist_manifest_path: Option<&Utf8PathBuf>) -> DistResult<DistWorkspaceConfig> {
     let path = dist_manifest_path.ok_or(DistError::NoDistManifest {})?;
     load_config(path)
@@ -962,7 +966,8 @@ pub(crate) fn parse_metadata_table_or_manifest(
 }
 
 pub(crate) fn is_v0_config(dist_manifest_path: &Utf8Path) -> bool {
-    crate::config::load_v0_config(dist_manifest_path).is_ok()
+    !is_v1_config(dist_manifest_path)
+        && load_v0_config(dist_manifest_path).is_ok()
 }
 
 pub(crate) fn load_v0_config(dist_manifest_path: &Utf8Path) -> DistResult<V0WorkspaceConfig> {

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -12,6 +12,7 @@ use cargo_dist_schema::{
 use serde::{Deserialize, Serialize};
 
 use crate::announce::TagSettings;
+use crate::config::v1::DistWorkspaceConfig;
 use crate::SortedMap;
 use crate::{
     errors::{DistError, DistResult},
@@ -22,7 +23,7 @@ pub mod v0;
 pub mod v0_to_v1;
 pub mod v1;
 
-pub use v0::{DistMetadata, GenericConfig};
+pub use v0::{DistMetadata, GenericConfig, V0WorkspaceConfig};
 
 /// values of the form `permission-name: read`
 pub type GithubPermissionMap = SortedMap<String, GithubPermission>;
@@ -929,6 +930,16 @@ impl std::fmt::Display for ProductionMode {
     }
 }
 
+pub(crate) fn load_config(dist_manifest_path: &Utf8Path) -> DistResult<DistWorkspaceConfig> {
+    let src = SourceFile::load_local(dist_manifest_path)?;
+    parse_config(src)
+}
+
+pub(crate) fn parse_config(src: SourceFile) -> DistResult<DistWorkspaceConfig> {
+    let config: DistWorkspaceConfig = src.deserialize_toml()?;
+    Ok(config)
+}
+
 pub(crate) fn parse_metadata_table_or_manifest(
     manifest_path: &Utf8Path,
     dist_manifest_path: Option<&Utf8Path>,
@@ -943,6 +954,15 @@ pub(crate) fn parse_metadata_table_or_manifest(
         // Pre-parsed Rust metadata table
         parse_metadata_table(manifest_path, metadata_table)
     }
+}
+
+pub(crate) fn load_v0_config(dist_manifest_path: &Utf8Path) -> DistResult<V0WorkspaceConfig> {
+    let src = SourceFile::load_local(dist_manifest_path)?;
+    parse_v0_config(src)
+}
+
+pub(crate) fn parse_v0_config(src: SourceFile) -> DistResult<V0WorkspaceConfig> {
+    Ok(src.deserialize_toml()?)
 }
 
 pub(crate) fn parse_generic_config(src: SourceFile) -> DistResult<DistMetadata> {

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -930,25 +930,6 @@ impl std::fmt::Display for ProductionMode {
     }
 }
 
-#[derive(Deserialize)]
-struct FauxV1 {
-    #[allow(dead_code)]
-    dist_version: String,
-}
-
-#[derive(Deserialize)]
-struct FauxConfigV1 {
-    #[allow(dead_code)]
-    dist: FauxV1,
-}
-
-pub(crate) fn is_v1_config(dist_manifest_path: &Utf8Path) -> bool {
-    let Ok(src) = SourceFile::load_local(dist_manifest_path) else {
-        return false;
-    };
-    src.deserialize_toml::<FauxConfigV1>().is_ok()
-}
-
 pub(crate) fn try_load_config(
     dist_manifest_path: Option<&Utf8PathBuf>,
 ) -> DistResult<DistWorkspaceConfig> {
@@ -1015,10 +996,6 @@ pub(crate) fn looks_like_v0_config(dist_manifest_path: &Utf8Path) -> bool {
     src.deserialize_toml::<FauxConfigV0>().is_ok()
 }
 
-pub(crate) fn is_v0_config(dist_manifest_path: &Utf8Path) -> bool {
-    !is_v1_config(dist_manifest_path) && load_v0_config(dist_manifest_path).is_ok()
-}
-
 pub(crate) fn load_v0_config(dist_manifest_path: &Utf8Path) -> DistResult<V0WorkspaceConfig> {
     let src = SourceFile::load_local(dist_manifest_path)?;
     parse_v0_config(src)
@@ -1026,11 +1003,6 @@ pub(crate) fn load_v0_config(dist_manifest_path: &Utf8Path) -> DistResult<V0Work
 
 pub(crate) fn parse_v0_config(src: SourceFile) -> DistResult<V0WorkspaceConfig> {
     Ok(src.deserialize_toml()?)
-}
-
-pub(crate) fn parse_generic_config(src: SourceFile) -> DistResult<DistMetadata> {
-    let config: GenericConfig = src.deserialize_toml()?;
-    Ok(config.dist.unwrap_or_default())
 }
 
 pub(crate) fn reject_metadata_table(

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -949,9 +949,22 @@ pub(crate) fn is_v1_config(dist_manifest_path: &Utf8Path) -> bool {
     src.deserialize_toml::<FauxConfigV1>().is_ok()
 }
 
-pub(crate) fn try_load_config(dist_manifest_path: Option<&Utf8PathBuf>) -> DistResult<DistWorkspaceConfig> {
+pub(crate) fn try_load_config(
+    dist_manifest_path: Option<&Utf8PathBuf>,
+) -> DistResult<DistWorkspaceConfig> {
     let path = dist_manifest_path.ok_or(DistError::NoDistManifest {})?;
     load_config(path)
+}
+
+pub(crate) fn try_load_package_config(
+    dist_manifest_path: Option<&Utf8PathBuf>,
+) -> DistResult<TomlLayer> {
+    if let Some(dist_manifest_path) = dist_manifest_path {
+        let src = SourceFile::load_local(dist_manifest_path)?;
+        Ok(parse_config(src)?.dist)
+    } else {
+        Ok(Default::default())
+    }
 }
 
 pub(crate) fn load_config(dist_manifest_path: &Utf8PathBuf) -> DistResult<DistWorkspaceConfig> {

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -679,6 +679,12 @@ impl ChecksumStyle {
     }
 }
 
+impl std::fmt::Display for ChecksumStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.ext())
+    }
+}
+
 /// Which style(s) of configuration to generate
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum GenerateMode {

--- a/cargo-dist/src/config/v0.rs
+++ b/cargo-dist/src/config/v0.rs
@@ -12,6 +12,19 @@ use super::*;
 use crate::platform::MinGlibcVersion;
 use crate::SortedMap;
 
+use crate::config::v1::{WorkspaceTable, PackageTable};
+
+/// A container to assist deserializing the entirety of `dist-workspace.toml`.
+#[derive(Debug, Deserialize)]
+pub struct V0WorkspaceConfig {
+    /// the `[workspace]` table.
+    pub workspace: Option<WorkspaceTable>,
+    /// the `[package]` table.
+    pub package: Option<PackageTable>,
+    /// the `[dist]` table.
+    pub dist: Option<DistMetadata>,
+}
+
 /// A container to assist deserializing metadata from dist(-workspace).tomls
 #[derive(Debug, Deserialize)]
 pub struct GenericConfig {

--- a/cargo-dist/src/config/v0.rs
+++ b/cargo-dist/src/config/v0.rs
@@ -12,7 +12,7 @@ use super::*;
 use crate::platform::MinGlibcVersion;
 use crate::SortedMap;
 
-use crate::config::v1::{WorkspaceTable, PackageTable};
+use crate::config::v1::{PackageTable, WorkspaceTable};
 
 /// A container to assist deserializing the entirety of `dist-workspace.toml`.
 #[derive(Debug, Deserialize)]

--- a/cargo-dist/src/config/v1/artifacts/mod.rs
+++ b/cargo-dist/src/config/v1/artifacts/mod.rs
@@ -23,7 +23,7 @@ pub struct WorkspaceArtifactConfig {
     pub checksum: ChecksumStyle,
 }
 /// artifact config (raw from file)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ArtifactLayer {
     /// archive config

--- a/cargo-dist/src/config/v1/installers/mod.rs
+++ b/cargo-dist/src/config/v1/installers/mod.rs
@@ -65,7 +65,7 @@ pub struct InstallerConfigInheritable {
 }
 
 /// installer config (raw from file)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct InstallerLayer {
     /// inheritable fields

--- a/cargo-dist/src/config/v1/layer.rs
+++ b/cargo-dist/src/config/v1/layer.rs
@@ -173,6 +173,7 @@ pub enum BoolOr<T> {
 }
 
 impl<T> BoolOr<T> {
+    /// Returns true if if the Bool portion is truthy, or if this contains a value.
     pub fn truthy(&self) -> bool {
         match self {
             BoolOr::Bool(b) => *b,

--- a/cargo-dist/src/config/v1/layer.rs
+++ b/cargo-dist/src/config/v1/layer.rs
@@ -181,3 +181,22 @@ impl<T> BoolOr<T> {
         }
     }
 }
+
+/// Extension trait to provide Option<BoolOr<T>>::none_or_false()
+pub trait BoolOrOptExt
+where
+    Self: Sized,
+{
+    /// Given an Option<BoolOr<T>>, returns `true` if the value is
+    /// `None` or `Some(BoolOr::Bool(false))`.
+    fn none_or_false(&self) -> bool;
+}
+impl<T> BoolOrOptExt for Option<BoolOr<T>> {
+    fn none_or_false(&self) -> bool {
+        if let Some(item) = self {
+            !item.not_false()
+        } else {
+            true
+        }
+    }
+}

--- a/cargo-dist/src/config/v1/layer.rs
+++ b/cargo-dist/src/config/v1/layer.rs
@@ -173,8 +173,8 @@ pub enum BoolOr<T> {
 }
 
 impl<T> BoolOr<T> {
-    /// Returns true if if the Bool portion is truthy, or if this contains a value.
-    pub fn truthy(&self) -> bool {
+    /// Returns true if it is `BoolOr::Bool(true)`, or if it contains a value.
+    pub fn not_false(&self) -> bool {
         match self {
             BoolOr::Bool(b) => *b,
             BoolOr::Val(_v) => true,

--- a/cargo-dist/src/config/v1/layer.rs
+++ b/cargo-dist/src/config/v1/layer.rs
@@ -190,6 +190,10 @@ where
     /// Given an Option<BoolOr<T>>, returns `true` if the value is
     /// `None` or `Some(BoolOr::Bool(false))`.
     fn none_or_false(&self) -> bool;
+
+    /// Given an Option<BoolOr<T>>, returns `true` if the value is
+    /// a `Some(BoolOr::Val(...))` or `Some(BoolOr::Bool(true))`.
+    fn is_some_and_not_false(&self) -> bool;
 }
 impl<T> BoolOrOptExt for Option<BoolOr<T>> {
     fn none_or_false(&self) -> bool {
@@ -197,6 +201,14 @@ impl<T> BoolOrOptExt for Option<BoolOr<T>> {
             !item.not_false()
         } else {
             true
+        }
+    }
+
+    fn is_some_and_not_false(&self) -> bool {
+        if let Some(item) = self {
+            item.not_false()
+        } else {
+            false
         }
     }
 }

--- a/cargo-dist/src/config/v1/layer.rs
+++ b/cargo-dist/src/config/v1/layer.rs
@@ -171,3 +171,12 @@ pub enum BoolOr<T> {
     /// They gave a more interesting value
     Val(T),
 }
+
+impl<T> BoolOr<T> {
+    pub fn truthy(&self) -> bool {
+        match self {
+            BoolOr::Bool(b) => *b,
+            BoolOr::Val(_v) => true,
+        }
+    }
+}

--- a/cargo-dist/src/config/v1/mod.rs
+++ b/cargo-dist/src/config/v1/mod.rs
@@ -651,7 +651,7 @@ impl TomlLayer {
         // All of `hosts.github` is global-only.
         if let Some(hosts) = &hosts {
             if let Some(github) = &hosts.github {
-                if github.truthy() {
+                if github.not_false() {
                     Self::merge_warn("hosts.github", package_manifest_path);
                 }
             }

--- a/cargo-dist/src/config/v1/mod.rs
+++ b/cargo-dist/src/config/v1/mod.rs
@@ -373,6 +373,78 @@ impl ApplyLayer for AppConfigInheritable {
     }
 }
 
+/// The internal representation of the [package] table from dist[-workspace].toml.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct PackageTable {
+    /// The name of the package.
+    pub name: String,
+    /// The version of the package. Syntax must be a valid Cargo SemVer Version.
+    pub version: String,
+    /// A brief description of the package.
+    pub description: Option<String>,
+    /// The authors of the package.
+    pub authors: Option<Vec<String>>,
+    /// A URL to the repository hosting this package.
+    pub repository: Option<String>,
+    /// A URL to the homepage of the package.
+    pub homepage: Option<String>,
+    /// A URL to the documentation of the package.
+    pub documentation: Option<String>,
+    /// A relative path to the changelog file for your package.
+    pub changelog: Option<String>,
+    /// A relative path to the readme file for your package.
+    pub readme: Option<String>,
+    /// The license(s) of your package, in SPDX format.
+    pub license: Option<String>,
+    /// Relative paths to the license files for your package.
+    pub license_files: Option<Vec<String>>,
+    /// Names of binaries (without the extension) your package is expected
+    /// to build and distribute.
+    pub binaries: Option<Vec<String>>,
+    /// Names of c-style static libraries (without the extension) your
+    /// package is expected to build and distribute.
+    pub cstaticlibs: Option<Vec<String>>,
+    /// Names of c-style dynamic libraries (without the extension) your
+    /// package is expected to build and distribute.
+    pub cdylibs: Option<Vec<String>>,
+    /// A command to run in your package's root directory to build its
+    /// binaries, cstaticlibs, and cdylibs.
+    pub build_command: Option<Vec<String>>,
+}
+
+/// The internal representation of dist.toml.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DistConfig {
+    /// The `[package]` table from dist.toml.
+    pub package: Option<PackageTable>,
+    /// The `[dist]` table from dist.toml.
+    pub dist: TomlLayer,
+}
+
+/// The internal representation of the [workspace] table from dist-workspace.toml.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct WorkspaceTable {
+    /// The various projects/workspaces/packages to be managed by dist.
+    pub members: Vec<String>,
+}
+
+/// The internal representation of dist-workspace.toml.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DistWorkspaceConfig {
+    /// The `[workspace]` table.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<WorkspaceTable>,
+    /// The `[dist]` table
+    pub dist: TomlLayer,
+    /// The `[package]` table.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package: Option<PackageTable>,
+}
+
 /// The "raw" input from a toml file containing config
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]

--- a/cargo-dist/src/config/v1/mod.rs
+++ b/cargo-dist/src/config/v1/mod.rs
@@ -126,6 +126,8 @@ use hosts::*;
 use installers::*;
 use publishers::*;
 
+use tracing::log::warn;
+
 /// Compute the workspace-level config
 pub fn workspace_config(
     workspaces: &WorkspaceGraph,
@@ -446,7 +448,7 @@ pub struct DistWorkspaceConfig {
 }
 
 /// The "raw" input from a toml file containing config
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct TomlLayer {
     /// The intended version of dist to build with. (normal Cargo SemVer syntax)
@@ -519,7 +521,7 @@ impl TomlLayer {
     ///
     /// This is important to do eagerly, because once we start merging configs
     /// we'll forget what file they came from!
-    fn make_relative_to(&mut self, base_path: &Utf8Path) {
+    pub fn make_relative_to(&mut self, base_path: &Utf8Path) {
         // It's kind of unfortunate that we don't exhaustively match this to
         // force you to update it BUT almost no config is ever applicable for
         // this so even when we used to, everyone just skimmed over this so
@@ -543,6 +545,180 @@ impl TomlLayer {
             if let Some(BoolOr::Val(github)) = &mut hosts.github {
                 if let Some(path) = &mut github.submodule_path {
                     make_path_relative_to(path, base_path);
+                }
+            }
+        }
+    }
+
+    /// Determines whether the configured install paths are compatible with each other
+    pub fn validate_install_paths(&self) -> DistResult<()> {
+        if let Some(installers) = &self.installers {
+            if let Some(paths) = &installers.common.install_path {
+                if paths.len() > 1 && paths.contains(&InstallPathStrategy::CargoHome) {
+                    return Err(DistError::IncompatibleInstallPathConfiguration {});
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    // we say "value is being ignored", but it seems like we use the "ignored" values anyway?
+    fn merge_warn(
+        name: &str,
+        package_manifest_path: &Utf8Path,
+    ) {
+        warn!("package.metadata.dist.{} is set, but this is only accepted in workspace.metadata (value is being ignored): {}", name, package_manifest_path);
+    }
+
+    /// Merge a workspace config into a package config (self)
+    pub fn merge_workspace_config(
+        &mut self,
+        workspace_config: &Self,
+        package_manifest_path: &Utf8Path,
+    ) {
+        // This is intentionally written awkwardly to make you update it
+        let TomlLayer {
+            dist_version,
+            dist_url_override,
+            dist,
+            allow_dirty,
+            targets,
+            artifacts,
+            builds,
+            ci,
+            hosts,
+            installers,
+            publishers,
+        } = self;
+
+        // Check for global settings on local packages
+        if dist_version.is_some() {
+            Self::merge_warn("dist-version", package_manifest_path);
+        }
+        if dist_url_override.is_some() {
+            Self::merge_warn("dist-url-override", package_manifest_path);
+        }
+
+        // Arguably should be package-local for things like msi installers, but doesn't make sense for CI,
+        // so let's not support that yet for its complexity!
+        if allow_dirty.is_some() {
+            Self::merge_warn("allow-dirty", package_manifest_path);
+        }
+
+        // artifacts
+        if let Some(artifacts) = artifacts {
+            if artifacts.source_tarball.is_some() {
+                Self::merge_warn("artifacts.source-tarball", package_manifest_path);
+            }
+        }
+
+        if let Some(builds) = builds {
+            if builds.ssldotcom_windows_sign.is_some() {
+                Self::merge_warn("builds.ssldotcom-windows-sign", package_manifest_path);
+            }
+
+            if let Some(macos_sign) = builds.macos_sign {
+                if macos_sign {
+                    Self::merge_warn("builds.macos-sign", package_manifest_path);
+                }
+            }
+
+            if let Some(BoolOr::Val(cargo)) = &builds.cargo {
+                if cargo.features.is_some() {
+                    Self::merge_warn("cargo.features", package_manifest_path);
+                }
+                if cargo.default_features.unwrap_or(false) {
+                    Self::merge_warn("cargo.default-features", package_manifest_path);
+                }
+                if cargo.all_features.unwrap_or(false) {
+                    Self::merge_warn("cargo.all-features", package_manifest_path);
+                }
+                if cargo.cargo_auditable.unwrap_or(false) {
+                    Self::merge_warn("cargo.cargo-auditable", package_manifest_path);
+                }
+                if cargo.cargo_cyclonedx.unwrap_or(false) {
+                    Self::merge_warn("cargo.cargo-cyclonedx", package_manifest_path);
+                }
+            }
+        }
+
+        // The entire CiLayer is global-only.
+        if ci.is_some() {
+            Self::merge_warn("ci", package_manifest_path);
+        }
+
+        // All of `hosts.github` is global-only.
+        if let Some(hosts) = &hosts {
+            if let Some(github) = &hosts.github {
+                if github.truthy() {
+                    Self::merge_warn("hosts.github", package_manifest_path);
+                }
+            }
+        }
+
+        // All of `installers` (InstallerLayer) is package-only, so no need to check it.
+
+        // All of PublisherLayer is global-only.
+        if publishers.is_some() {
+            Self::merge_warn("dist.publishers", package_manifest_path);
+        }
+
+        // Merge non-global settings
+        if installers.is_none() {
+            installers.clone_from(&workspace_config.installers);
+        }
+        if targets.is_none() {
+            targets.clone_from(&workspace_config.targets);
+        }
+        if dist.is_none() {
+            *dist = workspace_config.dist;
+        }
+
+        if artifacts.is_none() {
+            artifacts.clone_from(&workspace_config.artifacts);
+        }
+        if builds.is_none() {
+            builds.clone_from(&workspace_config.builds);
+        }
+        if ci.is_none() {
+            ci.clone_from(&workspace_config.ci);
+        }
+
+        // TODO: Copy hosts.github if needed
+        if let Some(hosts) = hosts.as_ref() {
+            //if hosts.github.is_none() {
+            //    hosts.github.clone_from(
+            //}
+        }
+
+        if publishers.is_none() {
+            publishers.clone_from(&workspace_config.publishers);
+        }
+
+        // fixme: make this less...  cthulu-esque.
+        if let Some(ws_artifacts) = &workspace_config.artifacts {
+            if let Some(ws_archives) = &ws_artifacts.archives {
+                if let Some(ws_include) = &ws_archives.include {
+                    // If we get here, we have something to bother copying.
+
+                    if artifacts.is_none() {
+                        artifacts.clone_from(&Some(Default::default()));
+                    }
+
+                    if let Some(artifacts) = artifacts {
+                        if artifacts.archives.is_none() {
+                            artifacts.archives.clone_from(&Some(Default::default()));
+                        }
+
+                        if let Some(archives) = &mut artifacts.archives {
+                            if let Some(include) = &mut archives.include {
+                                include.extend(ws_include.iter().cloned());
+                            } else {
+                                archives.include.clone_from(&ws_archives.include);
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/cargo-dist/src/config/v1/mod.rs
+++ b/cargo-dist/src/config/v1/mod.rs
@@ -685,13 +685,6 @@ impl TomlLayer {
             ci.clone_from(&workspace_config.ci);
         }
 
-        // TODO: Copy hosts.github if needed
-        if let Some(hosts) = hosts.as_ref() {
-            //if hosts.github.is_none() {
-            //    hosts.github.clone_from(
-            //}
-        }
-
         if publishers.is_none() {
             publishers.clone_from(&workspace_config.publishers);
         }

--- a/cargo-dist/src/config/v1/publishers/mod.rs
+++ b/cargo-dist/src/config/v1/publishers/mod.rs
@@ -31,7 +31,7 @@ pub struct PublisherConfigInheritable {
 }
 
 /// "raw" publisher config from presum
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct PublisherLayer {
     /// common fields that each publisher inherits
     #[serde(flatten)]

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -635,6 +635,10 @@ pub enum DistError {
     #[error("Your project is using an old configuration format. Please run `dist init` to migrate to the new format.")]
     //#[diagnostic(help("???? probably provide a link ???")]
     OldConfigFormat {},
+
+    /// No dist manifest
+    #[error("Could not find a dist-workspace.toml")]
+    NoDistManifest {},
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -74,6 +74,10 @@ pub enum DistError {
     #[error(transparent)]
     TripleError(#[from] cargo_dist_schema::target_lexicon::ParseError),
 
+    /// error when using axoasset::toml::to_string() or similar
+    #[error(transparent)]
+    AxoassetTomlSerErr(#[from] axoasset::toml::ser::Error),
+
     /// A problem with a jinja template, which is always a dist bug
     #[error("Failed to render template")]
     #[diagnostic(

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -637,7 +637,7 @@ pub enum DistError {
     OldConfigFormat {},
 
     /// No dist manifest
-    #[error("Could not find a dist-workspace.toml")]
+    #[error("No manifest path specified")]
     NoDistManifest {},
 }
 

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -630,6 +630,11 @@ pub enum DistError {
         /// Version the project uses
         your_version: semver::Version,
     },
+
+    /// Project is using a v0 config
+    #[error("Your project is using an old configuration format. Please run `dist init` to migrate to the new format.")]
+    //#[diagnostic(help("???? probably provide a link ???")]
+    OldConfigFormat {},
 }
 
 impl From<minijinja::Error> for DistError {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1050,7 +1050,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
         table,
         "dist",
         "# Whether the package should be distributed/built by dist (defaults to true)\n",
-        dist.clone(),
+        *dist,
     );
 
     apply_string_list(
@@ -1293,7 +1293,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
 fn apply_artifacts(table: &mut toml_edit::Table, artifacts: &Option<ArtifactLayer>) {
     let Some(artifacts) = artifacts else {
         return;
-    }
+    };
     let Some(artifacts_table) = table.get_mut("artifacts") else {
         return;
     };
@@ -1463,14 +1463,14 @@ fn apply_cargo_builds(builds_table: &mut toml_edit::Table, builds: &BuildLayer) 
         cargo_builds_table,
         "msvc-crt-static",
         "# Whether +crt-static should be used on msvc\n",
-        cargo_builds.msvc_crt_static.clone(),
+        cargo_builds.msvc_crt_static,
     );
 
     apply_optional_value(
         cargo_builds_table,
         "precise-builds",
         "# Build only the required packages, and individually\n",
-        cargo_builds.precise_builds.clone(),
+        cargo_builds.precise_builds,
     );
 
     apply_string_list(
@@ -1484,28 +1484,28 @@ fn apply_cargo_builds(builds_table: &mut toml_edit::Table, builds: &BuildLayer) 
         cargo_builds_table,
         "default-features",
         "# Whether default-features should be enabled with cargo build\n",
-        cargo_builds.default_features.clone(),
+        cargo_builds.default_features,
     );
 
     apply_optional_value(
         cargo_builds_table,
         "all-features",
         "# Whether to pass --all-features to cargo build\n",
-        cargo_builds.all_features.clone(),
+        cargo_builds.all_features,
     );
 
     apply_optional_value(
         cargo_builds_table,
         "cargo-auditable",
         "# Whether to embed dependency information using cargo-auditable\n",
-        cargo_builds.cargo_auditable.clone(),
+        cargo_builds.cargo_auditable,
     );
 
     apply_optional_value(
         cargo_builds_table,
         "cargo-cyclonedx",
         "# Whether to use cargo-cyclonedx to generate an SBOM\n",
-        cargo_builds.cargo_cyclonedx.clone(),
+        cargo_builds.cargo_cyclonedx,
     );
 
     // Finalize the table
@@ -1575,7 +1575,7 @@ fn apply_installers(table: &mut toml_edit::Table, installers: &Option<InstallerL
                 );
             }
             BoolOr::Val(v) => {
-                apply_installers_homebrew(installers_table, &v);
+                apply_installers_homebrew(installers_table, v);
             }
         }
     }
@@ -1591,7 +1591,7 @@ fn apply_installers(table: &mut toml_edit::Table, installers: &Option<InstallerL
                 );
             }
             BoolOr::Val(v) => {
-                apply_installers_msi(installers_table, &v);
+                apply_installers_msi(installers_table, v);
             }
         }
     }
@@ -1607,7 +1607,7 @@ fn apply_installers(table: &mut toml_edit::Table, installers: &Option<InstallerL
                 );
             }
             BoolOr::Val(v) => {
-                apply_installers_npm(installers_table, &v);
+                apply_installers_npm(installers_table, v);
             }
         }
     }
@@ -1623,7 +1623,7 @@ fn apply_installers(table: &mut toml_edit::Table, installers: &Option<InstallerL
                 );
             }
             BoolOr::Val(v) => {
-                apply_installers_powershell(installers_table, &v);
+                apply_installers_powershell(installers_table, v);
             }
         }
     }
@@ -1639,7 +1639,7 @@ fn apply_installers(table: &mut toml_edit::Table, installers: &Option<InstallerL
                 );
             }
             BoolOr::Val(v) => {
-                apply_installers_shell(installers_table, &v);
+                apply_installers_shell(installers_table, v);
             }
         }
     }
@@ -1655,7 +1655,7 @@ fn apply_installers(table: &mut toml_edit::Table, installers: &Option<InstallerL
                 );
             }
             BoolOr::Val(v) => {
-                apply_installers_pkg(installers_table, &v);
+                apply_installers_pkg(installers_table, v);
             }
         }
     }
@@ -1666,14 +1666,14 @@ fn apply_installers(table: &mut toml_edit::Table, installers: &Option<InstallerL
         installers_table,
         "updater",
         "# Whether to install an updater program alongside the software\n",
-        installers.updater.clone(),
+        installers.updater,
     );
 
     apply_optional_value(
         installers_table,
         "always-use-latest-updater",
         "# Whether to always use the latest updater version instead of a fixed version\n",
-        installers.always_use_latest_updater.clone(),
+        installers.always_use_latest_updater,
     );
 
 

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -324,11 +324,13 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
         }
     }
 
-    if root_workspace.kind == WorkspaceKind::Generic
-        && initted
-        && crate::config::has_v0_config(root_workspace) {
-        do_migrate()?;
-        return do_init(cfg, args);
+    if let Some(dist_manifest_path) = root_workspace.dist_manifest_path.as_deref() {
+        if root_workspace.kind == WorkspaceKind::Generic
+            && initted
+            && crate::config::is_v0_config(dist_manifest_path) {
+            do_migrate()?;
+            return do_init(cfg, args);
+        }
     }
 
     // If this is a Cargo.toml, offer to either write their config to

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1086,7 +1086,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
         allow_dirty.as_ref(),
     );
 
-    //apply_targets(table, targets);
+    apply_string_list(
+        table,
+        "targets",
+        "# Target platforms to build apps for (Rust target-triple syntax)\n",
+        targets.as_ref(),
+    );
+
     //apply_artifacts(table, artifacts);
     apply_builds(table, builds);
     //apply_ci(table, ci);
@@ -1220,13 +1226,6 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
         "formula",
         "# Customize the Homebrew formula name\n",
         formula.clone(),
-    );
-
-    apply_string_list(
-        table,
-        "targets",
-        "# Target platforms to build apps for (Rust target-triple syntax)\n",
-        targets.as_ref(),
     );
 
     apply_optional_value(
@@ -1532,7 +1531,7 @@ fn apply_builds(toplevel_table: &mut toml_edit::Table, builds: &Option<BuildLaye
         .unwrap_or_else(|| &mut possible_table);
 
     let toml_edit::Item::Table(table) = table else {
-        panic!("Expected [dist.builds] to be a table")
+        panic!("Expected [dist.builds] to be a table");
     };
 
     // / inheritable fields

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1078,20 +1078,6 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
     /*
     apply_optional_value(
         table,
-        "tap",
-        "# A GitHub repo to push Homebrew formulas to\n",
-        tap.clone(),
-    );
-
-    apply_optional_value(
-        table,
-        "formula",
-        "# Customize the Homebrew formula name\n",
-        formula.clone(),
-    );
-
-    apply_optional_value(
-        table,
         "dist",
         "# Whether to consider the binaries in a package for distribution (defaults true)\n",
         *dist,
@@ -1702,7 +1688,22 @@ fn apply_installers_homebrew(installers_table: &mut toml_edit::Table, homebrew: 
 
     apply_installers_common(homebrew_table, &homebrew.common);
 
-    // TODO(migration): implement this (similar to shell)
+    apply_optional_value(
+        homebrew_table,
+        "tap",
+        "# A GitHub repo to push Homebrew formulas to\n",
+        tap.clone(),
+    );
+
+    apply_optional_value(
+        homebrew_table,
+        "formula",
+        "# Customize the Homebrew formula name\n",
+        formula.clone(),
+    );
+
+    // Finalize the table
+    pkg_table.decor_mut().set_prefix("\n# Configure the built Homebrew installer\n");
 }
 
 fn apply_installers_msi(installers_table: &mut toml_edit::Table, msi: &MsiInstallerLayer) {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -711,7 +711,7 @@ fn get_new_dist_metadata(
     let has_ci = meta
         .ci
         .as_ref()
-        .is_some_and(|ci| ci.github.as_ref().is_some_and(|gh| gh.not_false()));
+        .is_some_and(|ci| ci.github.is_some_and_not_false());
 
     let existing_shell_config = installers.shell.is_some_and_not_false();
     let existing_powershell_config = installers.powershell.is_some_and_not_false();
@@ -820,7 +820,7 @@ fn get_new_dist_metadata(
     }
 
     // Special handling of the Homebrew installer
-    if installers.homebrew.as_ref().is_some_and(|hb| hb.not_false()) {
+    if installers.homebrew.is_some_and_not_false() {
         let homebrew_is_new = !existing_homebrew_config;
 
         if homebrew_is_new {
@@ -873,7 +873,7 @@ fn get_new_dist_metadata(
     }
 
     // Special handling of the npm installer
-    if installers.npm.as_ref().is_some_and(|npm| npm.not_false()) {
+    if installers.npm.is_some_and_not_false() {
         // If npm is being newly enabled here, prompt for a @scope
         let npm_is_new = !existing_npm_config;
         if npm_is_new {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -325,7 +325,7 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
             return do_init(cfg, args);
         }
     }
-//=====================
+
     // If this is a Cargo.toml, offer to either write their config to
     // a dist-workspace.toml, or migrate existing config there
     let mut newly_initted_generic = false;
@@ -647,8 +647,6 @@ fn get_new_dist_metadata(
     // once the user has any one enabled, right now it's just annoying to always
     // prompt for Github CI support.
     if meta.ci.is_none() {
-
-
         // FIXME: when there is more than one option this should be a proper
         // multiselect like the installer selector is! For now we do
         // most of the multi-select logic and then just give a prompt.
@@ -716,7 +714,6 @@ fn get_new_dist_metadata(
     let existing_pkg_config = meta.installers.is_some_and(|ins| ins.pkg.is_some_and(|pkg| pkg.truthy()));
 
     {
-
         // If they have CI, then they can use fetching installers,
         // otherwise they can only do vendored installers.
         let known: &[InstallerStyle] = if has_ci {
@@ -1001,7 +998,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
         publishers,
     } = &meta;
 
-/*
+    /*
     // Forcibly inline the default install_path if not specified,
     // and if we've specified a shell or powershell installer
     let install_path = if install_path.is_none()
@@ -1017,7 +1014,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
     } else {
         install_path.clone()
     };
-*/
+    */
 
     apply_optional_value(
         table,
@@ -1057,7 +1054,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
 
     if let Some(installers) = installers {
         // InstallerLayer
-/*
+        /*
         if let Some(homebrew) = &installers.homebrew {
             match homebrew {
                 BoolOr::Bool(b) => {
@@ -1156,11 +1153,11 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
             "# Whether to always use the latest updater version instead of a fixed version",
             installers.always_use_latest_updater.clone(),
         );
-*/
+        */
     }
 
 
-/*
+    /*
     apply_string_or_list(table, "ci", "# CI backends to support\n", ci.as_ref());
 
     apply_string_list(
@@ -1479,7 +1476,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
         "# Which kinds of packaged libraries to install\n",
         install_libraries.as_ref(),
     );
-*/
+    */
 
     // Finalize the table
     table.decor_mut().set_prefix("\n# Config for 'dist'\n");
@@ -1517,7 +1514,7 @@ fn apply_builds(toplevel_table: &mut toml_edit::Table, builds: &Option<BuildLaye
     //#[serde(rename = "dependencies")]
     //system_dependencies: Option<SystemDependencies>,
 
-        /*
+    /*
     apply_optional_min_glibc_version(
         table,
         "min-glibc-version",
@@ -1531,7 +1528,7 @@ fn apply_builds(toplevel_table: &mut toml_edit::Table, builds: &Option<BuildLaye
         "# Whether to use omnibor-cli to generate OmniBOR Artifact IDs\n",
         *omnibor,
     );
-        */
+    */
 }
 
 fn apply_cargo_builds(builds_table: &mut toml_edit::Table, builds: &BuildLayer) {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1048,6 +1048,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
         publishers,
     } = &meta;
 
+    // TODO(migration): figure out what we need to do with this
     /*
     // Forcibly inline the default install_path if not specified,
     // and if we've specified a shell or powershell installer
@@ -1108,6 +1109,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
     apply_installers(table, installers);
     apply_publishers(table, publishers);
 
+    // TODO(migration): make sure all of these are handled
     /*
     apply_string_or_list(table, "ci", "# CI backends to support\n", ci.as_ref());
 
@@ -1401,7 +1403,7 @@ fn apply_artifacts(table: &mut toml_edit::Table, artifacts: &Option<ArtifactLaye
         panic!("Expected [dist.artifacts] to be a table");
     };
 
-    // ...
+    // TODO(migration): implement this
 
     // Finalize the table
     artifacts_table.decor_mut().set_prefix("\n# Artifact configuration for dist\n");
@@ -1545,7 +1547,7 @@ fn apply_system_dependencies(builds_table: &mut toml_edit::Table, system_depende
         return;
     };
 
-
+    // TODO(migration): implement this
 }
 
 fn apply_ci(table: &mut toml_edit::Table, ci: &Option<CiLayer>) {
@@ -1557,7 +1559,7 @@ fn apply_ci(table: &mut toml_edit::Table, ci: &Option<CiLayer>) {
         panic!("Expected [dist.ci] to be a table");
     };
 
-    // ...
+    // TODO(migration): implement this
 
     // Finalize the table
     ci_table.decor_mut().set_prefix("\n# CI configuration for dist\n");
@@ -1572,7 +1574,7 @@ fn apply_hosts(table: &mut toml_edit::Table, hosts: &Option<HostLayer>) {
         panic!("Expected [dist.hosts] to be a table");
     };
 
-    // ...
+    // TODO(migration): implement this
 
     // Finalize the table
     hosts_table.decor_mut().set_prefix("\n# Hosting configuration for dist\n");
@@ -1731,7 +1733,7 @@ fn apply_installers_common(table: &mut toml_edit::Table, common: &CommonInstalle
     );
 
     // / Aliases to install binaries as
-    // FIXME/TODO: pub bin_aliases: Option<SortedMap<String, Vec<String>>>,
+    // TODO(migration): handle `pub bin_aliases: Option<SortedMap<String, Vec<String>>>`
 }
 
 fn apply_installers_homebrew(installers_table: &mut toml_edit::Table, homebrew: &HomebrewInstallerLayer) {
@@ -1744,7 +1746,7 @@ fn apply_installers_homebrew(installers_table: &mut toml_edit::Table, homebrew: 
 
     apply_installers_common(homebrew_table, &homebrew.common);
 
-    // TODO: similar to shell
+    // TODO(migration): implement this (similar to shell)
 }
 
 fn apply_installers_msi(installers_table: &mut toml_edit::Table, msi: &MsiInstallerLayer) {
@@ -1757,7 +1759,7 @@ fn apply_installers_msi(installers_table: &mut toml_edit::Table, msi: &MsiInstal
 
     apply_installers_common(msi_table, &msi.common);
 
-    // TODO: similar to shell
+    // TODO(migration): implement this (similar to shell)
 }
 
 fn apply_installers_npm(installers_table: &mut toml_edit::Table, npm: &NpmInstallerLayer) {
@@ -1770,7 +1772,7 @@ fn apply_installers_npm(installers_table: &mut toml_edit::Table, npm: &NpmInstal
 
     apply_installers_common(npm_table, &npm.common);
 
-    // TODO: similar to shell
+    // TODO(migration): implement this (similar to shell)
 }
 
 fn apply_installers_powershell(installers_table: &mut toml_edit::Table, powershell: &PowershellInstallerLayer) {
@@ -1783,7 +1785,7 @@ fn apply_installers_powershell(installers_table: &mut toml_edit::Table, powershe
 
     apply_installers_common(powershell_table, &powershell.common);
 
-    // TODO: similar to shell
+    // TODO(migration): implement this (similar to shell)
 }
 
 fn apply_installers_shell(installers_table: &mut toml_edit::Table, shell: &ShellInstallerLayer) {
@@ -1796,7 +1798,7 @@ fn apply_installers_shell(installers_table: &mut toml_edit::Table, shell: &Shell
 
     apply_installers_common(shell_table, &shell.common);
 
-    // TODO
+    // TODO(migration): implement this
 }
 
 fn apply_installers_pkg(installers_table: &mut toml_edit::Table, pkg: &PkgInstallerLayer) {
@@ -1818,22 +1820,23 @@ fn apply_installers_pkg(installers_table: &mut toml_edit::Table, pkg: &PkgInstal
 
     apply_optional_value(
         pkg_table,
-        "install_location",
+        "install-location",
         "# The location to which software should be installed (defaults to /usr/local)\n",
         pkg.install_location.clone(),
     );
+
+    // TODO(migration): verify there's no other macOS/pkg stuff to add here
 }
 
 fn apply_publishers(table: &mut toml_edit::Table, publishers: &Option<PublisherLayer>) {
     let Some(publishers_table) = table.get_mut("publishers") else {
-        // Nothing to do.
         return;
     };
     let toml_edit::Item::Table(publishers_table) = publishers_table else {
         panic!("Expected [dist.publishers] to be a table");
     };
 
-    // ...
+    // TODO(migration): implement this
 
     // Finalize the table
     publishers_table.decor_mut().set_prefix("\n# Publisher configuration for dist\n");
@@ -1901,6 +1904,7 @@ where
 }
 
 /// Similar to [`apply_optional_value`][] but specialized to `MacPkgConfig`, since we're not able to work with structs dynamically
+// TODO(migration): This should be replaced by `apply_installers_pkg() -- once that's done, remove this.
 fn apply_optional_mac_pkg(
     table: &mut toml_edit::Table,
     key: &str,

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -386,7 +386,7 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
     };
 
     if let Some(meta) = &multi_meta.workspace {
-        apply_dist_to_workspace_toml(&mut workspace_toml, desired_workspace_kind, meta);
+        apply_dist_to_workspace_toml(&mut workspace_toml, meta);
     }
 
     eprintln!();
@@ -979,7 +979,6 @@ fn get_new_dist_metadata(
 /// Update a workspace toml-edit document with the current DistMetadata value
 pub(crate) fn apply_dist_to_workspace_toml(
     workspace_toml: &mut toml_edit::DocumentMut,
-    _workspace_kind: WorkspaceKind,
     meta: &TomlLayer,
 ) {
     let metadata = workspace_toml.as_item_mut();

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1589,6 +1589,8 @@ fn apply_installers(table: &mut toml_edit::Table, installers: &Option<InstallerL
         panic!("Expected [dist.installers] to be a table");
     };
 
+    apply_installers_common(installers_table, &installers.common);
+
     if let Some(homebrew) = &installers.homebrew {
         match homebrew {
             BoolOr::Bool(b) => {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -11,7 +11,14 @@ use crate::{
         self,
         v1::{
             artifacts::ArtifactLayer, builds::BuildLayer, ci::CiLayer,
-            hosts::HostLayer, installers::InstallerLayer, publishers::PublisherLayer,
+            hosts::HostLayer,
+            installers::{
+                homebrew::HomebrewInstallerLayer, msi::MsiInstallerLayer,
+                npm::NpmInstallerLayer, pkg::PkgInstallerLayer,
+                powershell::PowershellInstallerLayer, shell::ShellInstallerLayer,
+                CommonInstallerLayer, InstallerLayer,
+            },
+            publishers::PublisherLayer,
             layer::BoolOr, TomlLayer,
         },
         CiStyle, Config, DistMetadata, HostingStyle, InstallPathStrategy, InstallerStyle,
@@ -1101,110 +1108,6 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
     apply_installers(table, installers);
     apply_publishers(table, publishers);
 
-    if let Some(installers) = installers {
-        // InstallerLayer
-        /*
-        if let Some(homebrew) = &installers.homebrew {
-            match homebrew {
-                BoolOr::Bool(b) => {
-                    apply_optional_value(
-                        installers_table,
-                        "homebrew",
-                        "# Whether to build a Homebrew installer",
-                        installers.updater.clone(),
-                    );
-                }
-                BoolOr::Val(v) => {
-                    // HomebrewInstallerLayer
-
-                }
-            }
-        }
-
-        if let Some(msi) = &installers.msi {
-            match msi {
-                BoolOr::Bool(b) => {
-                    /* handle bool */
-                }
-                BoolOr::Val(v) => {
-                    /* handle MsiInstallerLayer */
-                }
-            }
-        }
-
-        if let Some(npm) = &installers.npm {
-            match npm {
-                BoolOr::Bool(b) => {
-                    /* handle bool */
-                }
-                BoolOr::Val(v) => {
-                    /* handle NpmInstallerLayer */
-                }
-            }
-        }
-
-        if let Some(powershell) = &installers.powershell {
-            match powershell {
-                BoolOr::Bool(b) => {
-                    // handle bool
-                }
-                BoolOr::Val(v) => {
-                    // PowershellInstallerLayer
-                }
-            }
-        }
-
-        if let Some(shell) = &installers.shell {
-            match shell {
-                BoolOr::Bool(b) => {
-                    // handle bool
-                }
-                BoolOr::Val(v) => {
-                    // ShellInstallerLayer
-                }
-            }
-        }
-
-        if let Some(pkg) = &installers.pkg {
-            match pkg {
-                BoolOr::Bool(b) => {
-                    apply_optional_value(
-                        installers_table,
-                        "pkg",
-                        "\n# Configuration for the Mac .pkg installer\n",
-                        Some(b),
-                    );
-                }
-                BoolOr::Val(v) => {
-                    // PkgInstallerLayer
-                    apply_optional_mac_pkg(
-                        installers_table,
-                        "pkg",
-                        "\n# Configuration for the Mac .pkg installer\n",
-                        Some(v).as_ref(),
-                    );
-                }
-            }
-        }
-
-        // installer.updater: Option<Bool>
-        // installer.always_use_latest_updater: Option<bool>
-        apply_optional_value(
-            installers_table,
-            "updater",
-            "# Whether to install an updater program alongside the software",
-            installers.updater.clone(),
-        );
-
-        apply_optional_value(
-            installers_table,
-            "always-use-latest-updater",
-            "# Whether to always use the latest updater version instead of a fixed version",
-            installers.always_use_latest_updater.clone(),
-        );
-        */
-    }
-
     /*
     apply_string_or_list(table, "ci", "# CI backends to support\n", ci.as_ref());
 
@@ -1269,13 +1172,6 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
         "npm-package",
         "# The npm package should have this name\n",
         npm_package.as_deref(),
-    );
-
-    apply_optional_value(
-        table,
-        "install-success-msg",
-        "# Custom message to display on successful install\n",
-        install_success_msg.as_deref(),
     );
 
     apply_optional_value(
@@ -1362,13 +1258,6 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
         github_releases_submodule_path
             .as_ref()
             .map(|a| a.to_string()),
-    );
-
-    apply_string_or_list(
-        table,
-        "install-path",
-        "# Path that installers should place binaries in\n",
-        install_path.as_ref(),
     );
 
     apply_string_list(
@@ -1497,12 +1386,6 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
         package_libraries.as_ref(),
     );
 
-    apply_string_or_list(
-        table,
-        "install-libraries",
-        "# Which kinds of packaged libraries to install\n",
-        install_libraries.as_ref(),
-    );
     */
 
     // Finalize the table
@@ -1696,18 +1579,247 @@ fn apply_hosts(table: &mut toml_edit::Table, hosts: &Option<HostLayer>) {
 }
 
 fn apply_installers(table: &mut toml_edit::Table, installers: &Option<InstallerLayer>) {
+    let Some(installers) = installers else {
+        return;
+    };
     let Some(installers_table) = table.get_mut("installers") else {
-        // Nothing to do.
         return;
     };
     let toml_edit::Item::Table(installers_table) = installers_table else {
         panic!("Expected [dist.installers] to be a table");
     };
 
-    // ...
+    if let Some(homebrew) = &installers.homebrew {
+        match homebrew {
+            BoolOr::Bool(b) => {
+                apply_optional_value(
+                    installers_table,
+                    "homebrew",
+                    "# Whether to build a Homebrew installer\n",
+                    Some(*b),
+                );
+            }
+            BoolOr::Val(v) => {
+                apply_installers_homebrew(installers_table, &v);
+            }
+        }
+    }
+
+    if let Some(msi) = &installers.msi {
+        match msi {
+            BoolOr::Bool(b) => {
+                apply_optional_value(
+                    installers_table,
+                    "msi",
+                    "# Whether to build an MSI installer\n",
+                    Some(*b),
+                );
+            }
+            BoolOr::Val(v) => {
+                apply_installers_msi(installers_table, &v);
+            }
+        }
+    }
+
+    if let Some(npm) = &installers.npm {
+        match npm {
+            BoolOr::Bool(b) => {
+                apply_optional_value(
+                    installers_table,
+                    "npm",
+                    "# Whether to build an NPM installer\n",
+                    Some(*b),
+                );
+            }
+            BoolOr::Val(v) => {
+                apply_installers_npm(installers_table, &v);
+            }
+        }
+    }
+
+    if let Some(powershell) = &installers.powershell {
+        match powershell {
+            BoolOr::Bool(b) => {
+                apply_optional_value(
+                    installers_table,
+                    "powershell",
+                    "# Whether to build a PowerShell installer\n",
+                    Some(*b),
+                );
+            }
+            BoolOr::Val(v) => {
+                apply_installers_powershell(installers_table, &v);
+            }
+        }
+    }
+
+    if let Some(shell) = &installers.shell {
+        match shell {
+            BoolOr::Bool(b) => {
+                apply_optional_value(
+                    installers_table,
+                    "shell",
+                    "# Whether to build a Shell installer\n",
+                    Some(*b),
+                );
+            }
+            BoolOr::Val(v) => {
+                apply_installers_shell(installers_table, &v);
+            }
+        }
+    }
+
+    if let Some(pkg) = &installers.pkg {
+        match pkg {
+            BoolOr::Bool(b) => {
+                apply_optional_value(
+                    installers_table,
+                    "pkg",
+                    "\n# Configuration for the Mac .pkg installer\n",
+                    Some(*b),
+                );
+            }
+            BoolOr::Val(v) => {
+                apply_installers_pkg(installers_table, &v);
+            }
+        }
+    }
+
+    // installer.updater: Option<Bool>
+    // installer.always_use_latest_updater: Option<bool>
+    apply_optional_value(
+        installers_table,
+        "updater",
+        "# Whether to install an updater program alongside the software\n",
+        installers.updater.clone(),
+    );
+
+    apply_optional_value(
+        installers_table,
+        "always-use-latest-updater",
+        "# Whether to always use the latest updater version instead of a fixed version\n",
+        installers.always_use_latest_updater.clone(),
+    );
+
 
     // Finalize the table
     installers_table.decor_mut().set_prefix("\n# Installer configuration for dist\n");
+}
+
+fn apply_installers_common(table: &mut toml_edit::Table, common: &CommonInstallerLayer) {
+    apply_string_or_list(
+        table,
+        "install-path",
+        "# Path that installers should place binaries in\n",
+        common.install_path.as_ref(),
+    );
+
+    apply_optional_value(
+        table,
+        "install-success-msg",
+        "# Custom message to display on successful install\n",
+        common.install_success_msg.as_deref(),
+    );
+
+    apply_string_or_list(
+        table,
+        "install-libraries",
+        "# Which kinds of packaged libraries to install\n",
+        common.install_libraries.as_ref(),
+    );
+
+    // / Aliases to install binaries as
+    // FIXME/TODO: pub bin_aliases: Option<SortedMap<String, Vec<String>>>,
+}
+
+fn apply_installers_homebrew(installers_table: &mut toml_edit::Table, homebrew: &HomebrewInstallerLayer) {
+    let Some(homebrew_table) = installers_table.get_mut("homebrew") else {
+        return;
+    };
+    let toml_edit::Item::Table(homebrew_table) = homebrew_table else {
+        panic!("Expected [dist.installers.homebrew] to be a table");
+    };
+
+    apply_installers_common(homebrew_table, &homebrew.common);
+
+    // TODO: similar to shell
+}
+
+fn apply_installers_msi(installers_table: &mut toml_edit::Table, msi: &MsiInstallerLayer) {
+    let Some(msi_table) = installers_table.get_mut("msi") else {
+        return;
+    };
+    let toml_edit::Item::Table(msi_table) = msi_table else {
+        panic!("Expected [dist.installers.msi] to be a table");
+    };
+
+    apply_installers_common(msi_table, &msi.common);
+
+    // TODO: similar to shell
+}
+
+fn apply_installers_npm(installers_table: &mut toml_edit::Table, npm: &NpmInstallerLayer) {
+    let Some(npm_table) = installers_table.get_mut("npm") else {
+        return;
+    };
+    let toml_edit::Item::Table(npm_table) = npm_table else {
+        panic!("Expected [dist.installers.npm] to be a table");
+    };
+
+    apply_installers_common(npm_table, &npm.common);
+
+    // TODO: similar to shell
+}
+
+fn apply_installers_powershell(installers_table: &mut toml_edit::Table, powershell: &PowershellInstallerLayer) {
+    let Some(powershell_table) = installers_table.get_mut("powershell") else {
+        return;
+    };
+    let toml_edit::Item::Table(powershell_table) = powershell_table else {
+        panic!("Expected [dist.installers.powershell] to be a table");
+    };
+
+    apply_installers_common(powershell_table, &powershell.common);
+
+    // TODO: similar to shell
+}
+
+fn apply_installers_shell(installers_table: &mut toml_edit::Table, shell: &ShellInstallerLayer) {
+    let Some(shell_table) = installers_table.get_mut("shell") else {
+        return;
+    };
+    let toml_edit::Item::Table(shell_table) = shell_table else {
+        panic!("Expected [dist.installers.shell] to be a table");
+    };
+
+    apply_installers_common(shell_table, &shell.common);
+
+    // TODO
+}
+
+fn apply_installers_pkg(installers_table: &mut toml_edit::Table, pkg: &PkgInstallerLayer) {
+    let Some(pkg_table) = installers_table.get_mut("pkg") else {
+        return;
+    };
+    let toml_edit::Item::Table(pkg_table) = pkg_table else {
+        panic!("Expected [dist.installers.pkg] to be a table");
+    };
+
+    apply_installers_common(pkg_table, &pkg.common);
+
+    apply_optional_value(
+        pkg_table,
+        "identifier",
+        "# A unique identifier, in tld.domain.package format\n",
+        pkg.identifier.clone(),
+    );
+
+    apply_optional_value(
+        pkg_table,
+        "install_location",
+        "# The location to which software should be installed (defaults to /usr/local)\n",
+        pkg.install_location.clone(),
+    );
 }
 
 fn apply_publishers(table: &mut toml_edit::Table, publishers: &Option<PublisherLayer>) {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -731,7 +731,7 @@ fn get_new_dist_metadata(
         }
     }
 
-    let old_installers = if let Some(installers) = &meta.installers {
+    let old_installers = if let Some(installers) = &orig_meta.installers {
         installers.to_owned()
     } else {
         Default::default()

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1,4 +1,4 @@
-use axoasset::{toml_edit, LocalAsset};
+use axoasset::{toml, toml_edit, LocalAsset};
 use axoproject::{WorkspaceGraph, WorkspaceInfo, WorkspaceKind};
 use camino::Utf8PathBuf;
 use cargo_dist_schema::TripleNameRef;
@@ -199,11 +199,52 @@ fn do_migrate_from_dist_toml() -> DistResult<()> {
     Ok(())
 }
 
+fn do_migrate_from_v0() -> DistResult<()> {
+    let workspaces = config::get_project()?;
+    let root_workspace = workspaces.root_workspace();
+    let manifest_path = &root_workspace.manifest_path;
+
+    if config::load_config(manifest_path).is_ok() {
+        // We're already on a V1 config, no need to migrate!
+        return Ok(());
+    }
+
+    // Load in the root workspace toml to edit and write back
+    let Ok(old_config) = config::load_v0_config(manifest_path) else {
+        // We don't have a valid v0 _or_ v1 config. No migration can be done.
+        // It feels weird to return Ok(()) here, but I think it's right?
+        return Ok(());
+    };
+
+    let Some(dist_metadata) = &old_config.dist else {
+        // We don't have a valid v0 config. No migration can be done.
+        return Ok(());
+    };
+
+    let dist = dist_metadata.to_toml_layer(true);
+
+    let workspace = old_config.workspace;
+    let package = None;
+
+    let config = config::v1::DistWorkspaceConfig {
+        dist,
+        workspace,
+        package,
+    };
+
+    let workspace_toml_text = toml::to_string(&config)?;
+
+    // Write new config file.
+    axoasset::LocalAsset::write_new(&workspace_toml_text, manifest_path)?;
+
+    Ok(())
+}
+
 /// Run `dist migrate`
 pub fn do_migrate() -> DistResult<()> {
     do_migrate_from_rust_workspace()?;
     do_migrate_from_dist_toml()?;
-    //do_migrate_from_v0()?;
+    do_migrate_from_v0()?;
     Ok(())
 }
 
@@ -275,7 +316,7 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
             .interact()?;
 
         if is_migrating {
-            do_migrate_from_rust_workspace()?;
+            do_migrate()?;
             return do_init(cfg, args);
         }
     }

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1076,15 +1076,6 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
 
     // TODO(migration): make sure all of these are handled
     /*
-    apply_string_or_list(table, "ci", "# CI backends to support\n", ci.as_ref());
-
-    apply_string_list(
-        table,
-        "installers",
-        "# The installers to generate for each app\n",
-        installers.as_ref(),
-    );
-
     apply_optional_value(
         table,
         "tap",

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -329,9 +329,10 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
 
     if let Some(dist_manifest_path) = root_workspace.dist_manifest_path.as_deref() {
         if root_workspace.kind == WorkspaceKind::Generic
-            && initted
-            && crate::config::is_v0_config(dist_manifest_path)
+            && crate::config::looks_like_v0_config(dist_manifest_path)
         {
+            eprintln!("Found outdated configuration -- performing an automatic migration.");
+            eprintln!();
             do_migrate()?;
             return do_init(cfg, args);
         }

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -718,14 +718,14 @@ fn get_new_dist_metadata(
     let has_ci = meta
         .ci
         .as_ref()
-        .is_some_and(|ci| ci.github.as_ref().is_some_and(|gh| gh.truthy()));
+        .is_some_and(|ci| ci.github.as_ref().is_some_and(|gh| gh.not_false()));
 
-    let existing_shell_config = installers.shell.as_ref().is_some_and(|sh| sh.truthy());
-    let existing_powershell_config = installers.powershell.as_ref().is_some_and(|ps| ps.truthy());
-    let existing_npm_config = installers.npm.as_ref().is_some_and(|npm| npm.truthy());
-    let existing_homebrew_config = installers.homebrew.as_ref().is_some_and(|hb| hb.truthy());
-    let existing_msi_config = installers.msi.as_ref().is_some_and(|msi| msi.truthy());
-    let existing_pkg_config = installers.pkg.as_ref().is_some_and(|pkg| pkg.truthy());
+    let existing_shell_config = installers.shell.as_ref().is_some_and(|sh| sh.not_false());
+    let existing_powershell_config = installers.powershell.as_ref().is_some_and(|ps| ps.not_false());
+    let existing_npm_config = installers.npm.as_ref().is_some_and(|npm| npm.not_false());
+    let existing_homebrew_config = installers.homebrew.as_ref().is_some_and(|hb| hb.not_false());
+    let existing_msi_config = installers.msi.as_ref().is_some_and(|msi| msi.not_false());
+    let existing_pkg_config = installers.pkg.as_ref().is_some_and(|pkg| pkg.not_false());
 
     {
         let mut defaults: SortedMap<&str, bool> = SortedMap::new();
@@ -827,7 +827,7 @@ fn get_new_dist_metadata(
     }
 
     // Special handling of the Homebrew installer
-    if installers.homebrew.as_ref().is_some_and(|hb| hb.truthy()) {
+    if installers.homebrew.as_ref().is_some_and(|hb| hb.not_false()) {
         let homebrew_is_new = !existing_homebrew_config;
 
         if homebrew_is_new {
@@ -853,7 +853,7 @@ fn get_new_dist_metadata(
             } else {
                 let mut homebrew = match installers.homebrew.clone().unwrap_or(BoolOr::Bool(true)) {
                     BoolOr::Val(v) => v,
-                    // The hb.truthy() condition above means this should never be false.
+                    // The hb.not_false() condition above means this should never be false.
                     BoolOr::Bool(_b) => Default::default(),
                 };
 
@@ -880,7 +880,7 @@ fn get_new_dist_metadata(
     }
 
     // Special handling of the npm installer
-    if installers.npm.as_ref().is_some_and(|npm| npm.truthy()) {
+    if installers.npm.as_ref().is_some_and(|npm| npm.not_false()) {
         // If npm is being newly enabled here, prompt for a @scope
         let npm_is_new = !existing_npm_config;
         if npm_is_new {
@@ -919,7 +919,7 @@ fn get_new_dist_metadata(
 
             let mut npm = match installers.npm.unwrap_or(BoolOr::Bool(true)) {
                 BoolOr::Val(v) => v,
-                // The npm.truthy() condition above means this should never be false.
+                // The npm.not_false() condition above means this should never be false.
                 BoolOr::Bool(_b) => Default::default(),
             };
 

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1730,7 +1730,9 @@ fn apply_installers_msi(installers_table: &mut toml_edit::Table, msi: &MsiInstal
 
     apply_installers_common(msi_table, &msi.common);
 
-    // TODO(migration): implement this (similar to shell)
+    // There are no items under MsiInstallerConfig aside from `msi.common`.
+
+    msi_table.decor_mut().set_prefix("\n# Configure the built MSI installer\n");
 }
 
 fn apply_installers_npm(installers_table: &mut toml_edit::Table, npm: &NpmInstallerLayer) {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -324,6 +324,13 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
         }
     }
 
+    if root_workspace.kind == WorkspaceKind::Generic
+        && initted
+        && crate::config::has_v0_config(root_workspace) {
+        do_migrate()?;
+        return do_init(cfg, args);
+    }
+
     // If this is a Cargo.toml, offer to either write their config to
     // a dist-workspace.toml, or migrate existing config there
     let mut newly_initted_generic = false;

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -281,24 +281,6 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
     let root_workspace = workspaces.root_workspace();
     let check = console::style("✔".to_string()).for_stderr().green();
 
-    eprintln!("let's setup your dist config...");
-    eprintln!();
-
-    // For each [workspace] Cargo.toml in the workspaces, initialize [profile]
-    let mut did_add_profile = false;
-    for workspace_idx in workspaces.all_workspace_indices() {
-        let workspace = workspaces.workspace(workspace_idx);
-        if workspace.kind == WorkspaceKind::Rust {
-            let mut workspace_toml = config::load_toml(&workspace.manifest_path)?;
-            did_add_profile |= init_dist_profile(cfg, &mut workspace_toml)?;
-            config::write_toml(&workspace.manifest_path, workspace_toml)?;
-        }
-    }
-
-    if did_add_profile {
-        eprintln!("{check} added [profile.dist] to your workspace Cargo.toml");
-    }
-
     // Load in the root workspace toml to edit and write back
     let workspace_toml = config::load_toml(&root_workspace.manifest_path)?;
     let initted = has_metadata_table(root_workspace);
@@ -336,6 +318,24 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
             do_migrate()?;
             return do_init(cfg, args);
         }
+    }
+
+    eprintln!("let's setup your dist config...");
+    eprintln!();
+
+    // For each [workspace] Cargo.toml in the workspaces, initialize [profile]
+    let mut did_add_profile = false;
+    for workspace_idx in workspaces.all_workspace_indices() {
+        let workspace = workspaces.workspace(workspace_idx);
+        if workspace.kind == WorkspaceKind::Rust {
+            let mut workspace_toml = config::load_toml(&workspace.manifest_path)?;
+            did_add_profile |= init_dist_profile(cfg, &mut workspace_toml)?;
+            config::write_toml(&workspace.manifest_path, workspace_toml)?;
+        }
+    }
+
+    if did_add_profile {
+        eprintln!("{check} added [profile.dist] to your workspace Cargo.toml");
     }
 
     // If this is a Cargo.toml, offer to either write their config to

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -10,8 +10,9 @@ use crate::{
     config::{
         self,
         v1::{
-            builds::BuildLayer, hosts::HostLayer, installers::InstallerLayer, layer::BoolOr,
-            TomlLayer,
+            artifacts::ArtifactLayer, builds::BuildLayer, ci::CiLayer,
+            hosts::HostLayer, installers::InstallerLayer, publishers::PublisherLayer,
+            layer::BoolOr, TomlLayer,
         },
         CiStyle, Config, DistMetadata, HostingStyle, InstallPathStrategy, InstallerStyle,
         MacPkgConfig, PublishStyle,
@@ -1093,12 +1094,12 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
         targets.as_ref(),
     );
 
-    //apply_artifacts(table, artifacts);
+    apply_artifacts(table, artifacts);
     apply_builds(table, builds);
-    //apply_ci(table, ci);
-    //apply_hosts(table, hosts);
-    //apply_installers(table, installers);
-    //apply_publishers(table, publishers);
+    apply_ci(table, ci);
+    apply_hosts(table, hosts);
+    apply_installers(table, installers);
+    apply_publishers(table, publishers);
 
     if let Some(installers) = installers {
         // InstallerLayer
@@ -1522,15 +1523,28 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
     table.decor_mut().set_prefix("\n# Config for 'dist'\n");
 }
 
-fn apply_builds(toplevel_table: &mut toml_edit::Table, builds: &Option<BuildLayer>) {
-    let Some(builds) = builds else { return };
+fn apply_artifacts(table: &mut toml_edit::Table, artifacts: &Option<ArtifactLayer>) {
+    let Some(artifacts_table) = table.get_mut("artifacts") else {
+        // Nothing to do.
+        return;
+    };
+    let toml_edit::Item::Table(artifacts_table) = artifacts_table else {
+        panic!("Expected [dist.artifacts] to be a table");
+    };
 
-    let mut possible_table = toml_edit::table();
-    let table = toplevel_table
-        .get_mut("builds")
-        .unwrap_or_else(|| &mut possible_table);
+    // ...
+}
 
-    let toml_edit::Item::Table(table) = table else {
+fn apply_builds(table: &mut toml_edit::Table, builds: &Option<BuildLayer>) {
+    let Some(builds) = builds else {
+        // Nothing to do.
+        return;
+    };
+    let Some(builds_table) = table.get_mut("builds") else {
+        // Nothing to do.
+        return;
+    };
+    let toml_edit::Item::Table(builds_table) = builds_table else {
         panic!("Expected [dist.builds] to be a table");
     };
 
@@ -1543,7 +1557,7 @@ fn apply_builds(toplevel_table: &mut toml_edit::Table, builds: &Option<BuildLaye
     // / whether to sign macos binaries with apple
     //macos_sign: Option<bool>,
 
-    apply_cargo_builds(table, builds);
+    apply_cargo_builds(builds_table, builds);
     // / cargo builds
     //cargo: Option<BoolOr<CargoBuildLayer>>,
     // / generic builds
@@ -1638,6 +1652,54 @@ fn apply_cargo_builds(builds_table: &mut toml_edit::Table, builds: &BuildLayer) 
         "# Whether to use cargo-cyclonedx to generate an SBOM\n",
         cargo_builds.cargo_cyclonedx.clone(),
     );
+}
+
+fn apply_ci(table: &mut toml_edit::Table, ci: &Option<CiLayer>) {
+    let Some(ci_table) = table.get_mut("ci") else {
+        // Nothing to do.
+        return;
+    };
+    let toml_edit::Item::Table(ci_table) = ci_table else {
+        panic!("Expected [dist.ci] to be a table");
+    };
+
+    // ...
+}
+
+fn apply_hosts(table: &mut toml_edit::Table, hosts: &Option<HostLayer>) {
+    let Some(hosts_table) = table.get_mut("hosts") else {
+        // Nothing to do.
+        return;
+    };
+    let toml_edit::Item::Table(hosts_table) = hosts_table else {
+        panic!("Expected [dist.hosts] to be a table");
+    };
+
+    // ...
+}
+
+fn apply_installers(table: &mut toml_edit::Table, installers: &Option<InstallerLayer>) {
+    let Some(installers_table) = table.get_mut("installers") else {
+        // Nothing to do.
+        return;
+    };
+    let toml_edit::Item::Table(installers_table) = installers_table else {
+        panic!("Expected [dist.installers] to be a table");
+    };
+
+    // ...
+}
+
+fn apply_publishers(table: &mut toml_edit::Table, publishers: &Option<PublisherLayer>) {
+    let Some(publishers_table) = table.get_mut("publishers") else {
+        // Nothing to do.
+        return;
+    };
+    let toml_edit::Item::Table(publishers_table) = publishers_table else {
+        panic!("Expected [dist.publishers] to be a table");
+    };
+
+    // ...
 }
 
 /// Update the toml table to add/remove this value

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -701,17 +701,13 @@ fn get_new_dist_metadata(
         };
 
         if github_selected {
-            meta.ci
-                .as_mut()
-                .map(|ci| ci.github = Some(BoolOr::Bool(true)));
+            if let Some(ci) = meta.ci.as_mut() {
+                ci.github = Some(BoolOr::Bool(true));
+            }
         }
     }
 
-    let old_installers = if let Some(installers) = &orig_meta.installers {
-        installers.to_owned()
-    } else {
-        Default::default()
-    };
+    let old_installers = orig_meta.installers.map(|i| i.to_owned()).unwrap_or_default();
 
     let mut installers = old_installers.clone();
 
@@ -1448,7 +1444,7 @@ fn apply_cargo_builds(builds_table: &mut toml_edit::Table, builds: &BuildLayer) 
     let mut possible_table = toml_edit::table();
     let cargo_builds_table = builds_table
         .get_mut("cargo")
-        .unwrap_or_else(|| &mut possible_table);
+        .unwrap_or(&mut possible_table);
 
     let toml_edit::Item::Table(cargo_builds_table) = cargo_builds_table else {
         panic!("Expected [dist.builds.cargo] to be a table")

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -275,7 +275,7 @@ pub fn do_init(cfg: &Config, args: &InitArgs) -> DistResult<()> {
             .interact()?;
 
         if is_migrating {
-            do_migrate()?;
+            do_migrate_from_rust_workspace()?;
             return do_init(cfg, args);
         }
     }

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1721,18 +1721,18 @@ fn apply_installers_homebrew(installers_table: &mut toml_edit::Table, homebrew: 
         homebrew_table,
         "tap",
         "# A GitHub repo to push Homebrew formulas to\n",
-        tap.clone(),
+        homebrew.tap.clone(),
     );
 
     apply_optional_value(
         homebrew_table,
         "formula",
         "# Customize the Homebrew formula name\n",
-        formula.clone(),
+        homebrew.formula.clone(),
     );
 
     // Finalize the table
-    pkg_table.decor_mut().set_prefix("\n# Configure the built Homebrew installer\n");
+    homebrew_table.decor_mut().set_prefix("\n# Configure the built Homebrew installer\n");
 }
 
 fn apply_installers_msi(installers_table: &mut toml_edit::Table, msi: &MsiInstallerLayer) {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1075,19 +1075,6 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
     // TODO(migration): make sure all of these are handled
     /*
 
-    apply_optional_value(
-        table,
-        "npm-package",
-        "# The npm package should have this name\n",
-        npm_package.as_deref(),
-    );
-
-    apply_optional_value(
-        table,
-        "npm-scope",
-        "# A namespace to use when publishing this package to the npm registry\n",
-        npm_scope.as_deref(),
-    );
 
     apply_optional_value(
         table,
@@ -1756,7 +1743,19 @@ fn apply_installers_npm(installers_table: &mut toml_edit::Table, npm: &NpmInstal
 
     apply_installers_common(npm_table, &npm.common);
 
-    // TODO(migration): implement this (similar to shell)
+    apply_optional_value(
+        npm_table,
+        "package",
+        "# The npm package should have this name\n",
+        npm.package.as_deref(),
+    );
+
+    apply_optional_value(
+        npm_table,
+        "scope",
+        "# A namespace to use when publishing this package to the npm registry\n",
+        npm.scope.as_deref(),
+    );
 }
 
 fn apply_installers_powershell(installers_table: &mut toml_edit::Table, powershell: &PowershellInstallerLayer) {

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1076,13 +1076,6 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &TomlLayer) {
 
     // TODO(migration): make sure all of these are handled
     /*
-    apply_optional_value(
-        table,
-        "dist",
-        "# Whether to consider the binaries in a package for distribution (defaults true)\n",
-        *dist,
-    );
-
     apply_string_list(
         table,
         "include",

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -682,42 +682,7 @@ fn get_new_dist_metadata(
     }
 
     // Enable CI backends
-    // FIXME: when there is more than one option we maybe shouldn't hide this
-    // once the user has any one enabled, right now it's just annoying to always
-    // prompt for Github CI support.
     if meta.ci.is_none() {
-        // FIXME: when there is more than one option this should be a proper
-        // multiselect like the installer selector is! For now we do
-        // most of the multi-select logic and then just give a prompt.
-        /*let known = &[CiStyle::Github];
-        let mut defaults = vec![];
-        let mut keys = vec![];
-        let mut github_key = 0;
-        for item in known {
-            // If this CI style is in their config, keep it
-            // If they passed it on the CLI, flip it on
-            let mut default = meta
-                .ci
-                .as_ref()
-                .map(|ci| ci.contains(item))
-                .unwrap_or(false)
-                || cfg.ci.contains(item);
-
-            // Currently default to enabling github CI because we don't
-            // support anything else and we can give a good error later
-            #[allow(irrefutable_let_patterns)]
-            if let CiStyle::Github = item {
-                github_key = 0;
-                default = true;
-            }
-            defaults.push(default);
-            // This match is here to remind you to add new CiStyles
-            // to `known` above!
-            keys.push(match item {
-                CiStyle::Github => "github",
-            });
-        }*/
-
         // Prompt the user
         let prompt = r#"enable Github CI and Releases?"#;
         let default_value = true;
@@ -750,7 +715,6 @@ fn get_new_dist_metadata(
 
     // Enable installer backends (if they have a CI backend that can provide URLs)
     // FIXME: "vendored" installers like msi could be enabled without any CI...
-    //let has_ci = meta.ci.as_ref().map(|ci| !ci.is_empty()).unwrap_or(false);
     let has_ci = meta
         .ci
         .as_ref()

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -978,13 +978,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         };
         let dist_dir = target_dir.join(TARGET_DIST);
 
+        // Read the global config
         let mut workspace_metadata =
-            // Read the global config
-            config::parse_metadata_table_or_manifest(
-                &root_workspace.manifest_path,
-                root_workspace.dist_manifest_path.as_deref(),
-                root_workspace.cargo_metadata_table.as_ref(),
-            )?;
+            config::try_load_config(root_workspace.dist_manifest_path.as_ref())?.dist;
 
         let workspace_layer = workspace_metadata.clone();
         workspace_metadata.make_relative_to(&root_workspace.workspace_dir);
@@ -1002,11 +998,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let mut package_configs = vec![];
 
         for (pkg_idx, package) in workspaces.all_packages() {
-            let mut package_metadata = config::parse_metadata_table_or_manifest(
-                &package.manifest_path,
-                package.dist_manifest_path.as_deref(),
-                package.cargo_metadata_table.as_ref(),
-            )?;
+            let mut package_metadata = config::try_load_config(package.dist_manifest_path.as_ref())?.dist;
             package_configs.push(app_config(
                 workspaces,
                 pkg_idx,

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -986,7 +986,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 root_workspace.cargo_metadata_table.as_ref(),
             )?;
 
-        let workspace_layer = workspace_metadata.to_toml_layer(true);
+        let workspace_layer = workspace_metadata.clone();
         workspace_metadata.make_relative_to(&root_workspace.workspace_dir);
 
         let config = workspace_config(workspaces, workspace_layer.clone());
@@ -1011,7 +1011,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 workspaces,
                 pkg_idx,
                 workspace_layer.clone(),
-                package_metadata.to_toml_layer(false),
+                package_metadata.clone(), // fixme: this seems suspect since we call seemingly-mutating functions on it later
             ));
 
             package_metadata.make_relative_to(&package.package_root);

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -978,6 +978,12 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         };
         let dist_dir = target_dir.join(TARGET_DIST);
 
+        if let Some(metadata_path) = &root_workspace.dist_manifest_path {
+            if metadata_path.exists() && config::looks_like_v0_config(metadata_path) {
+                return Err(DistError::OldConfigFormat {});
+            }
+        }
+
         // Read the global config
         let mut workspace_metadata =
             config::try_load_config(root_workspace.dist_manifest_path.as_ref())?.dist;

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1004,7 +1004,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let mut package_configs = vec![];
 
         for (pkg_idx, package) in workspaces.all_packages() {
-            let mut package_metadata = config::try_load_config(package.dist_manifest_path.as_ref())?.dist;
+            let mut package_metadata =
+                config::try_load_package_config(package.dist_manifest_path.as_ref())?;
             package_configs.push(app_config(
                 workspaces,
                 pkg_idx,


### PR DESCRIPTION
Replaced by:

1. #1697 
2. #1698 
3. #1699 
4. #1701 
5. #1703 
6. #1704 
7. #1705 
8. #1706 
9. #1717 
10. #1718 
11. #1719 
12. #1721 
13. #1723 
14. #1724 
15. #1725 
16. #1726 
17. #1727 
18. #1730 
19. #1763  

---

Required functionality for this PR:
1. [x] make `dist migrate` move v0 to v1
   - [x] Have `do_migrate_from_v0()` actually copy workspace members to the new configuration.
2. [ ] make `dist init` use v1
3. [x] make everything but `dist init` load v1
4. [ ] make sure `dist plan` (and other commands) gives an actionable error for v0 configs

Current state (2025-01-10):

![image](https://github.com/user-attachments/assets/b5aedbc0-c629-4cd8-b85d-720ad4ec83fd)

![image](https://github.com/user-attachments/assets/6f10e3cd-79ea-4fe0-be64-633d6cec559d)

