### PR TITLE
feat: migrate dist.toml to dist-workspace.toml

### DIFF
--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -1,4 +1,4 @@
-use axoasset::toml_edit;
+use axoasset::{toml_edit, LocalAsset};
 use axoproject::{WorkspaceGraph, WorkspaceInfo, WorkspaceKind};
 use camino::Utf8PathBuf;
 use cargo_dist_schema::TripleNameRef;
@@ -162,23 +162,39 @@ fn do_migrate_from_dist_toml() -> DistResult<()> {
 
     // OK, now we know we have a root-level dist.toml. Time to fix that.
     let workspace_toml = config::load_toml(&root_workspace.manifest_path)?;
-    let mut original_workspace_toml = workspace_toml.clone();
 
+    eprintln!("Migrating tables");
     // Init a generic workspace with the appropriate members
     let mut new_workspace_toml = new_generic_workspace();
-    // Copy the [dist] section
+    // First copy the [package] section
+    if let Some(package) = workspace_toml.get("package") {
+        let mut package = package.clone();
+        // Ensures we have whitespace between the end of [workspace] and
+        // the start of [package]
+        if let Some(table) = package.as_table_mut() {
+            let decor = table.decor_mut();
+            // Try to keep existing comments if we can
+            if let Some(desc) = decor.prefix().and_then(|p| p.as_str()) {
+                if !desc.starts_with('\n') {
+                    decor.set_prefix(&format!("\n{desc}"));
+                }
+            } else {
+                decor.set_prefix("\n");
+            }
+        }
+        new_workspace_toml.insert("package", package.to_owned());
+    }
+    // ...then copy the [dist] section
     if let Some(dist) = workspace_toml.get("dist") {
         new_workspace_toml.insert("dist", dist.to_owned());
     }
-    // Then prune it from the old copy
-    original_workspace_toml.remove("dist");
 
     // Finally, write out the new config...
     let filename = "dist-workspace.toml";
     let destination = root_workspace.workspace_dir.join(filename);
     config::write_toml(&destination, new_workspace_toml)?;
-    // ...and write the modified config
-    config::write_toml(&root_workspace.manifest_path, original_workspace_toml)?;
+    // ...and delete the old config
+    LocalAsset::remove_file(&root_workspace.manifest_path)?;
 
     Ok(())
 }


### PR DESCRIPTION
We treat dist.toml-alone generic projects a bit awkwardly because of our migration to the new metadata structure. The easiest solution for us is to migrate those proejcts to dist-workspace.toml, where they can be structured and interpreted the same as Cargo.toml projects with a dist-workspace.toml file.

~~Currently, this produces a pair of `dist-workspace.toml` and `dist.toml`. The `dist.toml` retains the package-level metadata, while the `dist-workspace.toml` contains a workspace entry with a single `dist:.` member and the `[dist]` metadata.~~

At @ashleygwilliams's suggestion, I've updated axoproject so it now supports generic projects whose `dist-workspace.toml` contains a `[workspace]` and `[package]` in the same file, and we produce that single metadata when migrating solo-`dist.toml`.