### PR TITLE
Notify processes to refresh their environment variables

### DIFF
--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -469,7 +469,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -537,8 +537,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1839,7 +1839,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1907,8 +1907,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1866,7 +1866,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1934,8 +1934,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1820,7 +1820,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1888,8 +1888,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1791,7 +1791,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1859,8 +1859,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1791,7 +1791,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1859,8 +1859,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1839,7 +1839,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1907,8 +1907,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1843,7 +1843,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1911,8 +1911,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1886,7 +1886,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1954,8 +1954,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1811,7 +1811,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1879,8 +1879,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -1819,7 +1819,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1887,8 +1887,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -1663,7 +1663,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1731,8 +1731,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -1743,7 +1743,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1811,8 +1811,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1807,7 +1807,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1875,8 +1875,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {
@@ -3743,7 +3819,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -3811,8 +3887,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1843,7 +1843,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1911,8 +1911,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1743,7 +1743,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1811,8 +1811,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1743,7 +1743,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1811,8 +1811,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1820,7 +1820,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1888,8 +1888,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1876,8 +1876,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1852,8 +1852,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1852,8 +1852,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1852,8 +1852,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1852,8 +1852,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1807,7 +1807,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1875,8 +1875,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1852,8 +1852,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1852,8 +1852,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1852,8 +1852,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1852,8 +1852,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1807,7 +1807,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1875,8 +1875,84 @@ function Add-Path($OrigPathToAdd) {
     $NewPath = $PathToAdd + $OldPath
     # We use -Force here to make the value already existing not be an error
     $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
+    # Notify running processes that they should update their environment variables (in particular, explorer.exe)
+    # This ensures we only need a shell restart, rather than a system restart
+    Update-EnvironmentVariables
     return $true
   }
+}
+
+<#
+Source: https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1
+Version 1.0.4
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+function Update-EnvironmentVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification='Function name is accurate')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification='Keeping function identical to upstream')]
+
+    <#
+    .SYNOPSIS
+    Reloads environment variables.
+
+    .DESCRIPTION
+    Need to be run after changing global environment variables.
+    For details see http://stackoverflow.com/questions/6979741/setting-environment-variables-requires-reboot-on-64-bit
+
+    .EXAMPLE
+    Update-EnvironmentVariables
+    #>
+
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    Write-Verbose "Reloading environment variables."
+    if (-not ("win32.nativemethods" -As [type])) {
+        # import sendmessagetimeout from win32
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [intptr]0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [uintptr]::zero
+
+    # Notify all windows of environment block change
+    [void]([win32.nativemethods]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [uintptr]::Zero, "Environment", 2, 5000, [ref]$result))
+
+    if ($result -eq 0) {
+        throw "Failed to reload environment variables."
+    } else {
+        Write-Verbose "Environment variables have been reloaded."
+    }
 }
 
 function Initialize-Environment() {


### PR DESCRIPTION
Closes https://github.com/axodotdev/cargo-dist/issues/1614

This currently only handles the powershell installer, not msi. If someone wants to add and test msi support that would be great! Also, can someone please take over updating snapshot tests for me? I tried but got weird diffs like this:

<img width="1186" alt="Screenshot 2024-12-19 at 9 23 43 AM" src="https://github.com/user-attachments/assets/58166530-c370-4f87-8fa5-f2f8968fd288" />

And a few other failures I couldn't figure out.

---

The opening post here https://github.com/axodotdev/cargo-dist/issues/1614#issue-2727351448 discusses the problem in detail.

I opted to bring in the (well known?) implementation from the powershell gallery
https://www.powershellgallery.com/packages/PSCI/1.0.4/Content/core%5Cutils%5CUpdate-EnvironmentVariables.ps1

I tested this on a Windows machine and this _does_ indeed seem to work for me! Here's a video of me showing that
- previously I did not have `.local/` in the registry
- then I ran the patched installer
- then it _was_ in the registry (but still the cli tool air was not accessible yet)
- then I restarted Powershell and air was available

https://vimeo.com/1040789276?share=copy#t=0

---

@fdcastel noted that it did not work for him. I believe I can explain that. Likely what happened was:

- He ran the old installer once. It updated the registry, but did not tell processes to update their environments
- He patched the old installer with the code in this PR, but did not restart his machine
- He ran the patched installer. It detected that the registry had been updated already, and did not update it again (thus, not pushing an environment refresh notification).
- Because no refresh notification was pushed, it looks like nothing happened

Running `Get-Item -Path "HKCU:\Environment"` would likely show an updated `Path` for him, even though `ruff` won't be accessible at the command line until after a system restart.