### PR TITLE
Rework `Add-Path` to avoid expanding and request an environment refresh

### DIFF
--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -469,7 +469,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -491,54 +491,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1839,7 +1839,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1861,54 +1861,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1866,7 +1866,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1888,54 +1888,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1820,7 +1820,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1842,54 +1842,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1791,7 +1791,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1813,54 +1813,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -1791,7 +1791,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1813,54 +1813,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1839,7 +1839,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1861,54 +1861,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1843,7 +1843,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1865,54 +1865,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1886,7 +1886,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1908,54 +1908,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1811,7 +1811,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1833,54 +1833,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -1819,7 +1819,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1841,54 +1841,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -1663,7 +1663,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1685,54 +1685,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -1743,7 +1743,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1765,54 +1765,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1807,7 +1807,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1829,54 +1829,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {
@@ -3743,7 +3736,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -3765,54 +3758,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1843,7 +1843,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1865,54 +1865,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1743,7 +1743,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1765,54 +1765,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1743,7 +1743,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1765,54 +1765,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1820,7 +1820,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1842,54 +1842,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1808,7 +1808,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1830,54 +1830,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1806,54 +1806,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1806,54 +1806,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1806,54 +1806,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1806,54 +1806,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1807,7 +1807,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1829,54 +1829,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1806,54 +1806,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1806,54 +1806,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1806,54 +1806,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1784,7 +1784,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1806,54 +1806,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1807,7 +1807,7 @@ function Invoke-Installer($artifacts, $platforms) {
     Add-Ci-Path $dest_dir
     if (Add-Path $dest_dir) {
         Write-Information ""
-        Write-Information "To add $dest_dir to your PATH, either restart your system or run:"
+        Write-Information "To add $dest_dir to your PATH, either restart your shell or run:"
         Write-Information ""
         Write-Information "    set Path=$dest_dir;%Path%   (cmd)"
         Write-Information "    `$env:Path = `"$dest_dir;`$env:Path`"   (powershell)"
@@ -1829,54 +1829,47 @@ function Add-Ci-Path($OrigPathToAdd) {
   }
 }
 
-# Try to add the given path to PATH via the registry
+# Try to permanently add the given path to the user-level
+# PATH via the registry
 #
 # Returns true if the registry was modified, otherwise returns false
 # (indicating it was already on PATH)
-function Add-Path($OrigPathToAdd) {
-  Write-Verbose "Adding $OrigPathToAdd to your PATH"
-  $RegistryPath = "HKCU:\Environment"
-  $PropertyName = "Path"
-  $PathToAdd = $OrigPathToAdd
+#
+# This is a lightly modified version of this solution:
+# https://stackoverflow.com/questions/69236623/adding-path-permanently-to-windows-using-powershell-doesnt-appear-to-work/69239861#69239861
+function Add-Path($LiteralPath) {
+  Write-Verbose "Adding $LiteralPath to your user-level PATH"
 
-  $Item = if (Test-Path $RegistryPath) {
-    # If the registry key exists, get it
-    Get-Item -Path $RegistryPath
-  } else {
-    # If the registry key doesn't exist, create it
-    Write-Verbose  "Creating $RegistryPath"
-    New-Item -Path $RegistryPath -Force
-  }
+  $RegistryPath = 'registry::HKEY_CURRENT_USER\Environment'
 
-  $OldPath = ""
-  try {
-    # Try to get the old PATH value. If that fails, assume we're making it from scratch.
-    # Otherwise assume there's already paths in here and use a ; separator
-    $OldPath = $Item | Get-ItemPropertyValue -Name $PropertyName
-    $PathToAdd = "$PathToAdd;"
-  } catch {
-    # We'll be creating the PATH from scratch
-    Write-Verbose "No $PropertyName Property exists on $RegistryPath (we'll make one)"
-  }
+  # Note the use of the .GetValue() method to ensure that the *unexpanded* value is returned.
+  # If 'Path' is not an existing item in the registry, '' is returned.
+  $CurrentDirectories = (Get-Item -LiteralPath $RegistryPath).GetValue('Path', '', 'DoNotExpandEnvironmentNames') -split ';' -ne ''
 
-  # Check if the path is already there
-  #
-  # We don't want to incorrectly match "C:\blah\" to "C:\blah\blah\", so we include the semicolon
-  # delimiters when searching, ensuring exact matches. To avoid corner cases we add semicolons to
-  # both sides of the input, allowing us to pretend we're always in the middle of a list.
-  Write-Verbose "Old $PropertyName Property is $OldPath"
-  if (";$OldPath;" -like "*;$OrigPathToAdd;*") {
-    # Already on path, nothing to do
-    Write-Verbose "install dir already on PATH, all done!"
+  if ($LiteralPath -in $CurrentDirectories) {
+    Write-Verbose "Install directory $LiteralPath already on PATH, all done!"
     return $false
-  } else {
-    # Actually update PATH
-    Write-Verbose "Actually mutating $PropertyName Property"
-    $NewPath = $PathToAdd + $OldPath
-    # We use -Force here to make the value already existing not be an error
-    $Item | New-ItemProperty -Name $PropertyName -Value $NewPath -PropertyType String -Force | Out-Null
-    return $true
   }
+
+  Write-Verbose "Actually mutating 'Path' Property"
+
+  # Add the new path to the front of the PATH.
+  # The ',' turns $LiteralPath into an array, which the array of
+  # $CurrentDirectories is then added to.
+  $NewPath = (,$LiteralPath + $CurrentDirectories) -join ';'
+
+  # Update the registry. Will create the property if it did not already exist.
+  # Note the use of ExpandString to create a registry property with a REG_EXPAND_SZ data type.
+  Set-ItemProperty -Type ExpandString -LiteralPath $RegistryPath Path $NewPath
+
+  # Broadcast WM_SETTINGCHANGE to get the Windows shell to reload the
+  # updated environment, via a dummy [Environment]::SetEnvironmentVariable() operation.
+  $DummyName = 'cargo-dist-' + [guid]::NewGuid().ToString()
+  [Environment]::SetEnvironmentVariable($DummyName, 'cargo-dist-dummy', 'User')
+  [Environment]::SetEnvironmentVariable($DummyName, [NullString]::value, 'User')
+
+  Write-Verbose "Successfully added $LiteralPath to your user-level PATH"
+  return $true
 }
 
 function Initialize-Environment() {


### PR DESCRIPTION
Closes #1614
Closes #1657

A rework of #1657 after everything we have learned from https://github.com/axodotdev/cargo-dist/pull/1657#issuecomment-2555684533. Please read that comment / PR as it describes everything in detail.

I will once again require some help with snapshot updating!

Key points:

- Powershell installers no longer forcibly expand "expandable variables" in your `PATH`, like `%EXPAND%`
- Powershell installers no longer change your user-level `Path` registry property from `REG_EXPAND_SZ` to `REG_SZ`
- Powershell installers no longer require a _system_ restart, and now only require a _shell_ restart, like Unix shell installers

I tested this myself by:
- Completely resetting my `Path` to a state before dist touched it
- Adding `%TEMP%` into my `Path` as a test "expandable" variable 
- Running a patched powershell installer with these changes, resulting in:
    - The `Path` stayed a `REG_EXPAND_SZ` data type
    - The `Path` retained my unexpanded `%TEMP%`
    - On a _shell_ restart, I could load the cli tool I installed
- Running the patched powershell installer _again_, nothing happened because it detected the existing install directory in the `Path`

I even went so far as to wipe out my `Path` property in the registry to see if it could create it "from scratch" if it wasn't there already, and it worked and was created with the right `REG_EXPAND_SZ` type.

<img width="645" alt="Screenshot 2024-12-19 at 4 34 21 PM" src="https://github.com/user-attachments/assets/91bb133d-4ab1-4a12-9fe5-079fa690a3b9" />
