### PR TITLE
feat: check for shadowed binaries in shell installer

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -447,6 +447,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -651,6 +653,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -527,6 +527,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -702,6 +704,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -531,6 +531,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -706,6 +708,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -543,6 +543,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -718,6 +720,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -510,6 +510,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -685,6 +687,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss_only.snap
@@ -510,6 +510,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -685,6 +687,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -531,6 +531,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -706,6 +708,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -531,6 +531,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -706,6 +708,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -585,6 +585,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -760,6 +762,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -585,6 +585,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -760,6 +762,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -449,6 +449,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -624,6 +626,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {
@@ -2454,6 +2474,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -2629,6 +2651,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -527,6 +527,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -702,6 +704,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -507,6 +507,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -682,6 +684,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -531,6 +531,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -706,6 +708,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -694,6 +696,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -677,6 +679,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -677,6 +679,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -677,6 +679,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -677,6 +679,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -520,6 +520,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -690,6 +692,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -677,6 +679,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -677,6 +679,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -677,6 +679,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -519,6 +519,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -677,6 +679,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -520,6 +520,8 @@ install() {
     local _force_install_dir
     # Which install layout to use - "flat" or "hierarchical"
     local _install_layout="unspecified"
+    # A list of binaries which are shadowed in the PATH
+    local _shadowed_bins=""
 
     # Check the newer app-specific variable before falling back
     # to the older generic one
@@ -690,6 +692,24 @@ install() {
             say "    source $_fish_env_script_path_expr (fish)"
         fi
     fi
+
+    _shadowed_bins="$(check_for_shadowed_bins "$_install_dir" "$_bins")"
+    if [ -n "$_shadowed_bins" ]; then
+        say "WARNING: The following commands are shadowed by other commands in your PATH:$_shadowed_bins"
+    fi
+}
+
+check_for_shadowed_bins() {
+    local _install_dir="$1"
+    local _bins="$2"
+
+    for _bin_name in $_bins; do
+        if [ "$(command -v "$_bin_name")" != "$_install_dir/$_bin_name" ]; then
+            _shadowed_bins="$_shadowed_bins $_bin_name"
+        fi
+    done
+
+    echo "$_shadowed_bins"
 }
 
 print_home_for_script() {


### PR DESCRIPTION
This was a user request. In some cases, the user may have multiple copies of something installed, and won't realize the copy installed by the shell installer has been shadowed in their `PATH`. It's useful for us to test that and provide an explicit warning.

Tested and working:

```
$ ./axolotlsay-installer.sh
downloading axolotlsay 0.2.320 aarch64-apple-darwin
installing to /Users/mistydemeo/.cargo/bin
  axolotlsay
  axolotlsay-update
everything's installed!
WARNING: The following commands are shadowed by other commands in your PATH: axolotlsay
```