### PR TITLE
fix: Avoid 'dist migrate' deleting dist-workspace.toml.

### DIFF
--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -155,7 +155,7 @@ fn do_migrate_from_dist_toml() -> DistResult<()> {
     }
 
     if root_workspace.kind != WorkspaceKind::Generic
-        && root_workspace.manifest_path.file_name() != Some("dist.toml")
+        || root_workspace.manifest_path.file_name() != Some("dist.toml")
     {
         return Ok(());
     }


### PR DESCRIPTION
A condition like the following was intended to be switched from `==` to `!=`:

    A == B && C == D

The correct way to do this would be:

    A != B || C != D

However, instead, what we had was this inverted logic:

    A != B && C != D

In practice, because of the specific things we were checking, this meant instead of *never* deleting dist-workspace.toml, we were *always* deleting it.