### PR TITLE
feat: prioritize github over axo

### DIFF
--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -304,6 +304,11 @@ pub enum DistError {
         style: String,
     },
 
+    /// unrecognized hosting style
+    #[error("No GitHub hosting is defined!")]
+    #[diagnostic(help("Releases must have at least GitHub hosting for updates to be supported."))]
+    NoGitHubHosting {},
+
     /// unrecognized ci style
     #[error("{style} is not a recognized ci provider")]
     UnrecognizedCiStyle {

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -2032,7 +2032,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 artifacts,
                 hint,
                 desc,
-                receipt: InstallReceipt::from_metadata(&self.inner, release),
+                receipt: InstallReceipt::from_metadata(&self.inner, release)?,
                 bin_aliases,
                 install_libraries: config.install_libraries.clone(),
                 runtime_conditions,
@@ -2275,7 +2275,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 artifacts,
                 hint,
                 desc,
-                receipt: InstallReceipt::from_metadata(&self.inner, release),
+                receipt: InstallReceipt::from_metadata(&self.inner, release)?,
                 bin_aliases,
                 install_libraries: config.install_libraries.clone(),
                 runtime_conditions: RuntimeConditions::default(),
@@ -3345,19 +3345,22 @@ pub struct InstallReceipt {
 
 impl InstallReceipt {
     /// Produces an install receipt for the given DistGraph.
-    pub fn from_metadata(manifest: &DistGraph, release: &Release) -> Option<InstallReceipt> {
+    pub fn from_metadata(
+        manifest: &DistGraph,
+        release: &Release,
+    ) -> DistResult<Option<InstallReceipt>> {
         let hosting = if let Some(hosting) = &manifest.hosting {
             hosting
         } else {
-            return None;
+            return Ok(None);
         };
-        let source_type = if hosting.hosts.contains(&HostingStyle::Axodotdev) {
-            ReleaseSourceType::Axo
-        } else {
+        let source_type = if hosting.hosts.contains(&HostingStyle::Github) {
             ReleaseSourceType::GitHub
+        } else {
+            return Err(DistError::NoGitHubHosting {});
         };
 
-        Some(InstallReceipt {
+        Ok(Some(InstallReceipt {
             // These first five are placeholder values which the installer will update
             install_prefix: "AXO_INSTALL_PREFIX".to_owned(),
             install_layout: InstallLayout::Unspecified,
@@ -3377,7 +3380,7 @@ impl InstallReceipt {
             },
             binary_aliases: BTreeMap::default(),
             modify_path: true,
-        })
+        }))
     }
 }
 

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -49,12 +49,6 @@ param (
 
 $app_name = '{{ app_name }}'
 $app_version = '{{ app_version }}'
-
-{%- if hosting.axodotdev is defined %}
-if ($env:INSTALLER_DOWNLOAD_URL) {
-  $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
-}
-{% else %}
 if ($env:{{ env_vars.ghe_base_url_env_var }}) {
   $installer_base_url = $env:{{ env_vars.ghe_base_url_env_var }}
 } elseif ($env:{{ env_vars.github_base_url_env_var }}) {
@@ -67,7 +61,6 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url{{ hosting.github.artifact_download_path }}"
 }
-{%- endif %}
 
 $receipt = @"
 {{ receipt | tojson }}

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -18,9 +18,6 @@ set -u
 
 APP_NAME="{{ app_name }}"
 APP_VERSION="{{ app_version }}"
-{%- if hosting.axodotdev is defined %}
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-{{ base_url }}}"
-{% else %}
 # Look for GitHub Enterprise-style base URL first
 if [ -n "{{ '${' }}{{ env_vars.ghe_base_url_env_var }}:-}" ]; then
     INSTALLER_BASE_URL="${{ env_vars.ghe_base_url_env_var }}"
@@ -32,7 +29,6 @@ if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
 else
     ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}{{ hosting.github.artifact_download_path }}"
 fi
-{%- endif %}
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "{{ '${' }}{{ env_vars.no_modify_path_env_var }}:-}" ]; then

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -265,7 +265,8 @@ identifier = "dev.axo.axolotsay"
 }
 
 #[test]
-fn axolotlsay_abyss_only() -> Result<(), miette::Report> {
+#[should_panic(expected = r#"No GitHub hosting is defined!"#)]
+fn axolotlsay_abyss_only() {
     let test_name = _function_name!();
     AXOLOTLSAY.run_test(|ctx| {
         let dist_version = ctx.tools.cargo_dist.version().unwrap();
@@ -289,7 +290,7 @@ identifier = "dev.axo.axolotsay"
 install-location = "/opt/axolotlsay"
 
 "#
-        ))?;
+        )).unwrap();
 
         // Run generate to make sure stuff is up to date before running other commands
         let ci_result = ctx.cargo_dist_generate(test_name)?;
@@ -301,7 +302,7 @@ install-location = "/opt/axolotlsay"
         // snapshot all
         main_snap.join(ci_snap).snap();
         Ok(())
-    })
+    }).unwrap()
 }
 
 #[test]

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -24,8 +24,17 @@ set -u
 
 APP_NAME="axolotlsay"
 APP_VERSION="0.2.2"
-ARTIFACT_DOWNLOAD_URL="${INSTALLER_DOWNLOAD_URL:-https://fake.axo.dev/faker/axolotlsay/fake-id-do-not-upload}"
-
+# Look for GitHub Enterprise-style base URL first
+if [ -n "${AXOLOTLSAY_INSTALLER_GHE_BASE_URL:-}" ]; then
+    INSTALLER_BASE_URL="$AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+else
+    INSTALLER_BASE_URL="${AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL:-https://github.com}"
+fi
+if [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+    ARTIFACT_DOWNLOAD_URL="$INSTALLER_DOWNLOAD_URL"
+else
+    ARTIFACT_DOWNLOAD_URL="${INSTALLER_BASE_URL}/axodotdev/axolotlsay/releases/download/v0.2.2"
+fi
 PRINT_VERBOSE=${INSTALLER_PRINT_VERBOSE:-0}
 PRINT_QUIET=${INSTALLER_PRINT_QUIET:-0}
 if [ -n "${AXOLOTLSAY_NO_MODIFY_PATH:-}" ]; then
@@ -45,7 +54,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
 fi
 
 read -r RECEIPT <<EORECEIPT
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 EORECEIPT
 RECEIPT_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/axolotlsay"
 
@@ -1435,13 +1444,21 @@ param (
 
 $app_name = 'axolotlsay'
 $app_version = '0.2.2'
+if ($env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GHE_BASE_URL
+} elseif ($env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL) {
+  $installer_base_url = $env:AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL
+} else {
+  $installer_base_url = "https://github.com"
+}
 if ($env:INSTALLER_DOWNLOAD_URL) {
   $ArtifactDownloadUrl = $env:INSTALLER_DOWNLOAD_URL
+} else {
+  $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
 
-
 $receipt = @"
-{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"axo"},"version":"CENSORED"}
+{"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
 "@
 if ($env:XDG_CONFIG_HOME) {
   $receipt_home = "${env:XDG_CONFIG_HOME}\axolotlsay"


### PR DESCRIPTION
Previously, if the user was multi-host drifting, we preferred to install from Axo. This swaps it so we now prefer GitHub.

We also now make Axo-only publishing an error; GitHub-only and GitHub+Axo are both valid.