### PR TITLE
fix: allow installing apt packages in xwin

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -682,7 +682,7 @@ fn cargo_xwin() -> GithubRunnerConfig {
         container: Some(cargo_dist_schema::ContainerConfig {
             image: ContainerImageRef::from_str("messense/cargo-xwin").to_owned(),
             host: targets::TARGET_X64_LINUX_MUSL.to_owned(),
-            package_manager: None,
+            package_manager: Some(cargo_dist_schema::PackageManager::Apt),
         }),
     }
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -2001,7 +2001,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "container": {
               "image": "messense/cargo-xwin",
               "host": "x86_64-unknown-linux-musl",
-              "package_manager": null
+              "package_manager": "apt"
             },
             "install_dist": {
               "shell": "sh",


### PR DESCRIPTION
The default xwin cross-compile container is apt-based; we should allow apt packages to be installed here without extra configuration on the user's part.

Fixes #1670.