### PR TITLE
chore: update attest-build-provenance action to v2

### DIFF
--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -321,7 +321,7 @@ jobs:
           echo "dist ran successfully"
       {{%- if github_attestations is defined and github_attestations %}}
       - name: Attest
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         with:
           subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       {{%- endif %}}


### PR DESCRIPTION
Since some time there is a v2 version of the attest-build-provenance GitHub action. When used in a project with scorecard/dependabot/renovate using v1 version causes warning, update PRs, etc what `dist` is not happy about unless dirty-mode is enabled. Instead just update the template to use the newest action version.