### PR TITLE
(config-migration) Add BoolOr<T> and Option<BoolOr<T>> helper functions.

### DIFF
--- a/cargo-dist/src/config/v1/layer.rs
+++ b/cargo-dist/src/config/v1/layer.rs
@@ -171,3 +171,40 @@ pub enum BoolOr<T> {
     /// They gave a more interesting value
     Val(T),
 }
+
+impl<T> BoolOr<T> {
+    /// Returns true if it is `BoolOr::Bool(true)`, or if it contains a value.
+    pub fn is_not_false(&self) -> bool {
+        match self {
+            BoolOr::Bool(b) => *b,
+            BoolOr::Val(_v) => true,
+        }
+    }
+}
+
+/// Extension trait to provide `is_none_or_false` and `is_some_and_not_false`.
+pub trait BoolOrOptExt
+where
+    Self: Sized,
+{
+    /// Given an `Option<BoolOr<T>>`, returns `true` if the value is
+    /// `None` or `Some(BoolOr::Bool(false))`.
+    fn is_none_or_false(&self) -> bool;
+
+    /// Given an `Option<BoolOr<T>>`, returns `true` if the value is
+    /// a `Some(BoolOr::Val(...))` or `Some(BoolOr::Bool(true))`.
+    fn is_some_and_not_false(&self) -> bool;
+}
+impl<T> BoolOrOptExt for Option<BoolOr<T>> {
+    fn is_none_or_false(&self) -> bool {
+        !self.is_some_and_not_false()
+    }
+
+    fn is_some_and_not_false(&self) -> bool {
+        if let Some(item) = self {
+            item.is_not_false()
+        } else {
+            false
+        }
+    }
+}


### PR DESCRIPTION
These functions are needed for implementing the v0->v1 config migration.