### PR TITLE
(config-migration) Implement `Display` for `ChecksumStyle`, derive `Default` for `ArtifactLayer` and `InstallerLayer`

### DIFF
--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -678,6 +678,12 @@ impl ChecksumStyle {
     }
 }
 
+impl std::fmt::Display for ChecksumStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.ext())
+    }
+}
+
 /// Which style(s) of configuration to generate
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum GenerateMode {

--- a/cargo-dist/src/config/v1/artifacts/mod.rs
+++ b/cargo-dist/src/config/v1/artifacts/mod.rs
@@ -23,7 +23,7 @@ pub struct WorkspaceArtifactConfig {
     pub checksum: ChecksumStyle,
 }
 /// artifact config (raw from file)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ArtifactLayer {
     /// archive config

--- a/cargo-dist/src/config/v1/installers/mod.rs
+++ b/cargo-dist/src/config/v1/installers/mod.rs
@@ -65,7 +65,7 @@ pub struct InstallerConfigInheritable {
 }
 
 /// installer config (raw from file)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct InstallerLayer {
     /// inheritable fields


### PR DESCRIPTION
This is needed for implementing the v0->v1 config migration.