### PR TITLE
(config-migration) Add `do_migrate_from_v0()` implementation

### DIFF
--- a/axoproject/src/generic.rs
+++ b/axoproject/src/generic.rs
@@ -71,9 +71,9 @@ impl std::fmt::Display for WorkspaceMember {
         match self {
             WorkspaceMember::Generic(path) => write!(f, "{MEMBER_GENERIC}:{path}"),
             #[cfg(feature = "cargo-projects")]
-            WorkspaceMember::Cargo(path) => write!(f, "{MEMBER_CARGO}/{path}"),
+            WorkspaceMember::Cargo(path) => write!(f, "{MEMBER_CARGO}:{path}"),
             #[cfg(feature = "npm-projects")]
-            WorkspaceMember::Npm(path) => write!(f, "${MEMBER_NPM}/{path}"),
+            WorkspaceMember::Npm(path) => write!(f, "${MEMBER_NPM}:{path}"),
         }
     }
 }

--- a/cargo-dist/src/config/v1/mod.rs
+++ b/cargo-dist/src/config/v1/mod.rs
@@ -464,6 +464,22 @@ pub struct TomlLayer {
 }
 
 impl TomlLayer {
+    /// Update `config_version` to the current default.
+    pub fn with_current_config_version(&self) -> Self {
+        let mut new = self.clone();
+        new.config_version = crate::config::ConfigVersion::default();
+        new
+    }
+
+    /// Update `dist_version` to the current dist version.
+    pub fn with_current_dist_version(&self) -> Self {
+        let current_version: semver::Version = std::env!("CARGO_PKG_VERSION").parse()
+            .expect("CARGO_PKG_VERSION was not set -- this is probably a bug in dist; please file an issue!");
+        let mut new = self.clone();
+        new.dist_version = Some(current_version);
+        new
+    }
+
     /// Take any configs that contain paths that are *relative to the file they came from*
     /// and make them relative to the given basepath.
     ///

--- a/cargo-dist/src/config/version.rs
+++ b/cargo-dist/src/config/version.rs
@@ -8,7 +8,6 @@ use crate::DistResult;
 
 /// Represents all known configuration versions.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(untagged)]
 pub enum ConfigVersion {
     /// The original legacy configuration formats are all lumped in as V0.
     #[serde(rename = "0")]

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -74,6 +74,10 @@ pub enum DistError {
     #[error(transparent)]
     TripleError(#[from] dist_schema::target_lexicon::ParseError),
 
+    /// error when using axoasset::toml::to_string() or similar
+    #[error(transparent)]
+    AxoassetTomlSerErr(#[from] axoasset::toml::ser::Error),
+
     /// A problem with a jinja template, which is always a dist bug
     #[error("Failed to render template")]
     #[diagnostic(

--- a/cargo-dist/src/migrate/from_v0.rs
+++ b/cargo-dist/src/migrate/from_v0.rs
@@ -40,6 +40,8 @@ pub fn do_migrate_from_v0() -> DistResult<()> {
         return Ok(());
     }
 
+    eprintln!("migrating dist config from V0 to V1 format...");
+
     // Load in the root workspace toml to edit and write back
     let Ok(old_config) = config::v0::load(manifest_path) else {
         // We don't have a valid v0 _or_ v1 config. No migration can be done.

--- a/cargo-dist/src/migrate/from_v0.rs
+++ b/cargo-dist/src/migrate/from_v0.rs
@@ -11,9 +11,29 @@ use axoasset::toml;
 // need to make every piece of DistConfig derive/impl PartialEq, which is
 // a lot. -duckinator
 fn migrate_from_v0_dist_config(old_config: V0DistConfig) -> DistConfig {
-    let dist = old_config.dist.map(|dist| dist.to_toml_layer(true));
-    let workspace = old_config.workspace;
-    let package = old_config.package;
+    let V0DistConfig {
+        dist,
+        workspace,
+        package,
+    } = old_config;
+
+
+    let current_dist_version: semver::Version = std::env!("CARGO_PKG_VERSION").parse().unwrap();
+    let version_one = semver::Version::new(1, 0, 0);
+
+    let dist = dist
+        // Take Some(v0::DistMetadata) and turn it into Some(v1::TomlLayer).
+        .map(|dist| dist.to_toml_layer(true))
+        .map(|mut dist| {
+            // If dist_version is pinned to <1.0.0, set it to the current version
+            if dist.dist_version < Some(version_one) {
+                dist.dist_version = Some(current_dist_version);
+            }
+
+            // Change config_version from V0 to V1, since we're migrating to it.
+            dist.config_version = config::ConfigVersion::V1;
+            dist
+        });
 
     config::v1::DistConfig {
         dist,

--- a/cargo-dist/src/migrate/from_v0.rs
+++ b/cargo-dist/src/migrate/from_v0.rs
@@ -1,5 +1,50 @@
-use crate::errors::DistResult;
+use crate::config::v0::V0DistConfig;
+use crate::config::v1::DistConfig;
+use crate::{config, errors::DistResult};
+use axoasset::toml;
+
+// A purely-functional subset of `do_migrate_from_v0()`:
+// takes a DistMetadata (v0) and returns an equivalent DistConfig (v1)
+// without touching files on disk.
+//
+// This could theoretically have unit tests written for it, but we would
+// need to make every piece of DistConfig derive/impl PartialEq, which is
+// a lot. -duckinator
+fn migrate_from_v0_dist_config(old_config: V0DistConfig) -> DistConfig {
+    let dist = old_config.dist.map(|dist| dist.to_toml_layer(true));
+    let workspace = old_config.workspace;
+    let package = old_config.package;
+
+    config::v1::DistConfig {
+        dist,
+        workspace,
+        package,
+    }
+}
 
 pub fn do_migrate_from_v0() -> DistResult<()> {
-    unimplemented!()
+    let workspaces = config::get_project()?;
+    let root_workspace = workspaces.root_workspace();
+    let manifest_path = &root_workspace.manifest_path;
+
+    if config::v1::load(manifest_path).is_ok() {
+        // We're already on a V1 config, no need to migrate!
+        return Ok(());
+    }
+
+    // Load in the root workspace toml to edit and write back
+    let Ok(old_config) = config::v0::load(manifest_path) else {
+        // We don't have a valid v0 _or_ v1 config. No migration can be done.
+        // It feels weird to return Ok(()) here, but I think it's right?
+        return Ok(());
+    };
+
+    let config = migrate_from_v0_dist_config(old_config);
+
+    let workspace_toml_text = toml::to_string(&config)?;
+
+    // Write new config file.
+    axoasset::LocalAsset::write_new(&workspace_toml_text, manifest_path)?;
+
+    Ok(())
 }

--- a/cargo-dist/src/migrate/from_v0.rs
+++ b/cargo-dist/src/migrate/from_v0.rs
@@ -17,23 +17,11 @@ fn migrate_from_v0_dist_config(old_config: V0DistConfig) -> DistConfig {
         package,
     } = old_config;
 
-
-    let current_dist_version: semver::Version = std::env!("CARGO_PKG_VERSION").parse().unwrap();
-    let version_one = semver::Version::new(1, 0, 0);
-
-    let dist = dist
-        // Take Some(v0::DistMetadata) and turn it into Some(v1::TomlLayer).
-        .map(|dist| dist.to_toml_layer(true))
-        .map(|mut dist| {
-            // If dist_version is pinned to <1.0.0, set it to the current version
-            if dist.dist_version < Some(version_one) {
-                dist.dist_version = Some(current_dist_version);
-            }
-
-            // Change config_version from V0 to V1, since we're migrating to it.
-            dist.config_version = config::ConfigVersion::V1;
-            dist
-        });
+    let dist = dist.map(|dist| {
+        dist.to_toml_layer(true)
+            .with_current_config_version()
+            .with_current_dist_version()
+    });
 
     config::v1::DistConfig {
         dist,


### PR DESCRIPTION
<details>
<summary>starting Cargo.toml</summary>

```toml
[package]
name = "axolotlsay"
description = "💬 a CLI for learning to distribute CLIs in rust"
version = "0.2.275"
edition = "2021"
license = "MIT OR Apache-2.0"
repository = "https://github.com/mistydemeo/cargodisttest.git"
homepage = "https://github.com/mistydemeo/cargodisttest"

[dependencies]
clap = { version = "4.1.4", features = ["derive"] }
unicode-width = "0.1.10"

[dev-dependencies]
assert_cmd = "2.0.8"

# Config for 'dist'
[workspace.metadata.dist]
# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
cargo-dist-version = "0.25.1"
# CI backends to support
ci = "github"
# The installers to generate for each app
installers = ["shell", "powershell"]
# Target platforms to build apps for (Rust target-triple syntax)
targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
# Which actions to run on pull requests
pr-run-mode = "plan"
# Where to host releases
hosting = "github"
# Whether to install an updater program
install-updater = true
# Whether to enable GitHub Attestations
#github-attestations = true
# Path that installers should place binaries in
install-path = "CARGO_HOME"
# Whether to sign macOS executables
macos-sign = false
# Whether to embed dependency information using cargo-auditable
cargo-auditable = true

[workspace.metadata.dist.aliases]
axolotlsay = ["cargodisttest"]

[workspace.metadata.dist.dependencies.homebrew]
cmake = '*'
libcue = "2.2.1"

[workspace.metadata.dist.dependencies.apt]
cmake = '*'
libcue-dev = '*'

[workspace.metadata.dist.dependencies.chocolatey]
lftp = '*'
cmake = '3.27.6'

[workspace.metadata.dist.github-custom-runners]
x86_64-unknown-linux-gnu = "ubuntu-latest"
```

</details>

<details>
<summary><code>dist migrate</code> (without <code>DIST_V1=true</code>)</summary>

```
~/dev/axodotdev/cargodisttest main+ dist migrate
migrating dist config from Cargo.toml to dist-workspace.toml...
~/dev/axodotdev/cargodisttest main+ git --no-pager diff
diff --git a/Cargo.toml b/Cargo.toml
index be3df3e..839cb04 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,46 +13,3 @@ unicode-width = "0.1.10"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"
-
-# Config for 'dist'
-[workspace.metadata.dist]
-# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.25.1"
-# CI backends to support
-ci = "github"
-# The installers to generate for each app
-installers = ["shell", "powershell"]
-# Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
-# Which actions to run on pull requests
-pr-run-mode = "plan"
-# Where to host releases
-hosting = "github"
-# Whether to install an updater program
-install-updater = true
-# Whether to enable GitHub Attestations
-#github-attestations = true
-# Path that installers should place binaries in
-install-path = "CARGO_HOME"
-# Whether to sign macOS executables
-macos-sign = false
-# Whether to embed dependency information using cargo-auditable
-cargo-auditable = true
-
-[workspace.metadata.dist.aliases]
-axolotlsay = ["cargodisttest"]
-
-[workspace.metadata.dist.dependencies.homebrew]
-cmake = '*'
-libcue = "2.2.1"
-
-[workspace.metadata.dist.dependencies.apt]
-cmake = '*'
-libcue-dev = '*'
-
-[workspace.metadata.dist.dependencies.chocolatey]
-lftp = '*'
-cmake = '3.27.6'
-
-[workspace.metadata.dist.github-custom-runners]
-x86_64-unknown-linux-gnu = "ubuntu-latest"
~/dev/axodotdev/cargodisttest main+ cat dist-workspace.toml 
[workspace]
members = ["cargo:."]

# Config for 'dist'
[dist]
# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
cargo-dist-version = "0.25.1"
# CI backends to support
ci = "github"
# The installers to generate for each app
installers = ["shell", "powershell"]
# Target platforms to build apps for (Rust target-triple syntax)
targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
# Which actions to run on pull requests
pr-run-mode = "plan"
# Where to host releases
hosting = "github"
# Whether to install an updater program
install-updater = true
# Whether to enable GitHub Attestations
#github-attestations = true
# Path that installers should place binaries in
install-path = "CARGO_HOME"
# Whether to sign macOS executables
macos-sign = false
# Whether to embed dependency information using cargo-auditable
cargo-auditable = true

[dist.aliases]
axolotlsay = ["cargodisttest"]

[dist.dependencies.homebrew]
cmake = '*'
libcue = "2.2.1"

[dist.dependencies.apt]
cmake = '*'
libcue-dev = '*'

[dist.dependencies.chocolatey]
lftp = '*'
cmake = '3.27.6'

[dist.github-custom-runners]
x86_64-unknown-linux-gnu = "ubuntu-latest"
~/dev/axodotdev/cargodisttest main+
```

</details>

<details>
<summary><code>DIST_V1=true dist migrate</code></summary>

```
~/dev/axodotdev/cargodisttest main+ DIST_V1=true dist migrate                                 
migrating dist config from V0 to V1 format...
~/dev/axodotdev/cargodisttest main+ cat dist-workspace.toml
[workspace]
members = ["cargo:."]

[dist]
dist-version = "1.0.0-rc.1"
config-version = "1"
targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]

[dist.builds]
macos-sign = false

[dist.builds.cargo]
cargo-auditable = true

[dist.builds.dependencies.homebrew.cmake]
stage = []
targets = []

[dist.builds.dependencies.homebrew.libcue]
version = "2.2.1"
stage = []
targets = []

[dist.builds.dependencies.apt.cmake]
stage = []
targets = []

[dist.builds.dependencies.apt.libcue-dev]
stage = []
targets = []

[dist.builds.dependencies.chocolatey.cmake]
version = "3.27.6"
stage = []
targets = []

[dist.builds.dependencies.chocolatey.lftp]
stage = []
targets = []

[dist.ci]
pr-run-mode = "plan"

[dist.ci.github.runners]
x86_64-unknown-linux-gnu = "ubuntu-latest"

[dist.hosts]
github = true

[dist.installers]
install-path = "CARGO_HOME"
powershell = true
shell = true
updater = true

~/dev/axodotdev/cargodisttest main+ 
```

</details>