### PR TITLE
Pin omnibor-cli version for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,13 @@ jobs:
       # install pnpm for npm runtests
       - run: npm i -g pnpm
       # install omnibor-cli for tests
+      # NOTE: This is hard-coded to a specific version because omnibor-cli,
+      #       omnibor-rs, and gitoid are released on the same repo.
+      #       This means the "latest" release is sometimes NOT actually omnibor-cli!
+      #
+      # SEE ALSO: cargo-dist/src/backend/ci/mod.rs
       - run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/omnibor/omnibor-rs/releases/latest/download/omnibor-cli-installer.sh | sh
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/omnibor/omnibor-rs/releases/download/omnibor-cli-v0.7.0/omnibor-cli-installer.sh | sh
       # Currently there is essentially no difference between default and --all-features,
       # with the difference essentially being polyfilling a new stdio API for MSRV.
       # For now avoid --all-features which causes issues with axoproject.

--- a/cargo-dist/src/backend/ci/mod.rs
+++ b/cargo-dist/src/backend/ci/mod.rs
@@ -34,6 +34,8 @@ const BASE_OMNIBOR_FETCH_URL: &str = "https://github.com/omnibor/omnibor-rs/rele
 // NOTE: This is hard-coded to a specific version because omnibor-cli,
 //       omnibor-rs, and gitoid are released on the same repo.
 //       This means the "latest" release is sometimes NOT actually omnibor-cli!
+//
+// SEE ALSO: .github/workflows/ci.yml
 const OMNIBOR_VERSION: &str = "0.7.0";
 
 /// Info about all the enabled CI backends


### PR DESCRIPTION
They release multiple things from one repo, so latest isn't always omnibor-cli.

I discovered this before (hence the note in `backend/ci/mod.rs`), but forgot to treat `ci.yml` the same way.