### PR TITLE
Add plain cross-compilation mode for riscv64 and loongarch64

### DIFF
--- a/book/src/ci/customizing.md
+++ b/book/src/ci/customizing.md
@@ -119,6 +119,7 @@ dist will transparently use either of:
 
   * [cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild)
   * [cargo-xwin](https://github.com/rust-cross/cargo-xwin)
+  * plain `cargo build` with target-specific linkers
 
 To try and build for the target you specified, from the host you specified.
 


### PR DESCRIPTION
This patch introduces a "plain" cross-compilation mode that cross compiles directly using cargo build and target-specific linker(gcc).

It can be used for architectures where cargo-zigbuild is broken(e.g. riscv64 #1793, loongarch64 #1645)

I have done test locally by running `dist  build -t riscv64gc-unknown-linux-gnu` but not sure how to test such unreleased patches in CI context.

Close #1793