### PR TITLE
ci: use ubuntu-22.04 for x86_64 linux builds

### DIFF
--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -599,7 +599,7 @@ stdout:
             "cache_provider": "github"
           },
           {
-            "runner": "ubuntu-20.04",
+            "runner": "ubuntu-22.04",
             "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -42,3 +42,7 @@ host = "x86_64-unknown-linux-musl"
 [dist.github-custom-runners.aarch64-unknown-linux-musl.container]
 image = "quay.io/pypa/manylinux_2_28_x86_64"
 host = "x86_64-unknown-linux-musl"
+
+[dist.github-custom-runners]
+global = "ubuntu-22.04"
+x86_64-unknown-linux-gnu = "ubuntu-22.04"


### PR DESCRIPTION
Until we have a new release created that defaults to this version.