### PR TITLE
fix: use --locked for from-git installs

### DIFF
--- a/cargo-dist/src/backend/ci/mod.rs
+++ b/cargo-dist/src/backend/ci/mod.rs
@@ -130,7 +130,7 @@ impl InstallStrategy for DistInstallStrategy {
                 "curl --proto '=https' --tlsv1.2 -LsSf {installer_url}/{installer_name}.sh | sh"
             ),
             DistInstallStrategy::GitBranch { branch } => format!(
-                "cargo install --git https://github.com/axodotdev/cargo-dist/ --branch={branch} cargo-dist"
+                "cargo install --git https://github.com/axodotdev/cargo-dist/ --branch={branch} --locked cargo-dist"
             ),
         }).into()
     }


### PR DESCRIPTION
The non-locked dependencies can't be built with Rust 1.87 at the moment.