### PR TITLE
fix ignored configuration key 'msvc-crt-statis'

### DIFF
--- a/cargo-dist/src/config/v0_to_v1.rs
+++ b/cargo-dist/src/config/v0_to_v1.rs
@@ -121,7 +121,8 @@ impl DistMetadata {
             || default_features.is_some()
             || all_features.is_some()
             || cargo_auditable.is_some()
-            || cargo_cyclonedx.is_some();
+            || cargo_cyclonedx.is_some()
+            || msvc_crt_static.is_some();
         let cargo_layer = needs_cargo_build_layer.then_some(BoolOr::Val(CargoBuildLayer {
             common: CommonBuildLayer::default(),
             rust_toolchain_version,

--- a/cargo-dist/src/config/v1/builds/cargo.rs
+++ b/cargo-dist/src/config/v1/builds/cargo.rs
@@ -164,9 +164,9 @@ impl ApplyLayer for WorkspaceCargoBuildConfig {
             precise_builds,
             cargo_auditable,
             cargo_cyclonedx,
+            msvc_crt_static,
             // local-only
             common: _,
-            msvc_crt_static: _,
             features: _,
             default_features: _,
             all_features: _,
@@ -177,6 +177,7 @@ impl ApplyLayer for WorkspaceCargoBuildConfig {
         self.precise_builds.apply_opt(precise_builds);
         self.cargo_auditable.apply_val(cargo_auditable);
         self.cargo_cyclonedx.apply_val(cargo_cyclonedx);
+        self.msvc_crt_static.apply_val(msvc_crt_static);
     }
 }
 impl ApplyLayer for AppCargoBuildConfig {


### PR DESCRIPTION
Setting 'msvc-crt-static = false' under the '[dist]' section of the 'dist-workspace.toml' was ignored when applying configurations to determine the dist build configuration.

Fixed by properly propagating the 'msvc_crt_static' flag when the configurations are merged.

Cherry-picked from https://github.com/astral-sh/cargo-dist/pull/36.