### PR TITLE
ci: run for stable branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     branches:
       # The main branch
       - main
+      - stable
   # And once a week?
   # This can catch things like "rust updated and actually regressed something"
   schedule:


### PR DESCRIPTION
Since active work is happening on here in addition to main right now.