### PR TITLE
Add some more temporary release config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,7 @@
 
 name: Release
 permissions:
-  "attestations": "write"
   "contents": "write"
-  "id-token": "write"
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -144,10 +142,6 @@ jobs:
           # Actually do builds and make zips and whatnot
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
-      - name: Attest
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -51,8 +51,7 @@ stdout:
     }
   },
   "linkage": [],
-  "upload_files": [],
-  "github_attestations": true
+  "upload_files": []
 }
 
 stderr:

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -51,8 +51,7 @@ stdout:
     }
   },
   "linkage": [],
-  "upload_files": [],
-  "github_attestations": true
+  "upload_files": []
 }
 
 stderr:

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -486,8 +486,7 @@ stdout:
     }
   },
   "linkage": [],
-  "upload_files": [],
-  "github_attestations": true
+  "upload_files": []
 }
 
 stderr:

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -36,10 +36,6 @@ stdout:
         "sha256.sum",
         "cargo-dist-aarch64-apple-darwin.tar.xz",
         "cargo-dist-aarch64-apple-darwin.tar.xz.sha256",
-        "cargo-dist-aarch64-unknown-linux-gnu.tar.xz",
-        "cargo-dist-aarch64-unknown-linux-gnu.tar.xz.sha256",
-        "cargo-dist-aarch64-unknown-linux-musl.tar.xz",
-        "cargo-dist-aarch64-unknown-linux-musl.tar.xz.sha256",
         "cargo-dist-x86_64-apple-darwin.tar.xz",
         "cargo-dist-x86_64-apple-darwin.tar.xz.sha256",
         "cargo-dist-x86_64-pc-windows-msvc.zip",
@@ -103,92 +99,6 @@ stdout:
         "aarch64-apple-darwin"
       ]
     },
-    "cargo-dist-aarch64-unknown-linux-gnu.tar.xz": {
-      "name": "cargo-dist-aarch64-unknown-linux-gnu.tar.xz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "aarch64-unknown-linux-gnu"
-      ],
-      "assets": [
-        {
-          "name": "CHANGELOG.md",
-          "path": "CHANGELOG.md",
-          "kind": "changelog"
-        },
-        {
-          "name": "LICENSE-APACHE",
-          "path": "LICENSE-APACHE",
-          "kind": "license"
-        },
-        {
-          "name": "LICENSE-MIT",
-          "path": "LICENSE-MIT",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "id": "cargo-dist-aarch64-unknown-linux-gnu-exe-dist",
-          "name": "dist",
-          "path": "dist",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "cargo-dist-aarch64-unknown-linux-gnu.tar.xz.sha256"
-    },
-    "cargo-dist-aarch64-unknown-linux-gnu.tar.xz.sha256": {
-      "name": "cargo-dist-aarch64-unknown-linux-gnu.tar.xz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "aarch64-unknown-linux-gnu"
-      ]
-    },
-    "cargo-dist-aarch64-unknown-linux-musl.tar.xz": {
-      "name": "cargo-dist-aarch64-unknown-linux-musl.tar.xz",
-      "kind": "executable-zip",
-      "target_triples": [
-        "aarch64-unknown-linux-musl"
-      ],
-      "assets": [
-        {
-          "name": "CHANGELOG.md",
-          "path": "CHANGELOG.md",
-          "kind": "changelog"
-        },
-        {
-          "name": "LICENSE-APACHE",
-          "path": "LICENSE-APACHE",
-          "kind": "license"
-        },
-        {
-          "name": "LICENSE-MIT",
-          "path": "LICENSE-MIT",
-          "kind": "license"
-        },
-        {
-          "name": "README.md",
-          "path": "README.md",
-          "kind": "readme"
-        },
-        {
-          "id": "cargo-dist-aarch64-unknown-linux-musl-exe-dist",
-          "name": "dist",
-          "path": "dist",
-          "kind": "executable"
-        }
-      ],
-      "checksum": "cargo-dist-aarch64-unknown-linux-musl.tar.xz.sha256"
-    },
-    "cargo-dist-aarch64-unknown-linux-musl.tar.xz.sha256": {
-      "name": "cargo-dist-aarch64-unknown-linux-musl.tar.xz.sha256",
-      "kind": "checksum",
-      "target_triples": [
-        "aarch64-unknown-linux-musl"
-      ]
-    },
     "cargo-dist-installer.ps1": {
       "name": "cargo-dist-installer.ps1",
       "kind": "installer",
@@ -205,9 +115,6 @@ stdout:
       "kind": "installer",
       "target_triples": [
         "aarch64-apple-darwin",
-        "aarch64-unknown-linux-gnu",
-        "aarch64-unknown-linux-musl-dynamic",
-        "aarch64-unknown-linux-musl-static",
         "x86_64-apple-darwin",
         "x86_64-pc-windows-gnu",
         "x86_64-unknown-linux-gnu",
@@ -223,9 +130,6 @@ stdout:
       "target_triples": [
         "aarch64-apple-darwin",
         "aarch64-pc-windows-msvc",
-        "aarch64-unknown-linux-gnu",
-        "aarch64-unknown-linux-musl-dynamic",
-        "aarch64-unknown-linux-musl-static",
         "x86_64-apple-darwin",
         "x86_64-pc-windows-gnu",
         "x86_64-pc-windows-msvc",
@@ -470,9 +374,6 @@ stdout:
       "kind": "installer",
       "target_triples": [
         "aarch64-apple-darwin",
-        "aarch64-unknown-linux-gnu",
-        "aarch64-unknown-linux-musl-dynamic",
-        "aarch64-unknown-linux-musl-static",
         "x86_64-apple-darwin",
         "x86_64-pc-windows-gnu",
         "x86_64-unknown-linux-gnu",
@@ -524,44 +425,6 @@ stdout:
             "targets": [
               "aarch64-apple-darwin"
             ],
-            "cache_provider": "github"
-          },
-          {
-            "runner": "ubuntu-22.04",
-            "host": "x86_64-unknown-linux-gnu",
-            "container": {
-              "image": "quay.io/pypa/manylinux_2_28_x86_64",
-              "host": "x86_64-unknown-linux-musl",
-              "package_manager": null
-            },
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
-            },
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
-            "targets": [
-              "aarch64-unknown-linux-gnu"
-            ],
-            "packages_install": "if ! command -v cargo-zigbuild > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-zigbuild\nfi",
-            "cache_provider": "github"
-          },
-          {
-            "runner": "ubuntu-22.04",
-            "host": "x86_64-unknown-linux-gnu",
-            "container": {
-              "image": "quay.io/pypa/manylinux_2_28_x86_64",
-              "host": "x86_64-unknown-linux-musl",
-              "package_manager": null
-            },
-            "install_dist": {
-              "shell": "sh",
-              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v1.0.0-FAKEVERSION/cargo-dist-installer.sh | sh"
-            },
-            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-musl",
-            "targets": [
-              "aarch64-unknown-linux-musl"
-            ],
-            "packages_install": "if ! command -v cargo-zigbuild > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-zigbuild\nfi",
             "cache_provider": "github"
           },
           {

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -46,3 +46,5 @@ host = "x86_64-unknown-linux-musl"
 [dist.github-custom-runners]
 global = "ubuntu-22.04"
 x86_64-unknown-linux-gnu = "ubuntu-22.04"
+x86_64-unknown-linux-musl = "ubuntu-22.04"
+x86_64-pc-windows-msvc = "windows-2022"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -24,7 +24,7 @@ hosting = ["github"]
 # Whether to install an updater program
 install-updater = false
 # Whether to enable GitHub Attestations
-github-attestations = true
+github-attestations = false
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -16,7 +16,7 @@ npm-scope = "@axodotdev"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew", "npm", "./publish-crates"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Where to host releases


### PR DESCRIPTION
These changes can all be undone following the next release; they're here right now to bootstrap us to 0.28.1-prerelease.1.