### PR TITLE
chore(deps): bump axios version

### DIFF
--- a/cargo-dist/templates/installer/npm/npm-shrinkwrap.json
+++ b/cargo-dist/templates/installer/npm/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "axios": "^1.7.9",
+        "axios": "^1.10.0",
         "axios-proxy-builder": "^0.1.2",
         "console.table": "^0.10.0",
         "detect-libc": "^2.0.3",

--- a/cargo-dist/templates/installer/npm/package.json
+++ b/cargo-dist/templates/installer/npm/package.json
@@ -23,7 +23,7 @@
     "npm": "9.5.0"
   },
   "dependencies": {
-    "axios": "^1.7.9",
+    "axios": "^1.10.0",
     "axios-proxy-builder": "^0.1.2",
     "console.table": "^0.10.0",
     "detect-libc": "^2.0.3",


### PR DESCRIPTION
## Problem

- axios < 1.8.2 has a vulnerability that causes packages to fail npm audits

=> https://github.com/PostHog/posthog/issues/34782

## Changes

- bump axios to latest version 1.10.0