### PR TITLE
ci: publish docs from stable

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -30,7 +30,7 @@ on:
   # If you only want docs to update with releases, disable this one.
   push:
     branches:
-      - main
+      - stable
 
   # Whenever a workflow called "Release" completes, update the docs!
   #


### PR DESCRIPTION
I'm planning to get back to the 1.0 branch later and get that released, but since the next couple of releases will be coming from the pre-1.0 branch, the public docs should reflect that.