### PR TITLE
Revert "feat: add rename infrastructure"

### DIFF
--- a/cargo-dist/src/main.rs
+++ b/cargo-dist/src/main.rs
@@ -729,7 +729,7 @@ async fn cmd_update(_config: &Cli, args: &cli::UpdateArgs) -> Result<(), miette:
         return Ok(());
     }
 
-    let mut updater = AxoUpdater::new_for("dist");
+    let mut updater = AxoUpdater::new_for("cargo-dist");
 
     // If there's a specific version needed, random-access query it by tag,
     // because we always use the same tag format and this is fastest while
@@ -759,19 +759,12 @@ async fn cmd_update(_config: &Cli, args: &cli::UpdateArgs) -> Result<(), miette:
         updater.set_github_token(&token);
     }
 
-    // First, try to check for a "dist" receipt
-    // (this might be a post-rename release)
-    if updater.load_receipt_as("dist").is_err() {
-        // If that didn't work, try again as "cargo-dist"
-        if updater
-            .load_receipt_as("cargo-dist")
-            .map(|updater| updater.set_name("dist"))
-            .is_err()
-        {
-            eprintln!("Unable to load install receipt to check for updates.");
-            eprintln!("If you installed this via `brew`, please `brew upgrade cargo-dist`!");
-            return Ok(());
-        }
+    // Do we want to treat this as an error?
+    // Or do we want to sniff if this was a Homebrew installation?
+    if updater.load_receipt().is_err() {
+        eprintln!("Unable to load install receipt to check for updates.");
+        eprintln!("If you installed this via `brew`, please `brew upgrade cargo-dist`!");
+        return Ok(());
     }
 
     if !updater.check_receipt_is_for_this_executable()? {

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -267,7 +267,6 @@ fn generate_installer(version: &axotag::Version, release_type: ReleaseSourceType
 }
 
 #[test]
-#[ignore = "can't be reenabled until after the rename"]
 fn test_self_update() {
     // Only do this if RUIN_MY_COMPUTER_WITH_INSTALLERS is set
     if std::env::var(ENV_RUIN_ME)

--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -267,6 +267,7 @@ fn generate_installer(version: &axotag::Version, release_type: ReleaseSourceType
 }
 
 #[test]
+#[ignore = "can't be reenabled until after publishing a github-only release"]
 fn test_self_update() {
     // Only do this if RUIN_MY_COMPUTER_WITH_INSTALLERS is set
     if std::env::var(ENV_RUIN_ME)


### PR DESCRIPTION
This reverts commit c613fc81d959064c46bd884a0c548ee1ee0329ea.

This was added at the time we expected that release to be the final pre-1.0 release. Since I'm releasing an 0.28.1, that's not the right time to do a full rename; we should release 0.28.1 under the old name and go ahead with the rename at a later point in time.