### PR TITLE
deps: run dependabot on stable too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,23 @@ updates:
       interval: daily
       time: "10:00"
     open-pull-requests-limit: 10
+    target-branch: main
   - package-ecosystem: npm
     directory: "/cargo-dist/templates/installer/npm"
     schedule:
       interval: daily
       time: "10:00"
+    target-branch: main
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "10:00"
+    open-pull-requests-limit: 10
+    target-branch: stable
+  - package-ecosystem: npm
+    directory: "/cargo-dist/templates/installer/npm"
+    schedule:
+      interval: daily
+      time: "10:00"
+    target-branch: stable


### PR DESCRIPTION
For the time being, we'll be maintaining two branches. This can be removed once the last bits of 1.0 are ready to go.