### PR TITLE
tests: tweak self-updater test

### DIFF
--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -304,18 +304,6 @@ fn test_self_update() {
         // Remove the installed binary before running the next test
         std::fs::remove_file(installed_bin).unwrap();
 
-        // Then rerun with Axo; this is in one function because
-        // they touch the same global files and can't happen
-        // in parallel.
-        args.release_type = ReleaseSourceType::Axo;
-        let installed_bin = axoupdater::test::helpers::perform_runtest(&args);
-        assert!(installed_bin.exists());
-        let status = Command::new(&installed_bin)
-            .arg("--version")
-            .status()
-            .expect("binary didn't exist or --version returned nonzero");
-        assert!(status.success());
-
         // Next two runtests: like the above, but we produce
         // new installers so that we test against the latest installer
         // code in this PR instead of the installers that were generated
@@ -329,7 +317,7 @@ fn test_self_update() {
 
         let mut updater = AxoUpdater::new_for("cargo-dist");
         updater.set_release_source(axoupdater::ReleaseSource {
-            release_type: ReleaseSourceType::Axo,
+            release_type: ReleaseSourceType::GitHub,
             owner: "axodotdev".to_owned(),
             name: "cargo-dist".to_owned(),
             app_name: "cargo-dist".to_owned(),
@@ -348,18 +336,6 @@ fn test_self_update() {
         std::env::set_var("CARGO_DIST_USE_INSTALLER_AT_PATH", installer_path);
 
         args.release_type = ReleaseSourceType::GitHub;
-        let installed_bin = axoupdater::test::helpers::perform_runtest(&args);
-        assert!(installed_bin.exists());
-        let status = Command::new(&installed_bin)
-            .arg("--version")
-            .status()
-            .expect("binary didn't exist or --version returned nonzero");
-        assert!(status.success());
-
-        // And once more, with Axo
-        generate_installer(new_version, ReleaseSourceType::Axo);
-
-        args.release_type = ReleaseSourceType::Axo;
         let installed_bin = axoupdater::test::helpers::perform_runtest(&args);
         assert!(installed_bin.exists());
         let status = Command::new(&installed_bin)


### PR DESCRIPTION
This still isn't safe to reenable, but we'll want these changes for when it is turned back on.

Changes tested in #1912.