### PR TITLE
tests: re-disable self updater test

### DIFF
--- a/cargo-dist/tests/cli-tests.rs
+++ b/cargo-dist/tests/cli-tests.rs
@@ -267,6 +267,7 @@ fn generate_installer(version: &axotag::Version, release_type: ReleaseSourceType
 }
 
 #[test]
+#[ignore = "running into frequent rate limits in GH Actions"]
 fn test_self_update() {
     // Only do this if RUIN_MY_COMPUTER_WITH_INSTALLERS is set
     if std::env::var(ENV_RUIN_ME)


### PR DESCRIPTION
This is hitting rate limits from the GitHub API constantly. I don't remember it being this bad before! Just turn it off for now, but look into maybe authing with the actions token or something else to get a higher limit for more reliable tests.