### PR TITLE
fix: allow cross compiling from windows to windows

### DIFF
--- a/cargo-dist/src/tasks/mod.rs
+++ b/cargo-dist/src/tasks/mod.rs
@@ -522,6 +522,10 @@ pub fn build_wrapper_for_cross(
         },
         // compiling for Windows (making PE binaries, .dll files, etc.)
         OperatingSystem::Windows => match host.operating_system {
+            OperatingSystem::Windows => {
+                // from win to win is generally supported.
+                Ok(None)
+            }
             OperatingSystem::Linux | OperatingSystem::Darwin(_) => {
                 // cargo-xwin is made for that
                 Ok(Some(CargoBuildWrapper::Xwin))


### PR DESCRIPTION
This PR enables cross-compilation from windows to windows. This is needed to compile `aarch64-pc-windows-msvc` targets from another windows machine which is generally supported. This change was discussed in https://github.com/axodotdev/cargo-dist/issues/1644 but never materialized in a PR.

Fixes https://github.com/axodotdev/cargo-dist/issues/1644