### PR TITLE
fix: don't write unified checksum with no checksums

### DIFF
--- a/cargo-dist/src/tasks/mod.rs
+++ b/cargo-dist/src/tasks/mod.rs
@@ -2982,7 +2982,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             self.add_cyclonedx_sbom_file(info.package_idx, release);
 
             // Add the unified checksum file
-            self.add_unified_checksum_file(release);
+            if self.inner.config.artifacts.checksum != ChecksumStyle::False {
+                self.add_unified_checksum_file(release);
+            }
         }
 
         // Translate the result to DistManifest


### PR DESCRIPTION
If checksums are fully disabled, we shouldn't be writing this file at all. Previously, we'd write an empty file named `false.sum`.

Fixes #1963.