### PR TITLE
docs: add docs for 0.29.0 features

### DIFF
--- a/book/src/ci/customizing.md
+++ b/book/src/ci/customizing.md
@@ -238,6 +238,17 @@ Because of dist's cross-compilation support, if you have both `cargo-zigbuild` a
 installed on a macOS machine, you can build pretty much every target dist supports, by running
 `dist build --artifacts all` — in fact, this is used to develop dist itself!
 
+## Pinned actions commits
+
+> since 0.29.0
+
+Dist uses a number of first-party and third-party actions. Typically, it uses tagged versions; for example, dist 0.29.0 uses `actions/checkout@v4`. Some users with special security requirements may wish to pin these to specific commits rather than floating tags; this can be done using the `github-action-commits` setting. For example:
+
+```toml
+[dist.github-action-commits]
+"actions/checkout" = "11bd71901bbe5b1630ceea73d27597364c9af683"
+```
+
 ### Build and upload artifacts on every pull request
 
 > since 0.3.0

--- a/book/src/ci/customizing.md
+++ b/book/src/ci/customizing.md
@@ -249,7 +249,7 @@ Dist uses a number of first-party and third-party actions. Typically, it uses ta
 "actions/checkout" = "11bd71901bbe5b1630ceea73d27597364c9af683"
 ```
 
-### Build and upload artifacts on every pull request
+## Build and upload artifacts on every pull request
 
 > since 0.3.0
 

--- a/book/src/installers/usage.md
+++ b/book/src/installers/usage.md
@@ -119,6 +119,14 @@ requested API structure expectations to match either:
 or related feature requests, please join our [Discord](https://discord.gg/MnyjrpTceV) or send
 us an email at hello@axo.dev.
 
+## GitHub bearer token
+
+> since 0.29.0
+
+By default, the installer fetches archives without using any form of authentication. This is fine for public repos, but users with private projects (or who run into GitHub rate limits) may wish to provide their own tokens when downloading. If set, this will be used when fetching GitHub artifacts.
+
+- `${app name}_GITHUB_TOKEN`
+
 ## Receipt
 
 > since 0.9.0

--- a/book/src/reference/concepts.md
+++ b/book/src/reference/concepts.md
@@ -36,6 +36,8 @@ To match cargo-install's behaviour, if a package defines multiple binaries then 
 
 If you don't want a package-with-binaries to be considered an App that dist should care about, you can use Cargo's own builtin [publish = false][publish-false]. You can also use `dist = false` or `dist = true` in [dist's own config][config-dist], which when defined will take priority over `publish`.
 
+Distability can also be configured on the workspace level by using the `packages` setting in the workspace configuration. If set, this defines a specific list of packages which will be distributed, overriding any `dist = true` or `dist = false` configuration.
+
 
 
 # Defining Your Artifacts

--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -328,6 +328,21 @@ dist uses this feature to distribute its [`dist-manifest-schema.json`](./schema.
 By default, dist creates and uploads source tarballs from your repository. This setting disables that behaviour. This is especially useful for users who distribute closed-source software to hosts outside their git repos and who would prefer not to distribute source code to their users.
 
 
+### `recursive-tarball`
+
+> <span style="float:right">since 0.29.0<br>[global-only][]</span>
+> [📖 read the artifacts guide!][artifacts] \
+> default = `true`
+>
+> *in your dist-workspace.toml or dist.toml:*
+> ```toml
+> [dist]
+> recursive-tarball = true
+> ```
+
+By default, dist's source tarballs only includes the contents of your repository. Setting `recursive-tarball = true` switches to an alternate tarball generation method which includes the content of submodules.
+
+
 ### `ssldotcom-windows-sign`
 
 > <span style="float:right">since 0.14.0<br>[global-only][]</span>

--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -91,6 +91,7 @@ We're currently in the middle of [a major config migration](https://github.com/a
     * [`github-custom-job-permissions`](#github-custom-job-permissions)
     * [`github-custom-runners`](#github-custom-runners)
     * [`github-build-setup`](#github-build-setup)
+    * [`github-action-commits`](#github-action-commits)
 * [custom ci jobs](#custom-ci-jobs)
     * [`plan-jobs`](#plan-jobs)
     * [`local-artifacts-jobs`](#local-artifacts-jobs)
@@ -1337,6 +1338,21 @@ All other custom jobs default to no special permissions.
 Allows specifying which runner to use for a target. The keys within this table are target triples in the same format as the ["targets"](#targets) setting. Any targets not specified in this table will use the defaults.
 
 In addition to defining runners for a target, it's also possible to specify a runner for the global, non-target-specific tasks using the `global` key. This runner will be used for tasks like `plan`, `host`, generating installers, and so on.
+
+
+### `github-action-commits`
+
+> <span style="float:right">since 0.29.0<br>[global-only][]</span>
+> [📖 read the ci customization guide!][github-ci] \
+> default = `<none>`
+>
+> *in your dist-workspace.toml or dist.toml:*
+> ```toml
+> [dist.github-action-commits]
+> "actions/checkout" = "11bd71901bbe5b1630ceea73d27597364c9af683"
+> ```
+
+Allows overriding which version of a GitHub Action to use. This can be useful to replace the default set of tags used by dist with a specific pinned set of commits.
 
 
 ### custom ci jobs

--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -18,6 +18,7 @@ We're currently in the middle of [a major config migration](https://github.com/a
 * [`allow-dirty`](#allow-dirty)
 * [`cargo-dist-version`](#cargo-dist-version)
 * [`dist`](#dist)
+* [`packages`](#packages)
 * [`targets`](#targets)
 
 [artifact settings](#artifact-settings)
@@ -188,6 +189,21 @@ There are 3 major cases where you might use this:
 * `dist = false` on a package can be used to force dist to ignore it
 * `dist = true` on a package can be used to force dist to distribute it in spite of signals like Cargo's `publish = false` that would suggest otherwise.
 * `dist = false` on a whole workspace defaults all packages to do-not-distribute, forcing you to manually allow-list packages with `dist = true` (large monorepos often find this to be a better way of managing project distribution when most developers aren't release engineers).
+
+
+## `packages`
+
+> <span style="float:right">since 0.29.0<br>[global-only][]</span>
+> [📖 read the guide for this feature!][distribute] \
+> default = `<none>` (infer it)
+>
+> *in your dist-workspace.toml or dist.toml:*
+> ```toml
+> [dist]
+> packages = ["a", "b"]
+> ```
+
+`packages` provides a more explicit way of specifying which packages to dist (or not). If `packages` is set, it provides a list of exactly which packages should be distributed within the workspace. It overrides individual package-level `dist = true` or `dist = false` configuration.
 
 
 ## `targets`

--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -50,6 +50,7 @@ We're currently in the middle of [a major config migration](https://github.com/a
 * [`installers`](#installers)
 * [`install-libraries`](#install-libraries)
 * [`bin-aliases`](#bin-aliases)
+* [`binaries`](#binaries)
 * [shell and powershell installer settings](#shell-and-powershell-installer-settings)
     * [`install-success-msg`](#install-success-msg)
     * [`install-path`](#install-path)
@@ -712,6 +713,20 @@ This is a map of binary names to aliases that your [installers][] should create 
 * [npm][npm-installer]: extra "bins" pointing at the same command
 * [homebrew][homebrew-installer]: bin.install_symlink
 * [msi][msi-installer]: **not currently supported**
+
+
+### `binaries`
+
+> <span style="float:right">since 0.29.0<br>[package-local][]</span>
+> default = `<none>`
+>
+> *in your dist-workspace.toml or dist.toml:*
+> ```toml
+> [dist.binaries]
+> x86_64-pc-windows-msvc = ["a", "b"]
+> ```
+
+This setting allows overriding the list of binaries to install on a per-platform basis.
 
 
 ### `install-libraries`

--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -20,6 +20,7 @@ We're currently in the middle of [a major config migration](https://github.com/a
 * [`dist`](#dist)
 * [`packages`](#packages)
 * [`targets`](#targets)
+* [`version`](#version)
 
 [artifact settings](#artifact-settings)
 * [`checksum`](#checksum)
@@ -236,6 +237,19 @@ The supported choices are:
 * arm64 Linux (static musl): "aarch64-unknown-linux-musl"
 
 By default all runs of `dist` will be trying to handle all platforms specified here at once. If you specify `--target=...` on the CLI this will focus the run to only those platforms. As discussed in [concepts][], this cannot be used to specify platforms that are not listed in `metadata.dist`, to ensure different runs agree on the maximum set of platforms.
+
+
+## `version`
+> <span style="float:right">since 0.29.0<br>[global-only][]</span>
+> default = `<none>` (infer it)
+>
+> *in your dist-workspace.toml or dist.toml:*
+> ```toml
+> [dist]
+> version = "0.0.1"
+> ```
+
+If set, this value will override the actual version configured for each package. For example, if the workspace contains packages versioned "0.2" and "0.3", and this value is set to "0.1", then dist will consider every package in the workspace to have the version "0.1".
 
 
 ## artifact settings


### PR DESCRIPTION
These originated in the Astral fork but didn't get docs there, so I wrote these from scratch.