### PR TITLE
use GitHub ARM-specific runners for aarch64 Linux targets by default

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -671,7 +671,14 @@ fn github_runner_for_target(
     // where random system dependencies can creep in and be very
     // recent. This helps with portability!
     let result = Some(match target_triple.operating_system {
-        OperatingSystem::Linux => runner_to_config(GithubRunnerRef::from_str("ubuntu-22.04")),
+        OperatingSystem::Linux => {
+            // Use ARM-specific runner for aarch64 Linux targets
+            if matches!(target_triple.architecture, Architecture::Aarch64(_)) {
+                runner_to_config(GithubRunnerRef::from_str("ubuntu-22.04-arm"))
+            } else {
+                runner_to_config(GithubRunnerRef::from_str("ubuntu-22.04"))
+            }
+        }
         OperatingSystem::Darwin(_) => runner_to_config(GithubRunnerRef::from_str("macos-13")),
         OperatingSystem::Windows => {
             // Default to cargo-xwin for Windows cross-compiles

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -2507,7 +2507,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "cache_provider": "github"
           },
           {
-            "runner": "ubuntu-22.04",
+            "runner": "ubuntu-22.04-arm",
             "host": "x86_64-unknown-linux-gnu",
             "install_dist": {
               "shell": "sh",


### PR DESCRIPTION
GitHub now provides Linux ARM64 hosted runners for free in public repositories. This change updates the default runner for aarch64-unknown-linux-gnu targets to use ubuntu-22.04-arm instead of the x86_64 runner.

See: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Addresses https://github.com/axodotdev/cargo-dist/issues/74