### PR TITLE
Add cargo-install instructions to install.md

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -52,17 +52,17 @@ nix-env -i cargo-dist
 
 ### Other Options
 
-#### cargo-install
-
-```sh
-cargo install cargo-dist
-```
-
 #### cargo-binstall
 
 ```sh
 cargo install cargo-binstall # if you don't have binstall available already
 cargo binstall cargo-dist
+```
+
+#### cargo-install
+
+```sh
+cargo install cargo-dist
 ```
 
 ## Build From Source


### PR DESCRIPTION
I was not aware of cargo-binstall and assumed it to be a typo. cargo install seems to work, and cargo binstall requires an extra step, worth documenting IMHO