### PR TITLE
feat: Use cargo-config2 to read `rustflags` from the config to append to

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-config2"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3795d3a48839a46854805f56c8fe9c558f10804bcf57df53925ca843d87c788f"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "cargo-dist"
 version = "0.30.2"
 dependencies = [
@@ -364,6 +376,7 @@ dependencies = [
  "base64",
  "blake2",
  "camino",
+ "cargo-config2",
  "cargo-dist-schema",
  "cargo-wix",
  "cargo_metadata 0.23.0",

--- a/cargo-dist/Cargo.toml
+++ b/cargo-dist/Cargo.toml
@@ -72,6 +72,7 @@ current_platform.workspace = true
 color-backtrace.workspace = true
 backtrace.workspace = true
 schemars.workspace = true
+cargo-config2 = "0.1.36"
 
 [dev-dependencies]
 insta.workspace = true

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -69,6 +69,10 @@ pub enum DistError {
     #[error(transparent)]
     TripleError(#[from] cargo_dist_schema::target_lexicon::ParseError),
 
+    /// random cargo_config2 error
+    #[error(transparent)]
+    ConfigError(#[from] cargo_config2::Error),
+
     /// A problem with a jinja template, which is always a dist bug
     #[error("Failed to render template")]
     #[diagnostic(


### PR DESCRIPTION
This PR fixes #1571: currently, `dist` always passes a `RUSTFLAGS` variable to `cargo` that is based on the current environment variable (possibly empty), with possibly some target-specific values appended.

As noted in #1571, this causes issues when e.g. `rustflags = "-C target-cpu=native"` is set in `.cargo/config.toml`.

This PR first checks if the `RUSTFLAGS` environment variable is set, and if not, it then uses `cargo_config2` to read the `rustflags` variable.

Probably some test should be added:
- to check that an explicitly empty `RUSTFLAGS` is propagated,
- to check that an unset `RUSTFLAGS` indeed makes it fall back to `.cargo/config.toml`
- to check that it works for both `[build] rustflags = ...` and `[target.<cfg/triple>] rustflags = ...`,
- to check whether anything needs to be done with quoted values in a `rustflags=[...]` array. I'm not sure if simply concatenating is always valid?

---

An alternative, simpler solution could be to detect when the environment variable is not set and also no modifications to `rustflags` are needed (because these cases seem rare), and then just not pass the `RUSTFLAGS` environment variable to `cargo` at all, so that it does its usual thing.

See https://github.com/RagnarGrootKoerkamp/cargo-dist/tree/rustflags-optional for how that could look.

---

Yes another (surely controversial) solution could be to simply not manually override `rustflags` for bad defaults, and let users update `.cargo/config.toml` themselves. Specifically: any binary that is distributed via both `cargo-dist` and another platform with its own build pipeline should likely set these flags anyway.