### PR TITLE
fix: typo in variable name

### DIFF
--- a/cargo-dist/templates/installer/npm/binary.js
+++ b/cargo-dist/templates/installer/npm/binary.js
@@ -17,7 +17,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -63,7 +63,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -2781,7 +2781,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2827,7 +2827,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -2734,7 +2734,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2780,7 +2780,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -2738,7 +2738,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2784,7 +2784,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
@@ -2781,7 +2781,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2827,7 +2827,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
@@ -2781,7 +2781,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2827,7 +2827,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
@@ -2781,7 +2781,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2827,7 +2827,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2820,7 +2820,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2866,7 +2866,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -2781,7 +2781,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2827,7 +2827,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -2706,7 +2706,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2752,7 +2752,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -2703,7 +2703,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2749,7 +2749,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -2703,7 +2703,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2749,7 +2749,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2703,7 +2703,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2749,7 +2749,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -2703,7 +2703,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2749,7 +2749,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -2047,7 +2047,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2093,7 +2093,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -2027,7 +2027,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2073,7 +2073,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -2703,7 +2703,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2749,7 +2749,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -2738,7 +2738,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2784,7 +2784,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -2715,7 +2715,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2761,7 +2761,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -2703,7 +2703,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2749,7 +2749,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -2703,7 +2703,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2749,7 +2749,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -2703,7 +2703,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2749,7 +2749,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -2703,7 +2703,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2749,7 +2749,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -2703,7 +2703,7 @@ const {
 } = require("./package.json");
 
 const builderGlibcMajorVersion = glibcMinimum.major;
-const builderGlibcMInorVersion = glibcMinimum.series;
+const builderGlibcMinorVersion = glibcMinimum.series;
 
 const getPlatform = () => {
   const rawOsType = os.type();
@@ -2749,7 +2749,7 @@ const getPlatform = () => {
       let libcMinorVersion = splitLibcVersion[1];
       if (
         libcMajorVersion != builderGlibcMajorVersion ||
-        libcMinorVersion < builderGlibcMInorVersion
+        libcMinorVersion < builderGlibcMinorVersion
       ) {
         // We can't run the glibc binaries, but we can run the static musl ones
         // if they exist


### PR DESCRIPTION
Fixes a typo in the `builderGlibcMInorVersion`. The `I` in MInor shouldn't be capitalized