### PR TITLE
chore(docs): update contributing guidelines to include omnibor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,12 +20,12 @@ that your fix works.
 **3. Overcommunicate**
 
 In all scenarios, please provide as much context as possible- you may not think
-it's important but it may be! 
+it's important but it may be!
 
 **4. Patience**
 
 Axo is a very small company, it's possible that we may not be able to
-immediately prioritize your issue. We are excite to develop a community of 
+immediately prioritize your issue. We are excited to develop a community of
 contributors around this project, but it won't always be on the top of our to-do
 list, even if we wish it could be.
 
@@ -34,9 +34,14 @@ at-mention @ashleygwilliams- but please be kind while doing so!
 
 ## Running tests
 
+Run `just dev-install` to install required binaries into your path
+
 The test suite can be run with `cargo test`. [insta](https://insta.rs/docs/cli/)
 is used for snapshots; after running the test suite, use `cargo insta review` to
 review any changed snapshots.
+
+The test suite specifically requires v0.7.0 of `omnibor-cli`. Other versions may
+not work as expected
 
 The test suite cannot be run in parallel. Using an alternative test runner like
 `nextest` will cause unexpected behavior as tests will override each other's

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,6 @@
+dev-install: 
+  cargo binstall -y cargo-insta
+  cargo binstall -y omnibor-cli@0.7.0
 
 build-all-platforms:
   #!/bin/bash -eux

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ outputs. This allows us to both catch regressions and also more easily review UI
 test fails, you will need to use the `cargo insta` CLI tool to update them:
 
 ```sh
-cargo install cargo-insta
+just dev-install
 ```
 
 Once installed, you can review and accept the changes with:


### PR DESCRIPTION
While working on #2223, I found `omnibor` is required to run integration tests. This PR includes a script to install required testing tools

However, there are a few things I'd like to clear up before going further

## doubts

### README/CONTRIBUTING.md overlap

Both the README.md and CONTRIBUTING.md have information about contributions—some is overlapping and some is not. Would y'all be interested in any of these options?
1. move contributing info to CONTRIBUTING.md and link in the README
2. move contributing info fully to the README

### Nix 

Would y'all prefer updating the devenv.nix be 
- made into a separate issue
- note the current failures are expected when using the devenv.nix

As of now, the integration test using omnibor fails in the nix devenv, and it seems like not an insignficant amount of work to add omnibor to the devenv.nix, though of course I could be missing something obvious since this is the first time I've used nix

From what little I know of nix, running an install script for something without a deterministic lockfile is not the preferred way to do things. For reference, [omnibor-rs does not provide a `Cargo.lock`](https://github.com/omnibor/omnibor-rs). I have not checked if there is another deterministic build for this beyond directly downloading the artifacts

### Troubleshooting

I was unable to install omnibor via the devenv.nix

It did not seem that omnibor was already available to use like cargo-insta was https://search.nixos.org/packages?channel=25.11&query=omnibor-cli

Had trouble locally installing nix, so ran a dockerfile with the following configuration
```
FROM nixos/nix 

RUN nix-env --install --attr devenv -f https://github.com/NixOS/nixpkgs/tarball/nixpkgs-unstable

COPY . /workdir
WORKDIR /workdir

ENTRYPOINT [ "bash" ]
```

After dropping into the shell with `devenv shell` and running tests via `cargo test`, reproduced the integration test failure
```sh
test axolotlsay_basic ... FAILED
```

I got the git hash from the omnibor releases [chore: Release omnibor-v0.7.0 · omnibor/omnibor-rs@80ff804 · GitHub](https://github.com/omnibor/omnibor-rs/commit/80ff804c1048ea0ded03d84510b1d1cbdaf98229) 

As mentioned above, no Cargo.lock complicates building from source

It seems possible to set different download URLs per OS and architecture but wanted to check in before spending too much time here
