### PR TITLE
Add support for customizing artifact-download-url

### DIFF
--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -71,6 +71,8 @@ We're currently in the middle of [a major config migration](https://github.com/a
 
 [hosting settings](#hosting-settings)
 * [`hosting`](#hosting)
+* [`artifact-download-url`](#artifact-download-url)
+* [`artifact-download-fallback`](#artifact-download-fallback)
 * [`display`](#display)
 * [`display-name`](#display-name)
 * [`force-latest`](#force-latest)
@@ -1001,6 +1003,59 @@ Possible values:
 Specifies what hosting provider to use when hosting/announcing new releases.
 
 By default we will automatically use the native hosting of your CI provider, so when running on GitHub CI, we'll default to using GitHub Releases for hosting/announcing.
+
+
+### `artifact-download-url`
+
+> <span style="float:right">since 0.27.0<br>[global-only][]</span>
+> default = `<none>`
+>
+> *in your dist-workspace.toml or dist.toml:*
+> ```toml
+> [dist.hosts]
+> artifact-download-url = "https://cdn.example.com/{tag}/"
+> ```
+
+Specifies a custom base URL for downloading artifacts. When configured, the generated [shell][shell-installer] and [powershell][powershell-installer] installers will download artifacts from this URL instead of [GitHub Releases](#hosting).
+
+#### Template Variables
+
+The URL supports the following template variables:
+* `{tag}` - The release tag (e.g., `v1.0.0`)
+
+#### Use Cases
+
+This is useful for:
+* Serving artifacts from your own CDN or hosting
+* Improving download speeds via a geographically distributed CDN
+* Self-hosting releases independent of GitHub
+
+#### Fallback Behavior
+
+By default, if the custom URL fails, the installer will simply fail. To enable fallback to GitHub Releases, set [`artifact-download-fallback`](#artifact-download-fallback) to `true`.
+
+#### Runtime Override
+
+The artifact download URL can be overridden at runtime via the `{APP_NAME}_DOWNLOAD_URL` or `INSTALLER_DOWNLOAD_URL` environment variables. When set, these override the custom URL and no fallback occurs.
+
+
+### `artifact-download-fallback`
+
+> <span style="float:right">since 0.27.0<br>[global-only][]</span>
+> default = `false`
+>
+> *in your dist-workspace.toml or dist.toml:*
+> ```toml
+> [dist.hosts]
+> artifact-download-url = "https://cdn.example.com/{tag}/"
+> artifact-download-fallback = true
+> ```
+
+When `true` and [`artifact-download-url`](#artifact-download-url) is configured, the generated installers will fall back to GitHub Releases if the custom URL fails.
+
+This provides redundancy: artifacts are first fetched from your custom URL, and if that fails (e.g., the CDN is temporarily unavailable), the installer will retry using GitHub Releases.
+
+**Note**: If the user overrides the download URL via the `{APP_NAME}_DOWNLOAD_URL` or `INSTALLER_DOWNLOAD_URL` environment variables, the fallback is bypassed entirely.
 
 
 ### `display`

--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -1070,6 +1070,17 @@ pub struct Hosting {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub github: Option<GithubHosting>,
+    /// Custom artifact download URL template (e.g., "https://mycdn.com/{tag}/")
+    ///
+    /// Supports template variables: {tag}
+    /// When set, this URL is used instead of GitHub Releases for downloading artifacts.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_download_url: Option<String>,
+    /// Whether to fall back to GitHub Releases if the custom artifact_download_url fails
+    #[serde(default)]
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub artifact_download_fallback: bool,
 }
 
 /// Github Hosting
@@ -1091,7 +1102,11 @@ pub struct GithubHosting {
 impl Hosting {
     /// Get the base URL that artifacts should be downloaded from (append the artifact name to the URL)
     pub fn artifact_download_url(&self) -> Option<String> {
-        let Hosting { github } = &self;
+        let Hosting {
+            github,
+            artifact_download_url: _,
+            artifact_download_fallback: _,
+        } = &self;
         if let Some(host) = &github {
             return Some(format!(
                 "{}{}",
@@ -1102,7 +1117,11 @@ impl Hosting {
     }
     /// Gets whether there's no hosting
     pub fn is_empty(&self) -> bool {
-        let Hosting { github } = &self;
+        let Hosting {
+            github,
+            artifact_download_url: _,
+            artifact_download_fallback: _,
+        } = &self;
         github.is_none()
     }
 }

--- a/cargo-dist/src/backend/installer/mod.rs
+++ b/cargo-dist/src/backend/installer/mod.rs
@@ -93,6 +93,10 @@ pub struct InstallerInfo {
     pub platform_support: Option<PlatformSupport>,
     /// Environment variables for installer customization
     pub env_vars: Option<EnvironmentVariables>,
+    /// Custom artifact download URL template (if configured)
+    pub artifact_download_url: Option<String>,
+    /// Fallback download URL (GitHub), used when custom URL is configured with fallback enabled
+    pub fallback_base_url: Option<String>,
 }
 
 /// A fake fragment of an ExecutableZip artifact for installers

--- a/cargo-dist/src/config/v0_to_v1.rs
+++ b/cargo-dist/src/config/v0_to_v1.rs
@@ -266,7 +266,10 @@ impl DistMetadata {
             || display.is_some()
             || display_name.is_some();
         let host_layer = needs_host_layer.then_some(HostLayer {
-            common: CommonHostLayer {},
+            common: CommonHostLayer {
+                artifact_download_url: None,
+                artifact_download_fallback: None,
+            },
             github: github_host_layer,
             force_latest,
             display,

--- a/cargo-dist/src/manifest.rs
+++ b/cargo-dist/src/manifest.rs
@@ -106,9 +106,19 @@ pub(crate) fn load_and_merge_manifests(
             let out_release =
                 output.ensure_release(release.app_name.clone(), release.app_version.clone());
             // If the input has hosting info, apply it
-            let Hosting { github } = release.hosting;
+            let Hosting {
+                github,
+                artifact_download_url,
+                artifact_download_fallback,
+            } = release.hosting;
             if let Some(hosting) = github {
                 out_release.hosting.github = Some(hosting);
+            }
+            if artifact_download_url.is_some() {
+                out_release.hosting.artifact_download_url = artifact_download_url;
+            }
+            if artifact_download_fallback {
+                out_release.hosting.artifact_download_fallback = artifact_download_fallback;
             }
             // If the input has a list of artifacts for this release, merge them
             for artifact in release.artifacts {

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -2054,6 +2054,19 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
 
         let runtime_conditions = release.platform_support.safe_conflated_runtime_conditions();
 
+        // Custom artifact download URL with optional GitHub fallback
+        // Replace {tag} template variable with actual version tag
+        let artifact_download_url = hosting
+            .artifact_download_url
+            .as_ref()
+            .map(|url| url.replace("{tag}", &format!("v{}", release.version)));
+        let fallback_base_url =
+            if artifact_download_url.is_some() && hosting.artifact_download_fallback {
+                Some(download_url.to_owned())
+            } else {
+                None
+            };
+
         let installer_artifact = Artifact {
             id: artifact_name,
             target_triples,
@@ -2083,6 +2096,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 runtime_conditions,
                 platform_support: None,
                 env_vars,
+                artifact_download_url,
+                fallback_base_url,
             })),
             is_global: true,
         };
@@ -2222,6 +2237,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             platform_support: None,
             // Not actually needed for this installer type
             env_vars: None,
+            artifact_download_url: None,
+            fallback_base_url: None,
         };
 
         let installer_artifact = Artifact {
@@ -2297,6 +2314,20 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             return Ok(());
         };
         let bin_aliases = BinaryAliases(config.bin_aliases.clone()).for_targets(&target_triples);
+
+        // Custom artifact download URL with optional GitHub fallback
+        // Replace {tag} template variable with actual version tag
+        let artifact_download_url = hosting
+            .artifact_download_url
+            .as_ref()
+            .map(|url| url.replace("{tag}", &format!("v{}", release.version)));
+        let fallback_base_url =
+            if artifact_download_url.is_some() && hosting.artifact_download_fallback {
+                Some(download_url.to_owned())
+            } else {
+                None
+            };
+
         let installer_artifact = Artifact {
             id: artifact_name,
             target_triples,
@@ -2326,6 +2357,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                 runtime_conditions: RuntimeConditions::default(),
                 platform_support: None,
                 env_vars,
+                artifact_download_url,
+                fallback_base_url,
             })),
             is_global: true,
         };
@@ -2444,6 +2477,8 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
                     platform_support: None,
                     // Not actually needed for this installer type
                     env_vars: None,
+                    artifact_download_url: None,
+                    fallback_base_url: None,
                 },
             })),
             is_global: true,

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -64,6 +64,13 @@ if ($env:{{ env_vars.download_url_env_var }}) {
   $ArtifactDownloadUrl = "$installer_base_url{{ hosting.github.artifact_download_path }}"
 }
 $auth_token = $env:{{ env_vars.github_token_env_var }}
+{%- if artifact_download_url %}
+# Custom artifact download URL (with optional GitHub fallback)
+$artifact_download_url = "{{ artifact_download_url }}"
+{%- if fallback_base_url %}
+$fallback_base_url = "{{ fallback_base_url }}"
+{%- endif %}
+{%- endif %}
 
 $receipt = @"
 {{ receipt | tojson }}
@@ -143,8 +150,17 @@ function Install-Binary($install_args) {
     }
   {%- endfor %}
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+{%- if artifact_download_url %}
+  # Check if user overrode the download URL via env var
+  $use_custom = -not ($env:{{ env_vars.download_url_env_var }} -or $env:INSTALLER_DOWNLOAD_URL)
+  if ($use_custom) {
+    $fetched = Download "$artifact_download_url" {% if fallback_base_url %}"$fallback_base_url"{% else %}$null{% endif %} $platforms
+  } else {
+    $fetched = Download "$ArtifactDownloadUrl" $null $platforms
+  }
+{%- else %}
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
+{%- endif %}
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -240,7 +256,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -273,7 +289,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -318,7 +357,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\{{ app_name }}-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -63,7 +63,10 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     INSTALL_UPDATER=0
 fi
 AUTH_TOKEN="{{ '${' }}{{ env_vars.github_token_env_var }}:-}"
-
+{% if artifact_download_url %}# Custom artifact download URL (with optional GitHub fallback)
+CUSTOM_DOWNLOAD_URL="{{ artifact_download_url }}"
+{% if fallback_base_url %}FALLBACK_BASE_URL="{{ fallback_base_url }}"
+{% endif %}{% endif %}
 read -r RECEIPT <<EORECEIPT
 {{ receipt | tojson }}
 EORECEIPT
@@ -255,15 +258,55 @@ download_binary_and_run_installer() {
 
     # download the archive
     local _url="$ARTIFACT_DOWNLOAD_URL/$_artifact_name"
+{%- if artifact_download_url %}
+    local _custom_url="$CUSTOM_DOWNLOAD_URL/$_artifact_name"
+{% if fallback_base_url %}    local _fallback_url="$FALLBACK_BASE_URL/$_artifact_name"
+{% endif %}    # Check if user overrode the download URL via env var
+    local _use_custom=1
+    if [ -n "{{ '${' }}{{ env_vars.download_url_env_var }}:-}" ] || [ -n "${INSTALLER_DOWNLOAD_URL:-}" ]; then
+        _use_custom=0
+    fi
+{%- endif %}
     local _dir
     _dir="$(ensure mktemp -d)" || return 1
     local _file="$_dir/input$_zip_ext"
 
     say "downloading $APP_NAME $APP_VERSION ${_arch}" 1>&2
+{%- if artifact_download_url %}
+    if [ "$_use_custom" = "1" ]; then
+{% if fallback_base_url %}        say_verbose "  from $_custom_url (with fallback to $_fallback_url)" 1>&2
+{% else %}        say_verbose "  from $_custom_url" 1>&2
+{% endif %}    else
+        say_verbose "  from $_url" 1>&2
+    fi
+{%- else %}
     say_verbose "  from $_url" 1>&2
+{%- endif %}
     say_verbose "  to $_file" 1>&2
 
     ensure mkdir -p "$_dir"
+{%- if artifact_download_url %}
+
+    if [ "$_use_custom" = "1" ]; then
+{% if fallback_base_url %}        if ! download_with_fallback "$_custom_url" "$_file" "$_fallback_url"; then
+          say "failed to download from custom URL and fallback"
+{% else %}        if ! downloader "$_custom_url" "$_file"; then
+          say "failed to download $_custom_url"
+{% endif %}          say "this may be a standard network error, but it may also indicate"
+          say "that $APP_NAME's release process is not working. When in doubt"
+          say "please feel free to open an issue!"
+          exit 1
+        fi
+    else
+        if ! downloader "$_url" "$_file"; then
+          say "failed to download $_url"
+          say "this may be a standard network error, but it may also indicate"
+          say "that $APP_NAME's release process is not working. When in doubt"
+          say "please feel free to open an issue!"
+          exit 1
+        fi
+    fi
+{%- else %}
 
     if ! downloader "$_url" "$_file"; then
       say "failed to download $_url"
@@ -272,6 +315,7 @@ download_binary_and_run_installer() {
       say "please feel free to open an issue!"
       exit 1
     fi
+{%- endif %}
 
     if [ -n "${_checksum_style:-}" ]; then
         verify_checksum "$_file" "$_checksum_style" "$_checksum_value"
@@ -282,9 +326,35 @@ download_binary_and_run_installer() {
     # ...and then the updater, if it exists
     if [ -n "$_updater_name" ] && [ "$INSTALL_UPDATER" = "1" ]; then
         local _updater_url="$ARTIFACT_DOWNLOAD_URL/$_updater_name"
+{%- if artifact_download_url %}
+        local _updater_custom_url="$CUSTOM_DOWNLOAD_URL/$_updater_name"
+{% if fallback_base_url %}        local _updater_fallback_url="$FALLBACK_BASE_URL/$_updater_name"
+{% endif %}{%- endif %}
         # This renames the artifact while doing the download, removing the
         # target triple and leaving just the appname-update format
         local _updater_file="$_dir/$APP_NAME-update"
+{%- if artifact_download_url %}
+
+        if [ "$_use_custom" = "1" ]; then
+{% if fallback_base_url %}            if ! download_with_fallback "$_updater_custom_url" "$_updater_file" "$_updater_fallback_url"; then
+              say "failed to download updater from custom URL and fallback"
+{% else %}            if ! downloader "$_updater_custom_url" "$_updater_file"; then
+              say "failed to download $_updater_custom_url"
+{% endif %}              say "this may be a standard network error, but it may also indicate"
+              say "that $APP_NAME's release process is not working. When in doubt"
+              say "please feel free to open an issue!"
+              exit 1
+            fi
+        else
+            if ! downloader "$_updater_url" "$_updater_file"; then
+              say "failed to download $_updater_url"
+              say "this may be a standard network error, but it may also indicate"
+              say "that $APP_NAME's release process is not working. When in doubt"
+              say "please feel free to open an issue!"
+              exit 1
+            fi
+        fi
+{%- else %}
 
         if ! downloader "$_updater_url" "$_updater_file"; then
           say "failed to download $_updater_url"
@@ -293,6 +363,7 @@ download_binary_and_run_installer() {
           say "please feel free to open an issue!"
           exit 1
         fi
+{%- endif %}
 
         # Add the updater to the list of binaries to install
         _bins="$_bins $APP_NAME-update"
@@ -1378,6 +1449,28 @@ downloader() {
     else err "Unknown downloader"   # should not reach here
     fi
 }
+{%- if artifact_download_url %}
+
+# Download with fallback support - tries primary URL first, then fallback
+download_with_fallback() {
+    local _url="$1"
+    local _file="$2"
+    local _fallback_url="${3:-}"
+
+    if downloader "$_url" "$_file"; then
+        return 0
+    fi
+
+    if [ -n "$_fallback_url" ]; then
+        say "primary download failed, trying fallback..." >&2
+        if downloader "$_fallback_url" "$_file"; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+{%- endif %}
 
 verify_checksum() {
     local _file="$1"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1730,8 +1730,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{"akextract.exe":["akextract-link.exe"]}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1827,7 +1826,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1860,7 +1859,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1905,7 +1927,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1757,8 +1757,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{"akextract.exe":["akextract-link.exe"],"akmetadata.exe":["akmetadata-link.exe"]}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1854,7 +1853,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1887,7 +1886,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1932,7 +1954,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1711,8 +1711,7 @@ function Install-Binary($install_args) {
       }
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1808,7 +1807,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1841,7 +1840,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1886,7 +1908,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -1777,8 +1777,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1874,7 +1873,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1907,7 +1906,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1952,7 +1974,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1730,8 +1730,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{"axolotlsay.exe":["axolotlsay-link.exe"]}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1827,7 +1826,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1860,7 +1859,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1905,7 +1927,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1734,8 +1734,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{"nosuchbin.exe":["axolotlsay-link1.exe","axolotlsay-link2.exe"]}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1831,7 +1830,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1864,7 +1863,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1909,7 +1931,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
@@ -1777,8 +1777,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1874,7 +1873,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1907,7 +1906,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1952,7 +1974,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
@@ -1777,8 +1777,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1874,7 +1873,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1907,7 +1906,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1952,7 +1974,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
@@ -1777,8 +1777,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1874,7 +1873,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1907,7 +1906,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1952,7 +1974,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -1777,8 +1777,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1874,7 +1873,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1907,7 +1906,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1952,7 +1974,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1702,8 +1702,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1799,7 +1798,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1832,7 +1831,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1877,7 +1899,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -1710,8 +1710,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1807,7 +1806,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1840,7 +1839,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1885,7 +1907,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -1554,8 +1554,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1651,7 +1650,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1684,7 +1683,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1729,7 +1751,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -1634,8 +1634,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1731,7 +1730,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1764,7 +1763,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1809,7 +1831,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1698,8 +1698,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1795,7 +1794,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1828,7 +1827,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1873,7 +1895,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-js-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 
@@ -3868,8 +3913,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -3965,7 +4009,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -3998,7 +4042,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -4043,7 +4110,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1734,8 +1734,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{"axolotlsay.exe":["axolotlsay-link1.exe","axolotlsay-link2.exe"]}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1831,7 +1830,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1864,7 +1863,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1909,7 +1931,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1634,8 +1634,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1731,7 +1730,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1764,7 +1763,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1809,7 +1831,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1634,8 +1634,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1731,7 +1730,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1764,7 +1763,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1809,7 +1831,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1711,8 +1711,7 @@ function Install-Binary($install_args) {
       }
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1808,7 +1807,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1841,7 +1840,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1886,7 +1908,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1699,8 +1699,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1796,7 +1795,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1829,7 +1828,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1874,7 +1896,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1682,8 +1682,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1779,7 +1778,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1812,7 +1811,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1857,7 +1879,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1682,8 +1682,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1779,7 +1778,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1812,7 +1811,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1857,7 +1879,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1682,8 +1682,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1779,7 +1778,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1812,7 +1811,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1857,7 +1879,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1682,8 +1682,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1779,7 +1778,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1812,7 +1811,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1857,7 +1879,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1696,8 +1696,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1793,7 +1792,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1826,7 +1825,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1871,7 +1893,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1682,8 +1682,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1779,7 +1778,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1812,7 +1811,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1857,7 +1879,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1682,8 +1682,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1779,7 +1778,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1812,7 +1811,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1857,7 +1879,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1682,8 +1682,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1779,7 +1778,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1812,7 +1811,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1857,7 +1879,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1682,8 +1682,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1779,7 +1778,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1812,7 +1811,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1857,7 +1879,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1696,8 +1696,7 @@ function Install-Binary($install_args) {
       "aliases_json" = '{}'
     }
   }
-
-  $fetched = Download "$ArtifactDownloadUrl" $platforms
+  $fetched = Download "$ArtifactDownloadUrl" $null $platforms
   # FIXME: add a flag that lets the user not do this step
   try {
     Invoke-Installer -artifacts $fetched -platforms $platforms "$install_args"
@@ -1793,7 +1792,7 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
-function Download($download_url, $platforms) {
+function Download($download_url, $fallback_url, $platforms) {
   $arch = Get-TargetTriple $platforms
 
   if (-not $platforms.ContainsKey($arch)) {
@@ -1826,7 +1825,30 @@ function Download($download_url, $platforms) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  try {
+    $wc.downloadFile($url, $dir_path)
+  } catch {
+    $statusCode = $null
+    if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    }
+    if ($fallback_url) {
+      $fallback_artifact_url = "$fallback_url/$artifact_name"
+      $msg = "Primary download failed"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      Write-Information "$msg, trying fallback..."
+      Write-Verbose "  from $fallback_artifact_url"
+      try {
+        $wc.downloadFile($fallback_artifact_url, $dir_path)
+      } catch {
+        throw "ERROR: Failed to download from both primary ($url) and fallback ($fallback_artifact_url): $_"
+      }
+    } else {
+      $msg = "Failed to download from $url"
+      if ($statusCode) { $msg += " (HTTP $statusCode)" }
+      throw "ERROR: $msg : $_"
+    }
+  }
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1871,7 +1893,30 @@ function Download($download_url, $platforms) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    try {
+      $wc.downloadFile($updater_url, $out_name)
+    } catch {
+      $statusCode = $null
+      if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Response) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($fallback_url) {
+        $fallback_updater_url = "$fallback_url/$updater_id"
+        $msg = "Primary updater download failed"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        Write-Information "$msg, trying fallback..."
+        Write-Verbose "  from $fallback_updater_url"
+        try {
+          $wc.downloadFile($fallback_updater_url, $out_name)
+        } catch {
+          throw "ERROR: Failed to download updater from both primary ($updater_url) and fallback ($fallback_updater_url): $_"
+        }
+      } else {
+        $msg = "Failed to download updater from $updater_url"
+        if ($statusCode) { $msg += " (HTTP $statusCode)" }
+        throw "ERROR: $msg : $_"
+      }
+    }
     $bin_paths += $out_name
   }
 


### PR DESCRIPTION
## Summary

This PR allows users to customize the download URL, to support installing from a mirror. Fallback to GitHub Actions is also supported.

We're looking to use this in Ruff, uv, and ty to allow us to host our artifacts on a non-GitHub host with fallback.

Closes https://github.com/axodotdev/cargo-dist/issues/236.
