### PR TITLE
fix: prevent unintended escaping of multiline run

### DIFF
--- a/cargo-dist/templates/ci/github/release.yml.j2
+++ b/cargo-dist/templates/ci/github/release.yml.j2
@@ -249,7 +249,7 @@ jobs:
         {{%- if step.run is not undefined %}}
         {{%- if step.run is multiline %}}
         run: |
-          {{{ step.run|indent(10) }}}
+          {{{ step.run|indent(10)|safe }}}
         {{%- else %}}
         run: {{{ step.run }}}
         {{%- endif %}}


### PR DESCRIPTION
Fix #2257 - When generating GitHub Actions workflows, multi-line commands in run blocks were being automatically escaped with quotes, causing `command not found` and execution failures.

## Before
Renders with unintended quotes inside a multi-line block
```yaml
- name: "Build assets"
  run: |
    "npm run build"  # ← Quotes break command execution
```

## After
Single-line commands should render as inline strings without quotes
```yaml
- name: "Build assets"
  run: |
    npm run build
```