### PR TITLE
feat: support out_dir in config

### DIFF
--- a/axoproject/src/generic.rs
+++ b/axoproject/src/generic.rs
@@ -121,6 +121,7 @@ struct Package {
     readme: Option<Utf8PathBuf>,
     authors: Option<Vec<String>>,
     binaries: Option<Vec<String>>,
+    out_dir: Option<String>,
     license: Option<String>,
     changelog: Option<Utf8PathBuf>,
     license_files: Option<Vec<Utf8PathBuf>>,
@@ -401,6 +402,7 @@ fn process_package(
         license_files: package.license_files.unwrap_or_default(),
         changelog_file: package.changelog,
         binaries: package.binaries.unwrap_or_default(),
+        out_dir: package.out_dir,
         cstaticlibs: package.cstaticlibs.unwrap_or_default(),
         cdylibs: package.cdylibs.unwrap_or_default(),
         build_command: Some(build_command),
@@ -448,6 +450,7 @@ fn merge_package_with_raw_generic(
         readme,
         authors,
         binaries,
+        out_dir,
         license,
         changelog,
         license_files,
@@ -485,6 +488,9 @@ fn merge_package_with_raw_generic(
     }
     if let Some(val) = binaries {
         package.binaries = val;
+    }
+    if let Some(val) = out_dir {
+        package.out_dir = Some(val);
     }
     if let Some(val) = license {
         package.license = Some(val);

--- a/axoproject/src/javascript.rs
+++ b/axoproject/src/javascript.rs
@@ -153,6 +153,7 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
         // FIXME: is there any JS equivalent to this?
         changelog_file: None,
         binaries,
+        out_dir: None,
         // FIXME: is there any JS equivalent to this?
         cdylibs: vec![],
         // FIXME: is there any JS equivalent to this?

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -508,6 +508,8 @@ pub struct PackageInfo {
     /// For JS I *think* this is computed in its full complexity but Tests Needed
     /// and also there's so many ways to define things who can ever be sure.
     pub binaries: Vec<String>,
+    /// Path to the build directory for this package
+    pub out_dir: Option<String>,
     /// Names of C-style staticlibs (.a) this library defines.
     ///
     /// For Cargo this is currently properly computed in all its complexity.

--- a/axoproject/src/rust.rs
+++ b/axoproject/src/rust.rs
@@ -276,6 +276,7 @@ fn package_info(
             .collect(),
         changelog_file: None,
         binaries,
+        out_dir: None,
         cdylibs,
         cstaticlibs,
         cargo_metadata_table,

--- a/cargo-dist/src/build/generic.rs
+++ b/cargo-dist/src/build/generic.rs
@@ -51,11 +51,16 @@ impl<'a> DistGraphBuilder<'a> {
             }
             for (pkg_idx, expected_binaries) in builds_by_pkg_idx {
                 let package = self.workspaces.package(pkg_idx);
+                let out_dir = if let Some(dir) = package.out_dir.as_ref() {
+                    package.package_root.join(dir)
+                } else {
+                    package.package_root.clone()
+                };
                 builds.push(BuildStep::Generic(GenericBuildStep {
                     target_triple: target.clone(),
                     expected_binaries,
                     working_dir: package.package_root.clone(),
-                    out_dir: package.package_root.clone(),
+                    out_dir,
                     build_command: package
                         .build_command
                         .clone()

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -115,6 +115,7 @@ pub fn mock_package(name: &str, ver: &str) -> PackageInfo {
         license_files: vec![],
         changelog_file: None,
         binaries: vec![],
+        out_dir: None,
         cstaticlibs: vec![],
         cdylibs: vec![],
         cargo_metadata_table: None,


### PR DESCRIPTION
dist-workspace.toml now supports package.out-dir.
Previously, for non-Rust projects, binaries were assumed to be placed directly under the root. With this change, build artifacts can be stored in an arbitrary folder.

Related issues:
- https://github.com/axodotdev/cargo-dist/issues/874
- https://github.com/axodotdev/cargo-dist/issues/1335