### PR TITLE
chore: rust 1.93.1

### DIFF
--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -5,6 +5,11 @@
 
 #![deny(missing_docs)]
 #![allow(clippy::result_large_err)]
+// Since Rust 1.92, the unused_assignments lint incorrectly
+// flags values used by miette. This can be removed once this
+// is fixed.
+// https://github.com/rust-lang/rust/issues/147648
+#![allow(unused_assignments)]
 
 use std::fmt::Display;
 

--- a/cargo-dist-schema/src/macros.rs
+++ b/cargo-dist-schema/src/macros.rs
@@ -280,7 +280,7 @@ macro_rules! declare_strongly_typed_string {
             $(#[$attr])*
             pub struct $name(String);
 
-            #[automatically_derived]
+
             impl $name {
                 /// Constructs a new strongly-typed value
                 #[inline]
@@ -366,7 +366,7 @@ macro_rules! declare_strongly_typed_string {
             $(#[$attr])*
             pub struct $ref_name(str);
 
-            #[automatically_derived]
+
             impl $ref_name {
                 #[allow(unsafe_code)]
                 #[inline]

--- a/cargo-dist/src/announce.rs
+++ b/cargo-dist/src/announce.rs
@@ -928,37 +928,38 @@ pub fn announcement_github(manifest: &mut DistManifest) {
         other_artifacts.sort_by_cached_key(|a| sortable_triples(&a.target_triples));
 
         let download_url = release.artifact_download_url();
-        if !other_artifacts.is_empty() && download_url.is_some() {
-            let download_url = download_url.as_ref().unwrap();
-            writeln!(gh_body, "## Download {heading_suffix}\n",).unwrap();
-            gh_body.push_str("|  File  | Platform | Checksum |\n");
-            gh_body.push_str("|--------|----------|----------|\n");
+        if !other_artifacts.is_empty() {
+            if let Some(download_url) = download_url {
+                writeln!(gh_body, "## Download {heading_suffix}\n",).unwrap();
+                gh_body.push_str("|  File  | Platform | Checksum |\n");
+                gh_body.push_str("|--------|----------|----------|\n");
 
-            for artifact in &other_artifacts {
-                // Artifacts with no name do not exist as files, and should have had install-hints
-                let Some(name) = &artifact.name else {
-                    continue;
-                };
+                for artifact in &other_artifacts {
+                    // Artifacts with no name do not exist as files, and should have had install-hints
+                    let Some(name) = &artifact.name else {
+                        continue;
+                    };
 
-                let artifact_download_url = format!("{download_url}/{name}");
-                let download = format!("[{name}]({artifact_download_url})");
-                let checksum = if let Some(checksum_name) = &artifact.checksum {
-                    let checksum_download_url = format!("{download_url}/{checksum_name}");
-                    format!("[checksum]({checksum_download_url})")
-                } else {
-                    String::new()
-                };
-                let mut triple = artifact
-                    .target_triples
-                    .iter()
-                    .map(|t| triple_to_display_name(t).unwrap_or_else(|| t.as_str()))
-                    .join(", ");
-                if triple.is_empty() {
-                    triple = "Unknown".to_string();
+                    let artifact_download_url = format!("{download_url}/{name}");
+                    let download = format!("[{name}]({artifact_download_url})");
+                    let checksum = if let Some(checksum_name) = &artifact.checksum {
+                        let checksum_download_url = format!("{download_url}/{checksum_name}");
+                        format!("[checksum]({checksum_download_url})")
+                    } else {
+                        String::new()
+                    };
+                    let mut triple = artifact
+                        .target_triples
+                        .iter()
+                        .map(|t| triple_to_display_name(t).unwrap_or_else(|| t.as_str()))
+                        .join(", ");
+                    if triple.is_empty() {
+                        triple = "Unknown".to_string();
+                    }
+                    writeln!(&mut gh_body, "| {download} | {triple} | {checksum} |").unwrap();
                 }
-                writeln!(&mut gh_body, "| {download} | {triple} | {checksum} |").unwrap();
+                writeln!(&mut gh_body).unwrap();
             }
-            writeln!(&mut gh_body).unwrap();
         }
 
         if !other_artifacts.is_empty() && manifest.github_attestations {

--- a/cargo-dist/src/config/v1/mod.rs
+++ b/cargo-dist/src/config/v1/mod.rs
@@ -75,7 +75,7 @@
 //! This is because the "common" fields need to exist in the Layer types and be preserved
 //! as we fold in all the fields *BUT* we want them to go away in the final Config types
 //! because we want a single source of truth (we don't want code to forget to consult
-//! the inheritance chain). So a bunch of places grew [`...ConfigInheritable`] types that
+//! the inheritance chain). So a bunch of places grew `...ConfigInheritable` types that
 //! represent a hybrid between Config and Layer where the fields are ostensibly final
 //! but the "common" fields are still not folded in.
 //!

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -1,5 +1,10 @@
 #![deny(missing_docs)]
 #![allow(clippy::single_match, clippy::result_large_err)]
+// Since Rust 1.92, the unused_assignments lint incorrectly
+// flags values used by miette. This can be removed once this
+// is fixed.
+// https://github.com/rust-lang/rust/issues/147648
+#![allow(unused_assignments)]
 
 //! # dist
 //!

--- a/cargo-dist/src/tests/host.rs
+++ b/cargo-dist/src/tests/host.rs
@@ -8,7 +8,7 @@ use axoproject::errors::AxoprojectError;
 use axoproject::{PackageIdx, WorkspaceGraph};
 use semver::Version;
 
-fn mock_announce(workspaces: &mut WorkspaceGraph) -> (DistGraphBuilder, AnnouncementTag) {
+fn mock_announce(workspaces: &mut WorkspaceGraph) -> (DistGraphBuilder<'_>, AnnouncementTag) {
     let version: Version = BIN_AXO_VER.parse().unwrap();
     let tag = format!("{version}");
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87"
+channel = "1.93"
 components = ["rustc", "cargo", "rust-std", "clippy", "rustfmt"]


### PR DESCRIPTION
Applies changes recommended by the newer clippy and workarounds for an upstream clippy bug.