### PR TITLE
feat(homebrew): mirror support with multi-urls

### DIFF
--- a/cargo-dist/templates/installer/homebrew.rb.j2
+++ b/cargo-dist/templates/installer/homebrew.rb.j2
@@ -10,18 +10,20 @@ class {{ formula_class }} < Formula
   {%- if frag %}
     {%- if cond is defined %}
     if {{ cond }}
-      {#- FIXME: implement support for fallback URLs #}
-      url "{{ inner.base_urls[0] }}/{{ frag.id }}"
+      {%- for url in inner.base_urls %}
+      {{ "url" if loop.first else "mirror" }} "{{ url }}/{{ frag.id }}"
       {%- if frag.sha256 %}
       sha256 "{{ frag.sha256 }}"
       {%- endif %}
+      {%- endfor %}
     end
     {%- else %}
-    {#- FIXME: implement support for fallback URLs #}
-    url "{{ inner.base_urls[0] }}/{{ frag.id }}"
+    {%- for url in inner.base_urls %}
+    {{ "url" if loop.first else "mirror" }} "{{ url }}/{{ frag.id }}"
     {%- if frag.sha256 %}
     sha256 "{{ frag.sha256 }}"
     {%- endif %}
+    {%- endfor %}
     {%- endif %}
   {%- endif %}
   {%- endmacro %}

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
@@ -1654,17 +1654,21 @@ class Axolotlsay < Formula
   if OS.mac?
     if Hardware::CPU.arm?
       url "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz"
+      mirror "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz"
     end
     if Hardware::CPU.intel?
       url "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz"
+      mirror "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz"
     end
   end
   if OS.linux?
     if Hardware::CPU.arm?
       url "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-unknown-linux-gnu.tar.gz"
+      mirror "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-unknown-linux-gnu.tar.gz"
     end
     if Hardware::CPU.intel?
       url "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
+      mirror "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
     end
   end
   license any_of: ["MIT", "Apache-2.0"]

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
@@ -1654,17 +1654,21 @@ class Axolotlsay < Formula
   if OS.mac?
     if Hardware::CPU.arm?
       url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz"
+      mirror "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz"
     end
     if Hardware::CPU.intel?
       url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz"
+      mirror "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz"
     end
   end
   if OS.linux?
     if Hardware::CPU.arm?
       url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-unknown-linux-gnu.tar.gz"
+      mirror "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-unknown-linux-gnu.tar.gz"
     end
     if Hardware::CPU.intel?
       url "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
+      mirror "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
     end
   end
   license any_of: ["MIT", "Apache-2.0"]

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
@@ -1654,17 +1654,21 @@ class Axolotlsay < Formula
   if OS.mac?
     if Hardware::CPU.arm?
       url "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz"
+      mirror "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-apple-darwin.tar.gz"
     end
     if Hardware::CPU.intel?
       url "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz"
+      mirror "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-apple-darwin.tar.gz"
     end
   end
   if OS.linux?
     if Hardware::CPU.arm?
       url "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-unknown-linux-gnu.tar.gz"
+      mirror "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-aarch64-unknown-linux-gnu.tar.gz"
     end
     if Hardware::CPU.intel?
       url "https://github.com/axodotdev//axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
+      mirror "https://github.com/axodotdev/axolotlsay/releases/download/v0.2.2/axolotlsay-x86_64-unknown-linux-gnu.tar.gz"
     end
   end
   license any_of: ["MIT", "Apache-2.0"]


### PR DESCRIPTION
This adds Homebrew support for simple download URLs, and any other secondary URLs we'll be adding in the future. Homebrew has first-class mirror support via the `mirror` keyword. It allows arbitrary numbers of mirrors, which works perfectly for us.