### PR TITLE
docs fix typo in package.license-files config example

### DIFF
--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -1852,7 +1852,7 @@ This may be used in the metadata of various [installers][].
 > *in your dist-workspace.toml or dist.toml:*
 > ```toml
 > [package]
-> readme = ["../LICENSE-MIT", "../LICENSE-APACHE"]
+> license-files = ["../LICENSE-MIT", "../LICENSE-APACHE"]
 > ```
 
 Relative paths to the license files for your package.


### PR DESCRIPTION
Hi, I noticed a small documentation issue and wanted to help fix it.

The TOML example in the `package.license-files` section of the config reference contained a copy-paste error: the key was mistakenly written as `readme` instead of `license-files`. This appears to have been introduced when the example was copied from the adjacent `package.readme` section without updating the key name.

Thanks,