### PR TITLE
installer: add retry for transient network errors

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -1424,9 +1424,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -1424,15 +1424,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1478,9 +1478,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1478,15 +1478,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1482,15 +1482,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1482,9 +1482,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1494,9 +1494,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1494,15 +1494,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -1536,9 +1536,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -1536,15 +1536,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1482,15 +1482,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1482,9 +1482,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1482,15 +1482,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1482,9 +1482,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
@@ -1536,9 +1536,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
@@ -1536,15 +1536,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
@@ -1536,9 +1536,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
@@ -1536,15 +1536,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
@@ -1536,9 +1536,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
@@ -1536,15 +1536,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1568,15 +1568,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1568,9 +1568,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -1536,9 +1536,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -1536,15 +1536,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -1536,9 +1536,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -1536,15 +1536,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -1400,15 +1400,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -1400,9 +1400,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi
@@ -3712,15 +3712,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
@@ -3712,9 +3712,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1478,9 +1478,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1478,15 +1478,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1458,15 +1458,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1458,9 +1458,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1482,15 +1482,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1482,9 +1482,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
@@ -1568,15 +1568,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
@@ -1568,9 +1568,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
@@ -1568,15 +1568,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
@@ -1568,9 +1568,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
@@ -1568,15 +1568,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
@@ -1568,9 +1568,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
@@ -1568,15 +1568,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
@@ -1568,9 +1568,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1470,15 +1470,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1470,9 +1470,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1453,9 +1453,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1453,15 +1453,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1453,9 +1453,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1453,15 +1453,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1453,9 +1453,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1453,15 +1453,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1453,9 +1453,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1453,15 +1453,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1466,9 +1466,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1466,15 +1466,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/install_path_fallback_to_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_to_cargo_home.snap
@@ -914,7 +914,7 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+    then curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
     elif [ "$_dld" = wget ]
     then wget --tries=4 --waitretry=3 "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here

--- a/cargo-dist/tests/snapshots/install_path_fallback_to_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_to_cargo_home.snap
@@ -914,9 +914,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget --tries=4 --waitretry=3 "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1453,9 +1453,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1453,15 +1453,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1453,9 +1453,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1453,15 +1453,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1453,9 +1453,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1453,15 +1453,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1453,9 +1453,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1453,15 +1453,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1466,9 +1466,9 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1466,15 +1466,15 @@ downloader() {
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
         else
-            curl -sSfL "$1" -o "$2"
+            curl -sSfL --retry 3 --retry-delay 3 --retry-all-errors "$1" -o "$2"
         fi
     elif [ "$_dld" = wget ]; then
         if [ -n "${AUTH_TOKEN:-}" ]; then
-            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+            wget --tries=4 --waitretry=3 --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
         else
-            wget "$1" -O "$2"
+            wget --tries=4 --waitretry=3 "$1" -O "$2"
         fi
     else err "Unknown downloader"   # should not reach here
     fi


### PR DESCRIPTION
[Example failure](https://github.com/commaai/openpilot/actions/runs/22524031665/job/65253149581) doing a uv install in our openpilot CI.

Also may close https://github.com/axodotdev/cargo-dist/issues/943 if I understand correctly?

---

from `man curl`:
```
       --retry <num>
              If  a transient error is returned when curl tries to perform a trans‐
              fer, it retries this number of times before giving  up.  Setting  the
              number  to  0  makes curl do no retries (which is the default). Tran‐
              sient error means either: a timeout, an FTP 4xx response code  or  an
              HTTP 408, 429, 500, 502, 503 or 504 response code.
```