### PR TITLE
fix: double escape windows path in receipt

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -92,17 +92,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -662,7 +651,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -97,7 +97,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -716,7 +705,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -720,7 +709,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -732,7 +721,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -774,7 +763,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -720,7 +709,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -720,7 +709,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -774,7 +763,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -774,7 +763,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -774,7 +763,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -806,7 +795,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -774,7 +763,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -774,7 +763,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -638,7 +627,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi
@@ -2344,7 +2345,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout
@@ -2340,17 +2336,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -2951,7 +2936,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -716,7 +705,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -696,7 +685,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -720,7 +709,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -806,7 +795,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -806,7 +795,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -806,7 +795,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -806,7 +795,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -708,7 +697,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -691,7 +680,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -691,7 +680,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -691,7 +680,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -691,7 +680,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -704,7 +693,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -691,7 +680,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -691,7 +680,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -691,7 +680,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -691,7 +680,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -97,17 +97,6 @@ is_windows_posix() {
             ;;
     esac
 }
-# Convert POSIX path to Windows path
-convert_path_for_receipt() {
-    local _path="$1"
-    if is_windows_posix && check_cmd cygpath; then
-        # Use cygpath to convert path, then escape backslashes for JSON
-        # Need 4 backslashes to survive: command substitution + double quotes in sed command
-        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
-    else
-        echo "$_path"
-    fi
-}
 
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
@@ -704,7 +693,14 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
+    if is_windows_posix && check_cmd cygpath; then
+        # Use cygpath to convert to Windows path, then escape backslashes for JSON
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        _win_path=$(cygpath -w "$_receipt_install_dir" | sed 's/\\/\\\\\\\\/g')
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_win_path,")
+    else
+        RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    fi
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -102,7 +102,8 @@ convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && check_cmd cygpath; then
         # Use cygpath to convert path, then escape backslashes for JSON
-        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+        # Need 4 backslashes to survive: command substitution + double quotes in sed command
+        cygpath -w "$_path" | sed 's/\\/\\\\\\\\/g'
     else
         echo "$_path"
     fi


### PR DESCRIPTION
Follow-up fix for #2227. Good news: We're halfway there with supporting Windows. However, on Git Bash/MSYS/MINGW environments, the `uv-receipt.json` now contains unescaped backslashes in the `install_prefix` field, which is invalid JSON:
```json
{"install_prefix":"C:\Users\username\.local\bin",...}
```

### Root Cause
The `convert_path_for_receipt()` function outputs escaped backslashes (`\\`), but these are later inserted via command substitution into a [double-quoted sed command](https://github.com/axodotdev/cargo-dist/blob/73dc6326196427e5d0ac5b6950208be05e8c3b03/cargo-dist/templates/installer/installer.sh.j2#L664):

```bash
RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
```

Inside double quotes, the shell processes `\\` as an escape sequence, which reduces each pair to a single backslash before `sed` executes. This results in unescaped backslashes. With this change, we output 4 backslashes per original backslash, which get reduced to two again. Essentially:

`sed "s,AXO_INSTALL_PREFIX,C:\\\\Users\\\\test"` -> Correct JSON

Refactored it a little so the whole receipt path conversion logic is not spread all over the place