### PR TITLE
feat: add configurable npm registry URL for publishers

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -111,6 +111,8 @@ pub struct GithubCiInfo {
     pub need_cargo_cyclonedx: bool,
     /// Whether to install and run omnibor-cli
     pub need_omnibor: bool,
+    /// npm registry URL for publishing
+    pub npm_registry_url: String,
 }
 
 /// Details for github releases
@@ -286,6 +288,13 @@ impl GithubCiInfo {
 
         let tap = dist.global_homebrew_tap.clone();
 
+        let npm_registry_url = dist
+            .global_publishers
+            .as_ref()
+            .and_then(|p| p.npm.as_ref())
+            .and_then(|npm| npm.registry.clone())
+            .unwrap_or_else(|| "https://registry.npmjs.org".to_string());
+
         let mut job_permissions = ci_config.permissions.clone();
         // user publish jobs default to elevated privileges
         for JobStyle::User(name) in &ci_config.publish_jobs {
@@ -417,6 +426,7 @@ impl GithubCiInfo {
             need_cargo_auditable,
             need_cargo_cyclonedx,
             need_omnibor,
+            npm_registry_url,
         })
     }
 

--- a/cargo-dist/src/config/v1/publishers/npm.rs
+++ b/cargo-dist/src/config/v1/publishers/npm.rs
@@ -7,12 +7,17 @@ use super::*;
 pub struct NpmPublisherLayer {
     /// Common options
     pub common: CommonPublisherLayer,
+    /// Custom npm registry URL (e.g. "https://wombat-dressing-room.appspot.com")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry: Option<String>,
 }
 /// Options for npm publishes
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct NpmPublisherConfig {
     /// Common options
     pub common: CommonPublisherConfig,
+    /// Custom npm registry URL
+    pub registry: Option<String>,
 }
 
 impl NpmPublisherConfig {
@@ -24,20 +29,23 @@ impl NpmPublisherConfig {
     ) -> Self {
         Self {
             common: common.clone(),
+            registry: None,
         }
     }
 }
 
 impl ApplyLayer for NpmPublisherConfig {
     type Layer = NpmPublisherLayer;
-    fn apply_layer(&mut self, Self::Layer { common }: Self::Layer) {
+    fn apply_layer(&mut self, Self::Layer { common, registry }: Self::Layer) {
         self.common.apply_layer(common);
+        self.registry.apply_opt(registry);
     }
 }
 impl ApplyLayer for NpmPublisherLayer {
     type Layer = NpmPublisherLayer;
-    fn apply_layer(&mut self, Self::Layer { common }: Self::Layer) {
+    fn apply_layer(&mut self, Self::Layer { common, registry }: Self::Layer) {
         self.common.apply_layer(common);
+        self.registry.apply_opt(registry);
     }
 }
 

--- a/cargo-dist/templates/ci/github/partials/publish_npm.yml.j2
+++ b/cargo-dist/templates/ci/github/partials/publish_npm.yml.j2
@@ -20,7 +20,7 @@
       - uses: {{{ actions["actions/setup-node"] | safe }}}
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: {{{ npm_registry_url }}}
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -4534,7 +4534,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
@@ -4502,7 +4502,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
@@ -4543,7 +4543,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
@@ -4532,7 +4532,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -4655,7 +4655,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -4400,7 +4400,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
@@ -4640,7 +4640,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
@@ -4640,7 +4640,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
@@ -4634,7 +4634,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
@@ -4636,7 +4636,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)


### PR DESCRIPTION
Add a `registry` option to the npm publisher config so users can publish to custom npm registries instead of the hardcoded  https://registry.npmjs.org.

Config example:
      
```toml
[dist.publishers.npm]
registry = "https://example.com"
```

When omitted, defaults to https://registry.npmjs.org (current behavior).

Changes:
    - Added `registry: Option<String>` to NpmPublisherLayer/NpmPublisherConfig
    - Added `npm_registry_url: String` to GithubCiInfo (auto-populates template)
    - Updated publish_npm.yml.j2 to use template variable
    - Updated snapshot tests

Fixes: #2316 