### PR TITLE
feat(auditable): remove zigbuild limitation

### DIFF
--- a/cargo-dist/src/build/cargo.rs
+++ b/cargo-dist/src/build/cargo.rs
@@ -191,12 +191,6 @@ pub fn make_build_cargo_target_command(
             command.arg("build");
         }
         Some(CargoBuildWrapper::ZigBuild) => {
-            if auditable {
-                return Err(DistError::CannotDoCargoAuditableAndCrossCompile {
-                    host: host.to_owned(),
-                    target,
-                });
-            }
             command.arg("zigbuild");
         }
         Some(CargoBuildWrapper::Xwin) => {

--- a/cargo-dist/src/errors.rs
+++ b/cargo-dist/src/errors.rs
@@ -552,18 +552,6 @@ pub enum DistError {
         details: String,
     },
 
-    /// Cannot use cross-compilation with cargo-auditable
-    #[error(
-        "Cross-compilation builds from {host} to {target} cannot be used with cargo-auditable"
-    )]
-    #[diagnostic(help("set cargo-auditable to false or don't do cross-compilation"))]
-    CannotDoCargoAuditableAndCrossCompile {
-        /// The host system
-        host: Triple,
-        /// The target system
-        target: Triple,
-    },
-
     /// Generic build with Cargo-only build options
     #[error("You're building a generic package but have a Cargo-only option enabled")]
     #[diagnostic(help("Please disable the following from your configuration: {}", options.join(", ")))]


### PR DESCRIPTION
We had this limitation in place since zigbuild couldn't be used to cross-compile while cargo-auditable was in use. That limitation no longer exists as of the new cargo-auditable 0.7.3.

https://github.com/rust-secure-code/cargo-auditable/releases/tag/v0.7.3

cc @Shnatsel 