### PR TITLE
Add failing test for npm installer authenticated proxy bug

### DIFF
--- a/cargo-dist/tests/fixtures/test-npm-proxy-auth.js
+++ b/cargo-dist/tests/fixtures/test-npm-proxy-auth.js
@@ -1,0 +1,143 @@
+// Tests that the npm installer correctly forwards proxy authentication
+// credentials when HTTPS_PROXY contains username:password.
+//
+// This exercises the actual installer code path end-to-end:
+// 1. Starts a local HTTP CONNECT proxy requiring Basic auth
+// 2. Sets HTTPS_PROXY=http://testuser:testpass@127.0.0.1:<port>
+// 3. Patches package.json so binary.js has a real HTTPS download URL
+// 4. Requires binary.js (which sets up whatever proxy mechanism it uses)
+// 5. Calls install() — the same function npm postinstall runs
+// 6. Checks whether the proxy actually received Proxy-Authorization
+//
+// On the buggy code (axios-proxy-builder): FAILS — credentials are dropped
+// On the fixed code (undici EnvHttpProxyAgent): PASSES — credentials are sent
+
+"use strict";
+
+const http = require("http");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+// Kill the test if it hangs
+setTimeout(() => {
+  console.error("FAIL: Test timed out");
+  process.exit(1);
+}, 15000);
+
+async function main() {
+  let authReceived = false;
+
+  // Start a minimal CONNECT proxy that inspects the Proxy-Authorization header
+  const proxy = http.createServer();
+  proxy.on("connect", (req, clientSocket) => {
+    const auth = req.headers["proxy-authorization"];
+    if (auth) {
+      const decoded = Buffer.from(
+        auth.replace("Basic ", ""),
+        "base64",
+      ).toString();
+      if (decoded === "testuser:testpass") {
+        authReceived = true;
+      }
+    }
+    // Always reject — we only need to observe whether auth was sent
+    clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
+    clientSocket.end();
+  });
+
+  await new Promise((resolve) => proxy.listen(0, "127.0.0.1", resolve));
+  const { port } = proxy.address();
+
+  // Set proxy env vars BEFORE requiring binary.js (which may set up
+  // a global proxy dispatcher at module load time)
+  process.env.HTTPS_PROXY = `http://testuser:testpass@127.0.0.1:${port}`;
+  process.env.HTTP_PROXY = process.env.HTTPS_PROXY;
+  process.env.NO_PROXY = "";
+
+  // Patch package.json so install() has a valid HTTPS download URL
+  // and a supportedPlatforms entry matching this machine
+  const pkgPath = path.join(__dirname, "package.json");
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+
+  // Build the target triple the same way binary.js does
+  const rawOs = os.type();
+  const rawArch = os.arch();
+  let osType = "";
+  switch (rawOs) {
+    case "Windows_NT": osType = "pc-windows-msvc"; break;
+    case "Darwin": osType = "apple-darwin"; break;
+    case "Linux": osType = "unknown-linux-gnu"; break;
+  }
+  let arch = "";
+  switch (rawArch) {
+    case "x64": arch = "x86_64"; break;
+    case "arm64": arch = "aarch64"; break;
+  }
+  const triple = `${arch}-${osType}`;
+
+  pkg.artifactDownloadUrls = ["https://example.com/releases"];
+  pkg.supportedPlatforms = {
+    [triple]: {
+      artifactName: "fake-artifact.tar.gz",
+      bins: { "fake-bin": "fake-bin" },
+      zipExt: ".tar.gz",
+    },
+  };
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+
+  // Copy binary.js and binary-install.js into this directory so
+  // require("./binary") works (they live under npm/ in the template)
+  const npmDir = path.join(__dirname, "npm");
+  if (fs.existsSync(npmDir)) {
+    for (const file of ["binary.js", "binary-install.js"]) {
+      const src = path.join(npmDir, file);
+      if (fs.existsSync(src)) {
+        fs.copyFileSync(src, path.join(__dirname, file));
+      }
+    }
+  }
+
+  // The installer's error() helper calls process.exit(1) on download failure,
+  // which would kill the process before we can check the proxy. Intercept it.
+  const realExit = process.exit;
+  process.exit = () => {};
+
+  // NOW require binary.js — this is the actual installer code under test.
+  // On the fixed version, this calls setGlobalDispatcher(new EnvHttpProxyAgent())
+  // at module load time, configuring proxy for all subsequent fetch() calls.
+  // On the buggy version, this just loads axios-proxy-builder.
+  const { install } = require("./binary");
+
+  // Call install() — exactly what the npm postinstall hook does.
+  // This will attempt to download from https://example.com/releases/fake-artifact.tar.gz
+  // which must go through our proxy (since HTTPS_PROXY is set).
+  try {
+    await install(true);
+  } catch {
+    // Expected to fail (proxy rejects, or download fails)
+  }
+
+  // Restore process.exit for our own use
+  process.exit = realExit;
+
+  await new Promise((resolve) => proxy.close(resolve));
+
+  if (authReceived) {
+    console.log("PASS: Proxy received authentication credentials");
+    process.exit(0);
+  } else {
+    console.error(
+      "FAIL: Proxy did NOT receive authentication credentials\n" +
+        "The installer sent a CONNECT request to the proxy without " +
+        "Proxy-Authorization.\nThis means authenticated proxies " +
+        "(HTTPS_PROXY=http://user:pass@host:port) are broken.",
+    );
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error("Test error:", e);
+  process.exit(1);
+});

--- a/cargo-dist/tests/fixtures/test-npm-proxy-auth.js
+++ b/cargo-dist/tests/fixtures/test-npm-proxy-auth.js
@@ -10,7 +10,7 @@
 // 6. Checks whether the proxy actually received Proxy-Authorization
 //
 // On the buggy code (axios-proxy-builder): FAILS — credentials are dropped
-// On the fixed code (undici EnvHttpProxyAgent): PASSES — credentials are sent
+// On the fixed code: PASSES — credentials are sent
 
 "use strict";
 
@@ -28,9 +28,10 @@ setTimeout(() => {
 async function main() {
   let authReceived = false;
 
-  // Start a minimal CONNECT proxy that inspects the Proxy-Authorization header
-  const proxy = http.createServer();
-  proxy.on("connect", (req, clientSocket) => {
+  // Start a minimal proxy that inspects the Proxy-Authorization header.
+  // We check both plain HTTP proxy requests and CONNECT tunneling requests,
+  // since different HTTP clients use different proxy styles.
+  function checkAuth(req) {
     const auth = req.headers["proxy-authorization"];
     if (auth) {
       const decoded = Buffer.from(
@@ -41,7 +42,17 @@ async function main() {
         authReceived = true;
       }
     }
-    // Always reject — we only need to observe whether auth was sent
+  }
+
+  const proxy = http.createServer((req, res) => {
+    // Plain HTTP proxy request (e.g. GET https://... through proxy)
+    checkAuth(req);
+    res.writeHead(502);
+    res.end();
+  });
+  proxy.on("connect", (req, clientSocket) => {
+    // CONNECT tunneling request
+    checkAuth(req);
     clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
     clientSocket.end();
   });
@@ -104,9 +115,6 @@ async function main() {
   process.exit = () => {};
 
   // NOW require binary.js — this is the actual installer code under test.
-  // On the fixed version, this calls setGlobalDispatcher(new EnvHttpProxyAgent())
-  // at module load time, configuring proxy for all subsequent fetch() calls.
-  // On the buggy version, this just loads axios-proxy-builder.
   const { install } = require("./binary");
 
   // Call install() — exactly what the npm postinstall hook does.
@@ -129,7 +137,7 @@ async function main() {
   } else {
     console.error(
       "FAIL: Proxy did NOT receive authentication credentials\n" +
-        "The installer sent a CONNECT request to the proxy without " +
+        "The installer sent a request to the proxy without " +
         "Proxy-Authorization.\nThis means authenticated proxies " +
         "(HTTPS_PROXY=http://user:pass@host:port) are broken.",
     );

--- a/cargo-dist/tests/integration-tests.rs
+++ b/cargo-dist/tests/integration-tests.rs
@@ -26,6 +26,104 @@
 mod gallery;
 use gallery::*;
 
+/// Tests that the npm installer correctly forwards proxy authentication
+/// credentials when HTTPS_PROXY contains username:password.
+///
+/// This is a regression test for a bug in axios-proxy-builder, which silently
+/// drops proxy auth credentials — it passes only host and port to
+/// tunnel.httpsOverHttp(), ignoring proxyAuth entirely. The fix replaces
+/// axios with native fetch + undici's EnvHttpProxyAgent, which correctly
+/// handles authenticated proxies.
+///
+/// The test installs the template's npm dependencies, then runs a Node.js
+/// script that starts a local CONNECT proxy requiring Basic auth and verifies
+/// the Proxy-Authorization header is actually sent.
+#[test]
+fn npm_installer_sends_proxy_auth() {
+    // Skip if node/npm not available
+    let node_ok = std::process::Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    let npm_ok = std::process::Command::new("npm")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !node_ok || !npm_ok {
+        eprintln!("Skipping npm_installer_sends_proxy_auth: node/npm not found");
+        return;
+    }
+
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let template_dir = manifest_dir.join("templates").join("installer");
+    let fixture_script = manifest_dir
+        .join("tests")
+        .join("fixtures")
+        .join("test-npm-proxy-auth.js");
+
+    // Set up temp directory with the template's dependencies
+    let tempdir = std::env::temp_dir().join("cargo-dist-proxy-auth-test");
+    if tempdir.exists() {
+        std::fs::remove_dir_all(&tempdir).unwrap();
+    }
+    std::fs::create_dir_all(&tempdir).unwrap();
+
+    std::fs::copy(
+        template_dir.join("package.json"),
+        tempdir.join("package.json"),
+    )
+    .unwrap();
+    std::fs::copy(
+        template_dir.join("npm-shrinkwrap.json"),
+        tempdir.join("npm-shrinkwrap.json"),
+    )
+    .unwrap();
+
+    // Copy the npm/ subdirectory (binary.js, binary-install.js)
+    let npm_src = template_dir.join("npm");
+    let npm_dst = tempdir.join("npm");
+    std::fs::create_dir_all(&npm_dst).unwrap();
+    for entry in std::fs::read_dir(&npm_src).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_type().unwrap().is_file() {
+            std::fs::copy(entry.path(), npm_dst.join(entry.file_name())).unwrap();
+        }
+    }
+
+    let install = std::process::Command::new("npm")
+        .args(["install", "--ignore-scripts"])
+        .current_dir(&tempdir)
+        .output()
+        .unwrap();
+    assert!(
+        install.status.success(),
+        "npm install failed: {}",
+        String::from_utf8_lossy(&install.stderr)
+    );
+
+    // Copy and run the proxy auth test script
+    std::fs::copy(&fixture_script, tempdir.join("test-npm-proxy-auth.js")).unwrap();
+
+    let result = std::process::Command::new("node")
+        .arg("test-npm-proxy-auth.js")
+        .current_dir(&tempdir)
+        .output()
+        .unwrap();
+
+    let _ = std::fs::remove_dir_all(&tempdir);
+
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        result.status.success(),
+        "npm installer did not forward proxy auth credentials.\n\
+         Authenticated proxies (HTTPS_PROXY=http://user:pass@host:port) are broken.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
 #[test]
 fn axolotlsay_basic() -> Result<(), miette::Report> {
     let test_name = _function_name!();


### PR DESCRIPTION
### Context

We use `@j178/prek`, a Rust CLI distributed via npm through cargo-dist. The generated npm installer uses `axios` + `axios-proxy-builder` to download binaries. We discovered that authenticated proxies don't work. When a proxy (e.g. **Claude Code web sandbox**) requires credentials in the URL (`HTTPS_PROXY=http://user:pass@proxy:8080`), `axios-proxy-builder` silently drops them. It only passes `host` and `port` to `tunnel.httpsOverHttp()`, ignoring `proxyAuth` entirely.

We patched it locally:
```patch
// axios-proxy-builder dist/proxy-builder.js
-  const agent = tunnel.httpsOverHttp({
-    proxy: {
-      host: hostname,
-      port: parseInt(port),
-    },
-  });
+  const proxyConfig = {
+    host: hostname,
+    port: parseInt(port),
+  };
+  if (username && password) {
+    proxyConfig.proxyAuth = `${username}:${password}`;
+  }
+  const agent = tunnel.httpsOverHttp({
+    proxy: proxyConfig,
+  });
```

Patching this in every project isn't sustainable. `axios-proxy-builder` hasn't received an update in years, so fixing it upstream isn't realistic either. This is why  I am here. 

### What this PR does

Adds a failing regression test (`npm_installer_sends_proxy_auth`) that demonstrates the bug. The test:

1. Starts a local HTTP CONNECT proxy requiring Basic auth
2. Sets `HTTPS_PROXY` with credentials
3. Runs the actual installer code path (`binary.js` -> `install()` -> HTTP request)
4. Checks whether the proxy received the `Proxy-Authorization` header

The test fails because `axios-proxy-builder` drops the credentials from the CONNECT request.

### Suggested fix

Replace `axios` + `axios-proxy-builder` with native `fetch()` and `undici`'s `EnvHttpProxyAgent`, which handles authenticated proxies, `NO_PROXY`, and all standard proxy env vars correctly out of the box. This requires bumping the node engine minimum from `>=14` to `>=18` (for native `fetch()` and `Readable.fromWeb()`), but Node 14 has been EOL since April 2023, so that should be safe.

For reference, Node.js v22.21.0+ added [native proxy support for `fetch()`](https://nodejs.org/en/learn/http/enterprise-network-configuration) via `--use-env-proxy` / `NODE_USE_ENV_PROXY`, which would eliminate the `undici` dependency entirely. However, that requires Node 22.21+ and the end user has to opt in themselves. We can't set it from within the installer. `undici`'s `EnvHttpProxyAgent` works on Node 18+ with no user configuration required.

I have a working implementation on [this branch](https://github.com/tnkuehne/cargo-dist/tree/remove-broken-axios-dep). Happy to open a follow-up PR if this direction sounds good.