### PR TITLE
fix: add -y flag to apt-get install in generated CI

### DIFF
--- a/cargo-dist/src/backend/ci/github.rs
+++ b/cargo-dist/src/backend/ci/github.rs
@@ -830,7 +830,7 @@ fn system_deps_install_script(
                 }
             })
             .join(" ");
-        lines.push(format!("{sudo}apt-get install {args}"));
+        lines.push(format!("{sudo}apt-get install -y {args}"));
     }
 
     for (pkg, version) in &chocolatey_packages {

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1896,7 +1896,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "targets": [
               "x86_64-unknown-linux-musl"
             ],
-            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install -y musl-tools",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -280,7 +280,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "targets": [
               "aarch64-unknown-linux-musl"
             ],
-            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install -y musl-tools",
             "cache_provider": "buildjet"
           },
           {
@@ -307,7 +307,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "targets": [
               "x86_64-unknown-linux-musl"
             ],
-            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install -y musl-tools",
             "cache_provider": "buildjet"
           }
         ]

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -3246,7 +3246,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "targets": [
               "x86_64-unknown-linux-musl"
             ],
-            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install -y musl-tools",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -3168,7 +3168,7 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
             "targets": [
               "x86_64-unknown-linux-musl"
             ],
-            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install -y musl-tools",
             "cache_provider": "github"
           }
         ]

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -621,7 +621,7 @@ stdout:
             "targets": [
               "x86_64-unknown-linux-musl"
             ],
-            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
+            "packages_install": "sudo apt-get update\nsudo apt-get install -y musl-tools",
             "cache_provider": "github"
           }
         ]


### PR DESCRIPTION
apt-get requires -y (or the APT::Get::Assume-Yes config option) to automatically answer yes to confirmation prompts. GitHub Actions standard runners pre-configure APT::Get::Assume-Yes, so the missing flag has not caused issues there. However, custom containers or self-hosted runners may not have this setting, causing the command to hang waiting for user input.

Other package managers already handle this: choco uses --yes, dnf uses --assumeyes. brew and pip do not prompt by default.

fix #2353 