### PR TITLE
chore: update github actions for node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
   npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       # linter requires package.json to be in the same folder
@@ -44,7 +44,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
@@ -55,18 +55,15 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           components: clippy
       - uses: swatinem/rust-cache@v2
-      - uses: actions-rs/clippy-check@v1
+      - run: cargo clippy --workspace --tests --examples
         env:
           PWD: ${{ env.GITHUB_WORKSPACE }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --tests --examples
 
   # Make sure the docs build without warnings
   docs:
@@ -74,7 +71,7 @@ jobs:
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
@@ -86,9 +83,9 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check spelling of entire workspace
-        uses: crate-ci/typos@v1.26.0
+        uses: crate-ci/typos@v1.45.0
 
   # Build and run tests/doctests/examples on all platforms
   # FIXME: look into `cargo-hack` which lets you more aggressively
@@ -105,7 +102,7 @@ jobs:
         rust: [stable]
     steps:
       # Setup tools
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Setup
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
@@ -80,7 +80,7 @@ jobs:
       # go into repo's settings > pages and set "deploy from branch: gh-pages"
       # the other defaults work fine.
       - name: Deploy to Github Pages
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         # ONLY if we're on main (so no PRs or feature branches allowed!)
         if: ${{ github.ref == 'refs/heads/main' }}
         with:

--- a/cargo-dist/src/backend/installer/msi.rs
+++ b/cargo-dist/src/backend/installer/msi.rs
@@ -87,13 +87,13 @@ impl MsiInstallerInfo {
         Ok(renders)
     }
 
-    /// msi's impl of `dist genenerate --check`
+    /// msi's impl of `dist generate --check`
     pub fn check_config(&self) -> DistResult<()> {
         self.check_wix_guids()?;
         self.check_wxs()?;
         Ok(())
     }
-    /// msi's impl of `dist genenerate`
+    /// msi's impl of `dist generate`
     pub fn write_config_to_disk(&self) -> DistResult<()> {
         self.write_wix_guids_to_disk()?;
         self.write_wxs_to_disk()?;


### PR DESCRIPTION
Some actions are outdated and will be forced to use node 24 by June 2nd

- updates actions in non generated workflows
- updates typos action and resolves typo
- pins checkout action to same version in workflows

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v3, JamesIves/github-pages-deploy-action@v4.4.1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Validation

None of the bumps have any relevant breaking changes as far as I can tell, and the warnings are no longer popping up in the CI runs for this branch

- `web.yml` https://github.com/axodotdev/cargo-dist/actions/runs/24317434981/job/70997495669?pr=2363
- `ci.yml` https://github.com/axodotdev/cargo-dist/actions/runs/24317434995/job/70997495624?pr=2363