### PR TITLE
ps1: peek the inner exception on download failure

### DIFF
--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -162,6 +162,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -264,6 +265,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -289,7 +311,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -334,7 +356,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\{{ app_name }}-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1806,6 +1806,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1908,6 +1909,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1933,7 +1955,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1978,7 +2000,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1833,6 +1833,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1935,6 +1936,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1960,7 +1982,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -2005,7 +2027,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1787,6 +1787,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1889,6 +1890,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1914,7 +1936,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1959,7 +1981,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\akaikatana-repack-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -1853,6 +1853,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1955,6 +1956,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1980,7 +2002,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -2025,7 +2047,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1806,6 +1806,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1908,6 +1909,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1933,7 +1955,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1978,7 +2000,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1810,6 +1810,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1912,6 +1913,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1937,7 +1959,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1982,7 +2004,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
@@ -1853,6 +1853,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1955,6 +1956,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1980,7 +2002,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -2025,7 +2047,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
@@ -1853,6 +1853,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1955,6 +1956,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1980,7 +2002,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -2025,7 +2047,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
@@ -1853,6 +1853,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1955,6 +1956,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1980,7 +2002,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -2025,7 +2047,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1892,6 +1892,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1994,6 +1995,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -2019,7 +2041,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -2064,7 +2086,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -1853,6 +1853,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1955,6 +1956,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1980,7 +2002,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -2025,7 +2047,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1778,6 +1778,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1880,6 +1881,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1905,7 +1927,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1950,7 +1972,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -1786,6 +1786,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1888,6 +1889,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1913,7 +1935,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1958,7 +1980,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -1630,6 +1630,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1732,6 +1733,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1757,7 +1779,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1802,7 +1824,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -1710,6 +1710,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1812,6 +1813,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1837,7 +1859,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1882,7 +1904,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1774,6 +1774,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1876,6 +1877,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1901,7 +1923,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1946,7 +1968,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-js-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 
@@ -4017,6 +4039,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -4119,6 +4142,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -4144,7 +4188,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -4189,7 +4233,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1810,6 +1810,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1912,6 +1913,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1937,7 +1959,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1982,7 +2004,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
@@ -1896,6 +1896,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1998,6 +1999,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -2023,7 +2045,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -2068,7 +2090,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
@@ -1896,6 +1896,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1998,6 +1999,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -2023,7 +2045,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -2068,7 +2090,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
@@ -1892,6 +1892,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1994,6 +1995,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -2019,7 +2041,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -2064,7 +2086,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
@@ -1896,6 +1896,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1998,6 +1999,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -2023,7 +2045,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -2068,7 +2090,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1710,6 +1710,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1812,6 +1813,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1837,7 +1859,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1882,7 +1904,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1710,6 +1710,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1812,6 +1813,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1837,7 +1859,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1882,7 +1904,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1787,6 +1787,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1889,6 +1890,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1914,7 +1936,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1959,7 +1981,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1775,6 +1775,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1877,6 +1878,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1902,7 +1924,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1947,7 +1969,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1758,6 +1758,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1860,6 +1861,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1885,7 +1907,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1930,7 +1952,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1758,6 +1758,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1860,6 +1861,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1885,7 +1907,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1930,7 +1952,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1758,6 +1758,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1860,6 +1861,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1885,7 +1907,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1930,7 +1952,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1758,6 +1758,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1860,6 +1861,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1885,7 +1907,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1930,7 +1952,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1772,6 +1772,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1874,6 +1875,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1899,7 +1921,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1944,7 +1966,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1758,6 +1758,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1860,6 +1861,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1885,7 +1907,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1930,7 +1952,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1758,6 +1758,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1860,6 +1861,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1885,7 +1907,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1930,7 +1952,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1758,6 +1758,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1860,6 +1861,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1885,7 +1907,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1930,7 +1952,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1758,6 +1758,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1860,6 +1861,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1885,7 +1907,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1930,7 +1952,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1772,6 +1772,7 @@ function Install-Binary($install_args) {
       break
     } catch {
       Write-Information "failed to download from $url"
+      Write-Information "  $(Get-ExceptionMessage $_.Exception)"
       # keep going, maybe we have backup download URLs
     }
   }
@@ -1874,6 +1875,27 @@ function WebProxyFromEnvironment {
     return $webProxy
 }
 
+function Get-ExceptionMessage($exception) {
+  if ($null -eq $exception) {
+    return ""
+  }
+
+  while (($null -ne $exception.InnerException) -and (-not [string]::IsNullOrWhiteSpace($exception.InnerException.Message))) {
+    $exception = $exception.InnerException
+  }
+
+  return $exception.Message
+}
+
+function Invoke-DownloadFile($client, $url, $path) {
+  try {
+    $client.DownloadFile($url, $path)
+  } catch {
+    $message = Get-ExceptionMessage $_.Exception
+    throw "failed to download $url to ${path}: $message"
+  }
+}
+
 function Download($download_url, $platforms, $arch) {
   # Lookup what we expect this platform to look like
   $info = $platforms[$arch]
@@ -1899,7 +1921,7 @@ function Download($download_url, $platforms, $arch) {
   if ($auth_token) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
-  $wc.downloadFile($url, $dir_path)
+  Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
   Write-Verbose "Unpacking to $tmp"
 
@@ -1944,7 +1966,7 @@ function Download($download_url, $platforms, $arch) {
     $updater_url = "$download_url/$updater_id"
     $out_name = "$tmp\axolotlsay-update.exe"
 
-    $wc.downloadFile($updater_url, $out_name)
+    Invoke-DownloadFile -client $wc -url $updater_url -path $out_name
     $bin_paths += $out_name
   }
 


### PR DESCRIPTION
This tries to make error messages from PowerShell's `DownloadFile` less opaque by peeking through the inner exceptions for the first non-empty one. I'm _pretty_ sure this is the right approach, but I'm by no means a PowerShell expert.


xref https://github.com/astral-sh/uv/issues/16309 as an example of error opacity.