### PR TITLE
fix: downgrade pnpm in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           key: ${{ matrix.os }}
       # install pnpm for npm runtests
-      - run: npm i -g pnpm
+      - run: npm i -g pnpm@10
       # install omnibor-cli for tests
       # NOTE: This is hard-coded to a specific version because omnibor-cli,
       #       omnibor-rs, and gitoid are released on the same repo.


### PR DESCRIPTION
This test doesn't run with 11.2.2 due to a new error:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @mistydemeo/cargodisttest@file:axolotlsay-npm-package.tar.gz
```

There's nothing about it in the release notes, so I think this is a bug. https://github.com/pnpm/pnpm/releases/tag/v11.2.2