### PR TITLE
ci: let clippy write annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
 
   # Check that clippy is appeased
   clippy:
+    permissions:
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
This was inadvertantly removed in #2370; we still did want this permission for this one check.

cc @woodruffw 