### PR TITLE
deps: downgrade color-backtrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "color-backtrace"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c39683d44e712e45134c852c21c2f60139c3846047c9dde39cddf7066c78c6"
+checksum = "308329d5d62e877ba02943db3a8e8c052de9fde7ab48283395ba0e6494efbabd"
 dependencies = [
  "backtrace",
  "termcolor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ spdx = "0.13.4"
 base64 = "0.22.1"
 lazy_static = "1.5.0"
 current_platform = "0.2.0"
-color-backtrace = "0.7.3"
+color-backtrace = "0.7.2"
 backtrace = "0.3.76"
 target-lexicon = "0.13.2"
 


### PR DESCRIPTION
0.7.3 has been yanked due to compatibility issues.

Fixes #2418.

cc @piersfinlayson 