### PR TITLE
fix(npm): retry transient installer downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
       - name: npm fmt
         working-directory: cargo-dist/templates/installer/npm
         run: npm ci && npm run fmt:check
+      - name: npm installer tests
+        run: node --test cargo-dist/tests/npm-installer.test.js
 
   # Check that rustfmt is a no-op
   fmt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Nothing Yet!
 
 
+# Version 0.32.1 (2026-08-13)
+
+## npm installer
+
+The generated npm installer now retries transient download failures up to three times after the initial request, with exponential backoff. Retries cover HTTP 408, HTTP 429, HTTP 5xx, connection failures, and interrupted response streams while permanent failures such as HTTP 404 still fail immediately.
+
+
 # Version 0.32.0 (2026-05-21)
 
 This release contains several bugfixes and an update to the npm installer to reduce its dependencies. It also updates the default versions of all GitHub actions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "axoasset",
  "axoprocess",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "axoasset",
  "axocli",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "camino",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/cargo-dist"
 homepage = "https://axodotdev.github.io/cargo-dist"
-version = "0.32.0"
+version = "0.32.1"
 rust-version = "1.74"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!
-cargo-dist-schema = { version = "=0.32.0", path = "cargo-dist-schema" }
-axoproject = { version = "=0.32.0", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
+cargo-dist-schema = { version = "=0.32.1", path = "cargo-dist-schema" }
+axoproject = { version = "=0.32.1", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
 
 # first-party deps
 axocli = { version = "0.3.0" }

--- a/cargo-dist/templates/installer/npm/binary-install.js
+++ b/cargo-dist/templates/installer/npm/binary-install.js
@@ -8,16 +8,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -74,7 +140,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -129,7 +201,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -145,6 +222,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -230,82 +321,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -345,4 +443,9 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};

--- a/cargo-dist/tests/npm-installer.test.js
+++ b/cargo-dist/tests/npm-installer.test.js
@@ -1,0 +1,119 @@
+const assert = require("node:assert/strict");
+const { mkdtempSync, readFileSync, rmSync } = require("node:fs");
+const http = require("node:http");
+const { tmpdir } = require("node:os");
+const { join } = require("node:path");
+const { once } = require("node:events");
+const test = require("node:test");
+
+const {
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+} = require("../templates/installer/npm/binary-install");
+
+test("classifies transient download failures", () => {
+  for (const statusCode of [408, 429, 500, 502, 503, 504, 599]) {
+    const err = new Error(`HTTP ${statusCode}`);
+    err.statusCode = statusCode;
+    assert.equal(isTransientDownloadError(err), true, `HTTP ${statusCode}`);
+  }
+
+  for (const code of [
+    "EAI_AGAIN",
+    "ECONNRESET",
+    "ETIMEDOUT",
+    "ERR_STREAM_PREMATURE_CLOSE",
+  ]) {
+    const err = new Error(code);
+    err.code = code;
+    assert.equal(isTransientDownloadError(err), true, code);
+  }
+
+  assert.equal(isTransientDownloadError(new Error("HTTP 404")), false);
+  assert.equal(isTransientDownloadError(new Error("HTTP 600")), false);
+});
+
+test("retries transient failures with exponential backoff", async () => {
+  const delays = [];
+  let attempts = 0;
+
+  const result = await downloadWithRetry(
+    async () => {
+      attempts++;
+      if (attempts < 4) {
+        const err = new Error("HTTP 503");
+        err.statusCode = 503;
+        throw err;
+      }
+      return "downloaded";
+    },
+    {
+      sleepFn: async (delayMs) => delays.push(delayMs),
+    },
+  );
+
+  assert.equal(result, "downloaded");
+  assert.equal(attempts, 4);
+  assert.deepEqual(delays, [1000, 2000, 4000]);
+});
+
+test("does not retry permanent failures", async () => {
+  let attempts = 0;
+
+  await assert.rejects(
+    downloadWithRetry(async () => {
+      attempts++;
+      const err = new Error("HTTP 404");
+      err.statusCode = 404;
+      throw err;
+    }),
+    /HTTP 404/,
+  );
+
+  assert.equal(attempts, 1);
+});
+
+test("retries HTTP and mid-stream failures for the complete transfer", async () => {
+  const contents = Buffer.from("complete artifact contents");
+  let attempts = 0;
+  const server = http.createServer((request, response) => {
+    attempts++;
+
+    if (attempts === 1) {
+      response.writeHead(503);
+      response.end("temporarily unavailable");
+      return;
+    }
+
+    response.writeHead(200, { "Content-Length": contents.length });
+    if (attempts === 2) {
+      const socket = response.socket;
+      response.write(contents.subarray(0, 5));
+      setImmediate(() => socket.destroy());
+      return;
+    }
+
+    response.end(contents);
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const directory = mkdtempSync(join(tmpdir(), "cargo-dist-npm-test-"));
+  const outputPath = join(directory, "artifact.tar.gz");
+
+  try {
+    const { port } = server.address();
+    await downloadWithRetry(
+      () => downloadToFile(`http://127.0.0.1:${port}/artifact`, outputPath),
+      { sleepFn: async () => {} },
+    );
+
+    assert.equal(attempts, 3);
+    assert.deepEqual(readFileSync(outputPath), contents);
+  } finally {
+    server.close();
+    await once(server, "close");
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -2650,16 +2650,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2716,7 +2782,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2771,7 +2843,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2787,6 +2864,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2872,82 +2963,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2987,7 +3085,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -2603,16 +2603,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2669,7 +2735,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2724,7 +2796,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2740,6 +2817,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2825,82 +2916,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2940,7 +3038,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -2607,16 +2607,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2673,7 +2739,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2728,7 +2800,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2744,6 +2821,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2829,82 +2920,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2944,7 +3042,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
@@ -2650,16 +2650,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2716,7 +2782,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2771,7 +2843,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2787,6 +2864,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2872,82 +2963,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2987,7 +3085,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
@@ -2650,16 +2650,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2716,7 +2782,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2771,7 +2843,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2787,6 +2864,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2872,82 +2963,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2987,7 +3085,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
@@ -2650,16 +2650,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2716,7 +2782,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2771,7 +2843,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2787,6 +2864,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2872,82 +2963,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2987,7 +3085,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2689,16 +2689,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2755,7 +2821,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2810,7 +2882,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2826,6 +2903,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2911,82 +3002,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -3026,7 +3124,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -2650,16 +2650,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2716,7 +2782,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2771,7 +2843,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2787,6 +2864,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2872,82 +2963,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2987,7 +3085,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -2575,16 +2575,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2641,7 +2707,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2696,7 +2768,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2712,6 +2789,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2797,82 +2888,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2912,7 +3010,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -2572,16 +2572,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2638,7 +2704,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2693,7 +2765,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2709,6 +2786,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2794,82 +2885,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2909,7 +3007,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -2572,16 +2572,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2638,7 +2704,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2693,7 +2765,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2709,6 +2786,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2794,82 +2885,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2909,7 +3007,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -2572,16 +2572,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2638,7 +2704,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2693,7 +2765,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2709,6 +2786,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2794,82 +2885,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2909,7 +3007,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -2572,16 +2572,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2638,7 +2704,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2693,7 +2765,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2709,6 +2786,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2794,82 +2885,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2909,7 +3007,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1880,16 +1880,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -1946,7 +2012,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2001,7 +2073,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2017,6 +2094,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2102,82 +2193,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2217,7 +2315,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1860,16 +1860,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -1926,7 +1992,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -1981,7 +2053,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -1997,6 +2074,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2082,82 +2173,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2197,7 +2295,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -2572,16 +2572,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2638,7 +2704,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2693,7 +2765,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2709,6 +2786,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2794,82 +2885,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2909,7 +3007,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -2607,16 +2607,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2673,7 +2739,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2728,7 +2800,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2744,6 +2821,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2829,82 +2920,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2944,7 +3042,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
@@ -2693,16 +2693,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2759,7 +2825,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2814,7 +2886,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2830,6 +2907,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2915,82 +3006,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -3030,7 +3128,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
@@ -2693,16 +2693,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2759,7 +2825,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2814,7 +2886,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2830,6 +2907,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2915,82 +3006,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -3030,7 +3128,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
@@ -2689,16 +2689,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2755,7 +2821,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2810,7 +2882,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2826,6 +2903,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2911,82 +3002,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -3026,7 +3124,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
@@ -2693,16 +2693,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2759,7 +2825,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2814,7 +2886,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2830,6 +2907,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2915,82 +3006,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -3030,7 +3128,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -2584,16 +2584,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2650,7 +2716,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2705,7 +2777,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2721,6 +2798,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2806,82 +2897,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2921,7 +3019,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -2572,16 +2572,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2638,7 +2704,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2693,7 +2765,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2709,6 +2786,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2794,82 +2885,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2909,7 +3007,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -2572,16 +2572,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2638,7 +2704,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2693,7 +2765,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2709,6 +2786,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2794,82 +2885,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2909,7 +3007,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -2572,16 +2572,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2638,7 +2704,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2693,7 +2765,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2709,6 +2786,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2794,82 +2885,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2909,7 +3007,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -2572,16 +2572,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2638,7 +2704,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2693,7 +2765,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2709,6 +2786,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2794,82 +2885,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2909,7 +3007,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -2572,16 +2572,82 @@ const {
 const { join, sep } = require("path");
 const { spawnSync } = require("child_process");
 const { tmpdir } = require("os");
+const { pipeline } = require("node:stream");
 
 const https = require("node:https");
 const http = require("node:http");
 
 const tmpDir = tmpdir();
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 1000;
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+]);
 
 const error = (msg) => {
   console.error(msg);
   process.exit(1);
 };
+
+function httpError(statusCode, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+function isTransientDownloadError(err) {
+  const message = err && err.message ? err.message : "";
+  const statusMatch = /\bHTTP (\d{3})\b/.exec(message);
+  const statusCode = Number(err && err.statusCode) || Number(statusMatch?.[1]);
+
+  if (statusCode) {
+    return (
+      statusCode === 408 ||
+      statusCode === 429 ||
+      (statusCode >= 500 && statusCode < 600)
+    );
+  }
+
+  return (
+    TRANSIENT_NETWORK_ERROR_CODES.has(err && err.code) ||
+    /socket hang up|network|timed? ?out|aborted|premature close/i.test(message)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function downloadWithRetry(
+  operation,
+  {
+    maxAttempts = DOWNLOAD_MAX_ATTEMPTS,
+    baseDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+    sleepFn = sleep,
+    onRetry = () => {},
+  } = {},
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientDownloadError(err)) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry(err, attempt, delayMs);
+      await sleepFn(delayMs);
+    }
+  }
+}
 
 function getProxyForUrl(urlString) {
   const url = new URL(urlString);
@@ -2638,7 +2704,13 @@ function connectThroughProxy(proxy, target) {
       if (res.statusCode === 200) {
         resolve(socket);
       } else {
-        reject(new Error(`Proxy CONNECT failed with status ${res.statusCode}`));
+        socket.destroy();
+        reject(
+          httpError(
+            res.statusCode,
+            `Proxy CONNECT failed with HTTP ${res.statusCode}`,
+          ),
+        );
       }
     });
     connectReq.on("error", reject);
@@ -2693,7 +2765,12 @@ function download(urlString, maxRedirects) {
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} from ${urlString}`));
+          return reject(
+            httpError(
+              res.statusCode,
+              `HTTP ${res.statusCode} from ${urlString}`,
+            ),
+          );
         }
         resolve(res);
       });
@@ -2709,6 +2786,20 @@ function download(urlString, maxRedirects) {
     } else {
       doRequest();
     }
+  });
+}
+
+function downloadToFile(urlString, path) {
+  return download(urlString).then((res) => {
+    return new Promise((resolve, reject) => {
+      pipeline(res, createWriteStream(path), (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }
 
@@ -2794,82 +2885,89 @@ class Package {
       console.error(`Downloading release from ${this.url}`);
     }
 
-    return download(this.url)
-      .then((res) => {
-        return new Promise((resolve, reject) => {
-          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
-            if (err) return reject(err);
-            let tempFile = join(directory, this.filename);
-            const sink = res.pipe(createWriteStream(tempFile));
-            sink.on("error", (err) => reject(err));
-            sink.on("close", () => {
-              if (/\.tar\.*/.test(this.zipExt)) {
-                const result = spawnSync("tar", [
-                  "xf",
-                  tempFile,
-                  // The tarballs are stored with a leading directory
-                  // component; we strip one component in the
-                  // shell installers too.
-                  "--strip-components",
-                  "1",
-                  "-C",
-                  this.installDirectory,
-                ]);
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else if (this.zipExt == ".zip") {
-                let result;
-                if (this.platform.artifactName.includes("windows")) {
-                  // Windows does not have "unzip" by default on many installations, instead
-                  // we use Expand-Archive from powershell
-                  result = spawnSync("powershell.exe", [
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    `& {
+    let tempDirectory;
+    return new Promise((resolve, reject) => {
+      mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(directory);
+        }
+      });
+    })
+      .then((directory) => {
+        tempDirectory = directory;
+        const tempFile = join(directory, this.filename);
+        return downloadWithRetry(() => downloadToFile(this.url, tempFile), {
+          onRetry: (err, attempt, delayMs) => {
+            if (!suppressLogs) {
+              console.error(
+                `Download attempt ${attempt} failed (${err.message}); retrying in ${delayMs}ms...`,
+              );
+            }
+          },
+        }).then(() => tempFile);
+      })
+      .then((tempFile) => {
+        let result;
+        if (/\.tar\.*/.test(this.zipExt)) {
+          result = spawnSync("tar", [
+            "xf",
+            tempFile,
+            // The tarballs are stored with a leading directory
+            // component; we strip one component in the
+            // shell installers too.
+            "--strip-components",
+            "1",
+            "-C",
+            this.installDirectory,
+          ]);
+        } else if (this.zipExt == ".zip") {
+          if (this.platform.artifactName.includes("windows")) {
+            // Windows does not have "unzip" by default on many installations, instead
+            // we use Expand-Archive from powershell
+            result = spawnSync("powershell.exe", [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `& {
                         param([string]$LiteralPath, [string]$DestinationPath)
                         Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
                     }`,
-                    tempFile,
-                    this.installDirectory,
-                  ]);
-                } else {
-                  result = spawnSync("unzip", [
-                    "-q",
-                    tempFile,
-                    "-d",
-                    this.installDirectory,
-                  ]);
-                }
+              tempFile,
+              this.installDirectory,
+            ]);
+          } else {
+            result = spawnSync("unzip", [
+              "-q",
+              tempFile,
+              "-d",
+              this.installDirectory,
+            ]);
+          }
+        } else {
+          throw new Error(`Unrecognized file extension: ${this.zipExt}`);
+        }
 
-                if (result.status == 0) {
-                  resolve();
-                } else if (result.error) {
-                  reject(result.error);
-                } else {
-                  reject(
-                    new Error(
-                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
-                    ),
-                  );
-                }
-              } else {
-                reject(
-                  new Error(`Unrecognized file extension: ${this.zipExt}`),
-                );
-              }
-            });
-          });
-        });
+        if (result.status == 0) {
+          return;
+        }
+        if (result.error) {
+          throw result.error;
+        }
+
+        throw new Error(
+          `An error occurred extracting the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+        );
+      })
+      .finally(() => {
+        if (tempDirectory) {
+          try {
+            rmSync(tempDirectory, { recursive: true, force: true });
+          } catch {
+            // ignore temporary directory cleanup failures
+          }
+        }
       })
       .then(() => {
         if (!suppressLogs) {
@@ -2909,7 +3007,12 @@ class Package {
   }
 }
 
-module.exports.Package = Package;
+module.exports = {
+  Package,
+  downloadToFile,
+  downloadWithRetry,
+  isTransientDownloadError,
+};
 
 ================ axolotlsay-npm-package.tar.gz/package/binary.js ================
 const { Package } = require("./binary-install");


### PR DESCRIPTION
## Summary

- retry transient npm installer downloads with four total attempts and 1s/2s/4s exponential backoff
- retry the complete response stream, including mid-transfer disconnects, while failing permanent errors such as HTTP 404 immediately
- add focused Node tests, CI coverage, and updated installer snapshots
- prepare the 0.32.1 patch release with workspace version and changelog updates

This makes the workaround in PostHog/posthog#82416 unnecessary once consumers upgrade to cargo-dist 0.32.1, and extends the retry work from #2311 to the generated npm installer.

## Testing

- `node --test cargo-dist/tests/npm-installer.test.js`
- `npx prettier --check cargo-dist/templates/installer/npm/*.js cargo-dist/tests/npm-installer.test.js`
- `cargo fmt --all -- --check`
- `cargo test --workspace -- --test-threads=1`