### PR TITLE
Revert "ci: use stable versions for swatinem/build-cache"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: ${{ matrix.os }}-v2
+          key: ${{ matrix.os }}
       # install pnpm for npm runtests
       - run: npm i -g pnpm@10
       # install omnibor-cli for tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # v1.0.7
         env:
           PWD: ${{ env.GITHUB_WORKSPACE }}
@@ -91,7 +91,7 @@ jobs:
         with:
           toolchain: stable
           components: rust-docs
-      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo doc --workspace --no-deps
 
   # Check for typos (exceptions are provided by the typos.toml)
@@ -125,7 +125,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.os }}-v2
       # install pnpm for npm runtests

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
-      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       # Install mdbook plugins
       - name: Install mdbook plugins


### PR DESCRIPTION
This broke the integration tests.

This reverts commit d839dfc917c432c0102efd401d293ef006ec2516.