### PR TITLE
Verify archive checksums in PowerShell installers

### DIFF
--- a/book/src/artifacts/checksums.md
+++ b/book/src/artifacts/checksums.md
@@ -6,6 +6,8 @@ By default dist will generate a matching checksum file for each [archive][] it g
 
 The homebrew installer actually ignores your checksum setting and always uses sha256 hashes that are baked into it, as required by homebrew itself.
 
+The PowerShell installer also uses SHA-256 hashes embedded from the build manifest, regardless of the algorithm selected for checksum files. It verifies each archive with PowerShell's built-in `Get-FileHash` before extracting it. Installer generation needs the manifests from the local artifact builds to embed these hashes; fake builds and archives without checksum metadata omit verification.
+
 Updating the other fetching installers to use these checksums is [still a work in progress][issue-checksum-backlog].
 
 > since 0.24.0

--- a/cargo-dist/src/backend/installer/powershell.rs
+++ b/cargo-dist/src/backend/installer/powershell.rs
@@ -1,15 +1,50 @@
 //! Code for generating installer.ps1
 
 use axoasset::LocalAsset;
+use cargo_dist_schema::DistManifest;
+use serde::Serialize;
 
-use crate::{backend::templates::TEMPLATE_INSTALLER_PS1, errors::DistResult, DistGraph};
+use crate::{backend::templates::TEMPLATE_INSTALLER_PS1, errors::DistResult, DistGraph, SortedMap};
 
 use super::InstallerInfo;
 
-pub(crate) fn write_install_ps_script(dist: &DistGraph, info: &InstallerInfo) -> DistResult<()> {
+#[derive(Serialize)]
+struct PowershellInstallerInfo<'a> {
+    #[serde(flatten)]
+    installer: &'a InstallerInfo,
+    checksums: SortedMap<&'a str, &'a str>,
+}
+
+pub(crate) fn write_install_ps_script(
+    dist: &DistGraph,
+    info: &InstallerInfo,
+    manifest: &DistManifest,
+) -> DistResult<()> {
+    let checksums = if dist.local_builds_are_lies {
+        // Fake builds produce checksums for placeholder archives, not the downloads.
+        SortedMap::new()
+    } else {
+        // Every built archive has a SHA-256 in the manifest, independently of the
+        // algorithm selected for checksum files. PowerShell can verify it natively.
+        info.artifacts
+            .iter()
+            .filter_map(|artifact| {
+                let checksum = manifest
+                    .artifacts
+                    .get(&artifact.id)?
+                    .checksums
+                    .get("sha256")?;
+                Some((artifact.id.as_str(), checksum.as_str()))
+            })
+            .collect()
+    };
+    let context = PowershellInstallerInfo {
+        installer: info,
+        checksums,
+    };
     let script = dist
         .templates
-        .render_file_to_clean_string(TEMPLATE_INSTALLER_PS1, info)?;
+        .render_file_to_clean_string(TEMPLATE_INSTALLER_PS1, &context)?;
     LocalAsset::write_new(&script, &info.dest_path)?;
     dist.signer.sign(&info.dest_path)?;
     Ok(())

--- a/cargo-dist/src/lib.rs
+++ b/cargo-dist/src/lib.rs
@@ -952,7 +952,7 @@ fn generate_installer(
             installer::shell::write_install_sh_script(dist, info, manifest)?
         }
         InstallerImpl::Powershell(info) => {
-            installer::powershell::write_install_ps_script(dist, info)?
+            installer::powershell::write_install_ps_script(dist, info, manifest)?
         }
         InstallerImpl::Npm(info) => installer::npm::write_npm_project(dist, info)?,
         InstallerImpl::Homebrew(HomebrewImpl { info, fragments }) => {

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -105,6 +105,9 @@ function Install-Binary($install_args) {
   {%- for artifact in artifacts %}
     "{{ artifact.target_triple }}" = @{
       "artifact_name" = "{{ artifact.id }}"
+      {%- if artifact.id in checksums %}
+      "sha256" = "{{ checksums[artifact.id] }}"
+      {%- endif %}
       "bins" = @({% for bin in artifact.executables -%}
         "{{ bin }}"{{ ", " if not loop.last else "" }}
       {%- endfor %})
@@ -312,6 +315,19 @@ function Download($download_url, $platforms, $arch) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
+
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
 
   Write-Verbose "Unpacking to $tmp"
 

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1954,6 +1954,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1981,6 +1981,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1935,6 +1935,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -2001,6 +2001,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1954,6 +1954,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1958,6 +1958,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_announce.snap
@@ -2001,6 +2001,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_filters.snap
@@ -2001,6 +2001,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_attestations_host.snap
@@ -2001,6 +2001,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -2040,6 +2040,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -2001,6 +2001,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1926,6 +1926,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -1934,6 +1934,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -1778,6 +1778,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -1858,6 +1858,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1922,6 +1922,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.
@@ -4183,6 +4196,19 @@ function Download($download_url, $platforms, $arch) {
     $wc.Headers["Authorization"] = "Bearer $auth_token"
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
+
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
 
   Write-Verbose "Unpacking to $tmp"
 

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1958,6 +1958,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order1.snap
@@ -2044,6 +2044,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order2.snap
@@ -2044,6 +2044,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_and_order_no_github.snap
@@ -2040,6 +2040,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_simple_only.snap
@@ -2044,6 +2044,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1858,6 +1858,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1858,6 +1858,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1935,6 +1935,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1923,6 +1923,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1906,6 +1906,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1906,6 +1906,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1906,6 +1906,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1906,6 +1906,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1920,6 +1920,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1906,6 +1906,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1906,6 +1906,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1906,6 +1906,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1906,6 +1906,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1920,6 +1920,19 @@ function Download($download_url, $platforms, $arch) {
   }
   Invoke-DownloadFile -client $wc -url $url -path $dir_path
 
+  if ($info.ContainsKey("sha256")) {
+    $expected_hash = $info["sha256"]
+    if ($expected_hash -notmatch '\A[0-9a-fA-F]{64}\z') {
+      throw "invalid SHA-256 checksum for $artifact_name"
+    }
+    $actual_hash = (Get-FileHash -LiteralPath $dir_path -Algorithm SHA256 -ErrorAction Stop).Hash
+    if ($actual_hash -ine $expected_hash) {
+      throw "checksum mismatch for ${artifact_name}: expected $expected_hash, got $actual_hash"
+    }
+  } else {
+    Write-Information "no checksums to verify"
+  }
+
   Write-Verbose "Unpacking to $tmp"
 
   # Select the tool to unpack the files with.

--- a/typos.toml
+++ b/typos.toml
@@ -6,8 +6,12 @@ extend-ignore-identifiers-re = [
     # Allow all-caps words that are 2-letters or more and ends with 's'
     "[A-Z]{2,}s",
 ]
-# Ignore CLIENT_ID=<random letters>
-extend-ignore-re = ["CLIENT_ID=[A-Za-z0-9_-]+"]
+extend-ignore-re = [
+    # Ignore CLIENT_ID=<random letters>
+    "CLIENT_ID=[A-Za-z0-9_-]+",
+    # PowerShell's case-insensitive inequality operator
+    '\B-ine\b',
+]
 
 [default.extend-identifiers]
 PnP = "PnP"


### PR DESCRIPTION
## Summary

PowerShell installers currently extract downloaded archives without checking their checksums. Embed archive SHA-256 hashes from the build manifest and verify them with `Get-FileHash` before extraction. Malformed hashes, hash-read failures, and mismatches fail the download attempt; fallback URLs must pass the same check.

Use SHA-256 regardless of the checksum-file setting, since dist computes it for every archive and PowerShell supports it natively. Fake builds and archives without checksum metadata continue to skip verification. The snapshot diffs repeat the added verification block in the generated PowerShell scripts.

Fixes #2397.

## Test plan (on top of CI)

- Generated an installer from a fixture manifest and confirmed that all four Windows target aliases receive the SHA-256 value, even when another checksum algorithm is present.
- Tested on Windows with PowerShell 5.1 and 7.6.5 using real ZIP archives and local file downloads: valid archives install; invalid checksums fail before extraction, including fallbacks. Confirmed SHA-256 with SHA-512 checksum files and verification skipped for fake builds or absent metadata.
