### PR TITLE
feat(config): added support for workspace.repository

### DIFF
--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -1075,7 +1075,7 @@ By explicitly specifying `hosting` you can change the priority and whether a dow
 
 * `hosting = ["simple", "github"]` is the implicit default when both are enabled
 * `hosting = ["github", "simple"]` specifies to instead try GitHub first and fallback to the simple URL if it fails
-* `hosting = ["simple"]` specifies to *only* use the simple URL and ignore GitHub (if `ci = "github"` is set we will still upload to there) 
+* `hosting = ["simple"]` specifies to *only* use the simple URL and ignore GitHub (if `ci = "github"` is set we will still upload to there)
 
 The preferred entry will also be the one rendered into things like `curl | sh` strings we emit.
 
@@ -1684,6 +1684,22 @@ be managed by dist. Each member is of the format `<project-type>:<relative-path>
 * cargo: expect a Cargo.toml for a cargo-based Rust project in that dir
 * npm: expect a package.json for an npm-based JavaScript project in that dir
 * dist: expect a dist.toml for a dist-based generic project in that dir
+
+
+### `workspace.repository`
+
+> <span style="float:right">since 0.33.0<br>[global-only][]</span>
+> default = `<none>`
+>
+> *in your dist-workspace.toml:*
+> ```toml
+> [workspace]
+> repository = "https://github.com/your-org/your-repo"
+> ```
+
+An optional workspace-level repository URL that overrides package-level URLs.
+Useful for monorepos with inconsistent package repository URLs. Also supported
+in `[workspace.metadata.dist]` of Cargo.toml.
 
 
 # the `[package]` section

--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -1686,6 +1686,41 @@ be managed by dist. Each member is of the format `<project-type>:<relative-path>
 * dist: expect a dist.toml for a dist-based generic project in that dir
 
 
+### `workspace.packages`
+
+> <span style="float:right">since 0.30.3<br>[global-only][]</span>
+> [📖 read the guide for this feature!][distribute] \
+> default = `<none>` (infer it)
+>
+> *in your dist-workspace.toml:*
+> ```toml
+> [workspace]
+> packages = ["a", "b"]
+> ```
+
+`packages` provides a more explicit way of specifying which packages to dist
+(or not). If `packages` is set, it provides a list of exactly which packages
+should be distributed within the workspace. It overrides individual
+package-level `dist = true` or `dist = false` configuration.
+
+
+### `workspace.version`
+
+> <span style="float:right">since 0.30.3<br>[global-only][]</span>
+> default = `<none>` (infer it)
+>
+> *in your dist-workspace.toml:*
+> ```toml
+> [workspace]
+> version = "0.0.1"
+> ```
+
+If set, this value will override the actual version configured for each
+package. For example, if the workspace contains packages versioned "0.2" and
+"0.3", and this value is set to "0.1", then dist will consider every package in
+the workspace to have the version "0.1".
+
+
 ### `workspace.repository`
 
 > <span style="float:right">since 0.33.0<br>[global-only][]</span>

--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -18,9 +18,7 @@ We're currently in the middle of [a major config migration](https://github.com/a
 * [`allow-dirty`](#allow-dirty)
 * [`cargo-dist-version`](#cargo-dist-version)
 * [`dist`](#dist)
-* [`packages`](#packages)
 * [`targets`](#targets)
-* [`version`](#version)
 
 [artifact settings](#artifact-settings)
 * [`checksum`](#checksum)
@@ -111,6 +109,8 @@ We're currently in the middle of [a major config migration](https://github.com/a
 
 [`[workspace]`](#the-workspace-section)
 * [`members`](#workspacemembers)
+* [`packages`](#workspacepackages)
+* [`version`](#workspaceversion)
 
 [`[package]`](#the-package-section)
 * [`name`](#packagename)
@@ -199,21 +199,6 @@ There are 3 major cases where you might use this:
 * `dist = false` on a whole workspace defaults all packages to do-not-distribute, forcing you to manually allow-list packages with `dist = true` (large monorepos often find this to be a better way of managing project distribution when most developers aren't release engineers).
 
 
-## `packages`
-
-> <span style="float:right">since 0.29.0<br>[global-only][]</span>
-> [📖 read the guide for this feature!][distribute] \
-> default = `<none>` (infer it)
->
-> *in your dist-workspace.toml or dist.toml:*
-> ```toml
-> [dist]
-> packages = ["a", "b"]
-> ```
-
-`packages` provides a more explicit way of specifying which packages to dist (or not). If `packages` is set, it provides a list of exactly which packages should be distributed within the workspace. It overrides individual package-level `dist = true` or `dist = false` configuration.
-
-
 ## `targets`
 
 > <span style="float:right">since 0.0.3<br>[package-local][]</span>
@@ -244,19 +229,6 @@ The supported choices are:
 * arm64 Linux (static musl): "aarch64-unknown-linux-musl"
 
 By default all runs of `dist` will be trying to handle all platforms specified here at once. If you specify `--target=...` on the CLI this will focus the run to only those platforms. As discussed in [concepts][], this cannot be used to specify platforms that are not listed in `metadata.dist`, to ensure different runs agree on the maximum set of platforms.
-
-
-## `version`
-> <span style="float:right">since 0.29.0<br>[global-only][]</span>
-> default = `<none>` (infer it)
->
-> *in your dist-workspace.toml or dist.toml:*
-> ```toml
-> [dist]
-> version = "0.0.1"
-> ```
-
-If set, this value will override the actual version configured for each package. For example, if the workspace contains packages versioned "0.2" and "0.3", and this value is set to "0.1", then dist will consider every package in the workspace to have the version "0.1".
 
 
 ## artifact settings

--- a/book/src/reference/config.md
+++ b/book/src/reference/config.md
@@ -17,6 +17,7 @@ We're currently in the middle of [a major config migration](https://github.com/a
 [`[dist]`](#the-dist-section)
 * [`allow-dirty`](#allow-dirty)
 * [`cargo-dist-version`](#cargo-dist-version)
+* [`cargo-dist-url-override`](#cargo-dist-url-override)
 * [`dist`](#dist)
 * [`targets`](#targets)
 
@@ -176,6 +177,30 @@ This is added automatically by [`dist init`][init], and is a recording of its ow
 Your [release CI][github-ci] will fetch and use the given version of dist to build and publish your project.
 
 The syntax must be a valid [Cargo-style SemVer Version][semver-version] (not a VersionReq!).
+
+
+## `cargo-dist-url-override`
+
+> <span style="float:right">since 0.26.0<br>[global-only][]</span>
+> default = `<none>`
+>
+> *in your dist-workspace.toml or dist.toml:*
+> ```toml
+> [dist]
+> cargo-dist-url-override = "https://github.com/axodotdev/cargo-dist/releases/download/v0.26.0"
+> ```
+
+Overrides the URL that your [release CI][github-ci] uses to fetch and install
+dist itself, replacing the default
+`https://github.com/axodotdev/cargo-dist/releases/download/v{VERSION}`
+location.
+
+This is useful if you want to pin CI to a fork or mirror of dist, or to a custom build of dist that you host yourself.
+
+The value is used verbatim as the base URL, with `/cargo-dist-installer.sh`/`.ps1`
+appended to it. The version is **not** appended automatically, so the base URL must include the version.
+
+Setting this overrides [`cargo-dist-version`](#cargo-dist-version) for the purpose of fetching dist in CI.
 
 
 ## `dist`

--- a/cargo-dist/src/config/mod.rs
+++ b/cargo-dist/src/config/mod.rs
@@ -959,7 +959,12 @@ pub(crate) fn parse_metadata_table_or_manifest(
 
 pub(crate) fn parse_generic_config(src: SourceFile) -> DistResult<DistMetadata> {
     let config: GenericConfig = src.deserialize_toml()?;
-    Ok(config.dist.unwrap_or_default())
+    let mut metadata = config.dist.unwrap_or_default();
+    // Extract workspace repository if present
+    if let Some(workspace) = config.workspace {
+        metadata.workspace_repository = workspace.repository;
+    }
+    Ok(metadata)
 }
 
 pub(crate) fn reject_metadata_table(

--- a/cargo-dist/src/config/v0.rs
+++ b/cargo-dist/src/config/v0.rs
@@ -520,8 +520,8 @@ pub struct DistMetadata {
     /// Where to download artifacts from on the Simple host
     pub simple_download_url: Option<String>,
 
-    /// Workspace-level repository URL (from [workspace] section in dist-workspace.toml)
-    /// This is internal-only and not serialized from TOML directly
+    /// Workspace-level repository URL (for `[workspace]` section in dist-workspace.toml),
+    /// internal-only and not serialized from TOML directly.
     #[serde(skip)]
     pub workspace_repository: Option<String>,
 }

--- a/cargo-dist/src/config/v0.rs
+++ b/cargo-dist/src/config/v0.rs
@@ -17,6 +17,15 @@ use crate::SortedMap;
 pub struct GenericConfig {
     /// The dist field within dist.toml
     pub dist: Option<DistMetadata>,
+    /// The workspace field within dist.toml (if present)
+    pub workspace: Option<WorkspaceMetadata>,
+}
+
+/// Workspace-level metadata from dist(-workspace).toml files
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceMetadata {
+    /// Repository URL that overrides package-level URLs
+    pub repository: Option<String>,
 }
 
 declare_strongly_typed_string! {
@@ -510,6 +519,11 @@ pub struct DistMetadata {
 
     /// Where to download artifacts from on the Simple host
     pub simple_download_url: Option<String>,
+
+    /// Workspace-level repository URL (from [workspace] section in dist-workspace.toml)
+    /// This is internal-only and not serialized from TOML directly
+    #[serde(skip)]
+    pub workspace_repository: Option<String>,
 }
 
 impl DistMetadata {
@@ -592,6 +606,7 @@ impl DistMetadata {
             cargo_cyclonedx: _,
             omnibor: _,
             simple_download_url: _,
+            workspace_repository: _,
         } = self;
         if let Some(include) = include {
             for include in include {
@@ -702,6 +717,7 @@ impl DistMetadata {
             cargo_cyclonedx,
             omnibor,
             simple_download_url,
+            workspace_repository: _,
         } = self;
 
         // Check for global settings on local packages

--- a/cargo-dist/src/config/v0_to_v1.rs
+++ b/cargo-dist/src/config/v0_to_v1.rs
@@ -98,6 +98,7 @@ impl DistMetadata {
             cargo_cyclonedx,
             omnibor,
             simple_download_url,
+            workspace_repository,
         } = self.clone();
 
         // Archives
@@ -397,7 +398,7 @@ impl DistMetadata {
         TomlLayer {
             dist_version: cargo_dist_version,
             dist_url_override: cargo_dist_url_override,
-            repository: None,
+            repository: workspace_repository,
             dist,
             allow_dirty,
             targets,

--- a/cargo-dist/src/config/v0_to_v1.rs
+++ b/cargo-dist/src/config/v0_to_v1.rs
@@ -397,6 +397,7 @@ impl DistMetadata {
         TomlLayer {
             dist_version: cargo_dist_version,
             dist_url_override: cargo_dist_url_override,
+            repository: None,
             dist,
             allow_dirty,
             targets,

--- a/cargo-dist/src/config/v1/mod.rs
+++ b/cargo-dist/src/config/v1/mod.rs
@@ -166,6 +166,8 @@ pub struct WorkspaceConfig {
     pub dist_url_override: Option<CargoDistUrlOverride>,
     /// Generate targets whose dist should avoid checking for up-to-dateness.
     pub allow_dirty: Vec<GenerateMode>,
+    /// Workspace-level repository URL that overrides package-level URLs
+    pub repository: Option<String>,
     /// ci config
     pub ci: CiConfig,
     /// artifact config
@@ -188,6 +190,8 @@ pub struct WorkspaceConfigInheritable {
     pub dist_url_override: Option<CargoDistUrlOverride>,
     /// Generate targets whose dist should avoid checking for up-to-dateness.
     pub allow_dirty: Vec<GenerateMode>,
+    /// Workspace-level repository URL that overrides package-level URLs
+    pub repository: Option<String>,
     /// artifact config
     pub artifacts: WorkspaceArtifactConfig,
     /// ci config
@@ -211,6 +215,7 @@ impl WorkspaceConfigInheritable {
             dist_version: None,
             dist_url_override: None,
             allow_dirty: vec![],
+            repository: None,
         }
     }
     /// Apply the inheritance to get the final WorkspaceConfig
@@ -224,6 +229,7 @@ impl WorkspaceConfigInheritable {
             dist_version,
             dist_url_override,
             allow_dirty,
+            repository,
         } = self;
         WorkspaceConfig {
             artifacts,
@@ -234,6 +240,7 @@ impl WorkspaceConfigInheritable {
             dist_version,
             dist_url_override,
             allow_dirty,
+            repository,
         }
     }
 }
@@ -250,6 +257,7 @@ impl ApplyLayer for WorkspaceConfigInheritable {
             allow_dirty,
             dist_version,
             dist_url_override,
+            repository,
             // app-scope only
             dist: _,
             targets: _,
@@ -264,6 +272,7 @@ impl ApplyLayer for WorkspaceConfigInheritable {
         self.dist_version.apply_opt(dist_version);
         self.dist_url_override.apply_opt(dist_url_override);
         self.allow_dirty.apply_val(allow_dirty);
+        self.repository.apply_opt(repository);
     }
 }
 
@@ -405,6 +414,10 @@ pub struct TomlLayer {
     /// Generate targets whose dist should avoid checking for up-to-dateness.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_dirty: Option<Vec<GenerateMode>>,
+
+    /// Workspace-level repository URL that overrides package-level URLs
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
 
     /// The full set of target triples to build for.
     ///

--- a/cargo-dist/src/config/v1/mod.rs
+++ b/cargo-dist/src/config/v1/mod.rs
@@ -370,6 +370,7 @@ impl ApplyLayer for AppConfigInheritable {
             allow_dirty: _,
             dist_version: _,
             dist_url_override: _,
+            repository: _,
         }: Self::Layer,
     ) {
         self.artifacts.apply_val_layer(artifacts);

--- a/cargo-dist/src/host.rs
+++ b/cargo-dist/src/host.rs
@@ -211,7 +211,7 @@ pub(crate) fn select_hosting(
         .collect::<Vec<_>>();
 
     let raw_repository_url = if let Some(repo_url) = workspace_repository {
-        // Use workspace-level override if provided
+        // Use workspace override if present
         axoproject::RepositoryUrl::from_string(repo_url)
     } else {
         match workspaces.repository_url(Some(&package_list)) {

--- a/cargo-dist/src/host.rs
+++ b/cargo-dist/src/host.rs
@@ -85,7 +85,7 @@ impl<'a> DistGraphBuilder<'a> {
         } else {
             Some(hosting)
         };
-        self.inner.hosting = select_hosting(self.workspaces, announcing, hosting, Some(&ci))?;
+        self.inner.hosting = select_hosting(self.workspaces, announcing, hosting, Some(&ci), self.inner.config.repository.as_deref())?;
         // If we don't think we can host things, don't bother
         let Some(hosting) = &self.inner.hosting else {
             return Ok(());
@@ -189,6 +189,7 @@ pub(crate) fn select_hosting(
     announcing: &AnnouncementTag,
     hosting: Option<Vec<HostingStyle>>,
     ci: Option<&[CiStyle]>,
+    workspace_repository: Option<&str>,
 ) -> DistResult<Option<HostingInfo>> {
     // Either use the explicit one, or default to the CI provider's native solution
     let Some(hosting_providers) = hosting
@@ -209,19 +210,24 @@ pub(crate) fn select_hosting(
         .map(|release| release.package_idx)
         .collect::<Vec<_>>();
 
-    let raw_repository_url = match workspaces.repository_url(Some(&package_list)) {
-        Ok(Some(url)) => url,
-        Ok(None) => {
-            let mut manifest_list = String::new();
-            for pkg_idx in package_list {
-                let package = workspaces.package(pkg_idx);
-                manifest_list.push('\n');
-                manifest_list.push_str(package.manifest_path.as_str());
+    let raw_repository_url = if let Some(repo_url) = workspace_repository {
+        // Use workspace-level override if provided
+        axoproject::RepositoryUrl::from_string(repo_url)
+    } else {
+        match workspaces.repository_url(Some(&package_list)) {
+            Ok(Some(url)) => url,
+            Ok(None) => {
+                let mut manifest_list = String::new();
+                for pkg_idx in package_list {
+                    let package = workspaces.package(pkg_idx);
+                    manifest_list.push('\n');
+                    manifest_list.push_str(package.manifest_path.as_str());
+                }
+                return Err(DistError::CantEnableGithubNoUrl { manifest_list });
             }
-            return Err(DistError::CantEnableGithubNoUrl { manifest_list });
-        }
-        Err(e) => {
-            return Err(DistError::CantEnableGithubUrlInconsistent { inner: e });
+            Err(e) => {
+                return Err(DistError::CantEnableGithubUrlInconsistent { inner: e });
+            }
         }
     };
 

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -554,6 +554,7 @@ fn get_new_dist_metadata(
             cargo_cyclonedx: None,
             omnibor: None,
             simple_download_url: None,
+            workspace_repository: None,
         }
     };
 
@@ -1056,6 +1057,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         cargo_cyclonedx,
         simple_download_url,
         omnibor,
+        workspace_repository: _,
         // These settings are complex enough that we don't support editing them in init
         github_action_commits: _,
         extra_artifacts: _,

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1349,7 +1349,7 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         let idx = ReleaseIdx(self.inner.releases.len());
         let id = app_name.clone();
         info!("added release {id}");
-        self.inner.releases.push(Release {
+        let mut release = Release {
             app_name,
             app_desc,
             app_authors,
@@ -1371,7 +1371,12 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
             config,
             static_assets,
             platform_support,
-        });
+        };
+        // Apply workspace-level repository override if set
+        if let Some(workspace_repo) = &self.inner.config.repository {
+            release.app_repository_url = Some(workspace_repo.clone());
+        }
+        self.inner.releases.push(release);
         idx
     }
 

--- a/cargo-dist/src/tests/host.rs
+++ b/cargo-dist/src/tests/host.rs
@@ -38,7 +38,7 @@ fn github_simple() {
     let ci = Some(vec![CiStyle::Github]);
 
     let (_graph, announcing) = mock_announce(&mut workspaces);
-    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref(), None);
 
     let hosting = hosting.unwrap().unwrap();
     assert_eq!(hosting.hosts, &[HostingStyle::Github]);
@@ -55,7 +55,7 @@ fn github_implicit() {
     let ci = Some(vec![CiStyle::Github]);
 
     let (_graph, announcing) = mock_announce(&mut workspaces);
-    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref(), None);
 
     let hosting = hosting.unwrap().unwrap();
     assert_eq!(hosting.hosts, &[HostingStyle::Github]);
@@ -80,7 +80,7 @@ fn github_diff_repository_on_non_distables() {
     let ci = Some(vec![CiStyle::Github]);
 
     let (_graph, announcing) = mock_announce(&mut workspaces);
-    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref(), None);
 
     let hosting = hosting.unwrap().unwrap();
     assert_eq!(hosting.hosts, &[HostingStyle::Github]);
@@ -103,7 +103,7 @@ fn github_no_repository() {
     let ci = Some(vec![CiStyle::Github]);
 
     let (_graph, announcing) = mock_announce(&mut workspaces);
-    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref(), None);
 
     if let Err(DistError::CantEnableGithubNoUrl { manifest_list }) = &hosting {
         assert!(manifest_list.contains(".toml"));
@@ -130,7 +130,7 @@ fn github_diff_repository() {
     let ci = Some(vec![CiStyle::Github]);
 
     let (_graph, announcing) = mock_announce(&mut workspaces);
-    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref(), None);
 
     if let Err(DistError::CantEnableGithubUrlInconsistent {
         inner:
@@ -165,7 +165,7 @@ fn github_not_github_repository() {
     let ci = Some(vec![CiStyle::Github]);
 
     let (_graph, announcing) = mock_announce(&mut workspaces);
-    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref(), None);
 
     if let Err(DistError::CantEnableGithubUrlNotGithub {
         inner: AxoprojectError::NotGitHubError { url },
@@ -191,7 +191,7 @@ fn no_ci_no_problem() {
     let ci = None;
 
     let (_graph, announcing) = mock_announce(&mut workspaces);
-    let hosting = select_hosting(&workspaces, &announcing, hosting, ci);
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci, None);
 
     assert!(matches!(hosting, Ok(None)))
 }
@@ -209,7 +209,7 @@ fn github_dot_git() {
     let ci = Some(vec![CiStyle::Github]);
 
     let (_graph, announcing) = mock_announce(&mut workspaces);
-    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref(), None);
 
     let hosting = hosting.unwrap().unwrap();
     assert_eq!(hosting.hosts, &[HostingStyle::Github]);
@@ -234,7 +234,7 @@ fn github_trail_slash() {
     let ci = Some(vec![CiStyle::Github]);
 
     let (_graph, announcing) = mock_announce(&mut workspaces);
-    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref());
+    let hosting = select_hosting(&workspaces, &announcing, hosting, ci.as_deref(), None);
 
     let hosting = hosting.unwrap().unwrap();
     assert_eq!(hosting.hosts, &[HostingStyle::Github]);

--- a/cargo-dist/src/tests/host.rs
+++ b/cargo-dist/src/tests/host.rs
@@ -242,3 +242,26 @@ fn github_trail_slash() {
     assert_eq!(hosting.project, REPO_PROJECT);
     assert_eq!(hosting.source_host, "github");
 }
+
+#[test]
+fn github_workspace_repository_override() {
+    let mut workspaces = workspace_unified();
+    let hosting = Some(vec![HostingStyle::Github]);
+    let ci = Some(vec![CiStyle::Github]);
+
+    let (_graph, announcing) = mock_announce(&mut workspaces);
+    let override_repo = Some("https://github.com/override-owner/override-project");
+    let hosting = select_hosting(
+        &workspaces,
+        &announcing,
+        hosting,
+        ci.as_deref(),
+        override_repo,
+    );
+
+    let hosting = hosting.unwrap().unwrap();
+    assert_eq!(hosting.hosts, &[HostingStyle::Github]);
+    assert_eq!(hosting.owner, "override-owner");
+    assert_eq!(hosting.project, "override-project");
+    assert_eq!(hosting.source_host, "github");
+}


### PR DESCRIPTION
This feature is meant to handle the error one gets when a submodule monorepo has inconsistent package repository URLs:

```sh-session
$ dist build
  × Github CI support requires your crates to agree on the URL of your repository
  ╰─▶   ⚠ your workspace has inconsistent values for 'repository', refusing to select one:
        │   ~/rust/nushell-ci/nushell/Cargo.toml:
        │     https://github.com/nushell/nushell
        │   ~/rust/nushell-ci/nushell/crates/nu_plugin_formats/Cargo.toml:
        │     https://github.com/nushell/nushell/tree/main/crates/nu_plugin_formats
```